### PR TITLE
This fixes an issue in Chrome where swipePrev will not work if the user is zoomed in on the page.

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -1192,7 +1192,7 @@ var Swiper = function (selector, params, callback) {
 
         _this.callPlugins('onSwipePrev');
 
-        var getTranslate = isHorizontal ? _this.getTranslate('x') : _this.getTranslate('y')
+        var getTranslate = Math.ceil( isHorizontal ? _this.getTranslate('x') : _this.getTranslate('y') );
         
         var groupSize = slideSize * params.slidesPerGroup;
         var newPosition = (Math.ceil(-getTranslate/groupSize)-1)*groupSize;


### PR DESCRIPTION
Found a bug where due to rounding, swipePrev would not work if the user has zoomed the page in (ctrl + =).
