### PR TITLE
Added a feature - an option that allows to set an initial slide index

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -252,6 +252,10 @@ Swiper = function(selector, params, callback) {
 		// Set Initial Slide Position	
 		if(params.initialSlide > 0 && params.initialSlide < numOfSlides) {
 			_this.realIndex = params.initialSlide;
+			
+			if (_this.params.loop) {
+                _this.activeSlide = _this.realIndex-params.slidesPerSlide
+            }
 						
 			if (isHorizontal) {
 				_this.positions.current = -params.initialSlide * slideWidth;


### PR DESCRIPTION
Hi,
I just added a new feature. I just personally needed it and added the feature so the initial slide index can be set.
e.g. when the value of  'initialSlide' option is set 2, the the third slide is shown at initial loading.

Ignore this pull req if you don't think the option is useful.

thanks!
tomomi
