### PR TITLE
swipeTo function

### DIFF
--- a/idangerous.swiper-1.3.js
+++ b/idangerous.swiper-1.3.js
@@ -448,6 +448,7 @@ Swiper = function(selector, params, callback) {
 		_this.setTransform(newPosition,0,0)
 		_this.setTransition( speed )	
 		_this.updateActiveSlide(newPosition)
+		_this.positions.current = newPosition;
 		//Run Callbacks
 		if (runCallbacks) 
 			slideChangeCallbacks()


### PR DESCRIPTION
There is an issue with the swipeTo function not updating the internal position properly. This causes the slider to get out of sync when the swipeTo function is called. E.g.

Slider is on slide 1
Use swipeTo to change to slide 3
Click previous button to go to the previous slide and you are returned to slide 1 and not slide 2 as I expected

I have fixed this by adding: _this.positions.current = newPosition;
