### PR TITLE
fully respect the law of demeter

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -812,7 +812,7 @@ var Swiper = function (selector, params, callback) {
         if (_this.isTouched || params.onlyExternal) {
             return false
         }
-        if (params.preventClassNoSwiping && event.target && event.target.className.indexOf('NoSwiping') > -1) return false;
+        if (params.preventClassNoSwiping && event.target && event.target.className && event.target.className.indexOf('NoSwiping') > -1) return false;
         
         //Check For Nested Swipers
         _this.isTouched = true;


### PR DESCRIPTION
believe it or not, but this fixes an IOS 4 bug for me where I get an error on swipe left. my current workaround until this is pulled is to set the preventClassNoSwiping option to false
