### PR TITLE
Issue with input field in swiper

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -1105,8 +1105,11 @@ var Swiper = function (selector, params) {
             _this.callPlugins('onTouchStartBegin');
 
             if(!isTouchEvent) {
-                if(event.preventDefault) event.preventDefault();
-                else event.returnValue = false;
+                // Added check for input element since we are getting a mousedown event even on some touch devices.
+                if (!(params.releaseFormElements && event.srcElement.tagName.toLowerCase() === 'input')) {
+                    if (event.preventDefault) event.preventDefault();
+                    else event.returnValue = false;
+                }
             }
 
             var pageX = isTouchEvent ? event.targetTouches[0].pageX : (event.pageX || event.clientX);


### PR DESCRIPTION
Even if "releaseFormElements" is set to true the the input field has to be tapped twice to give focus.  This is because the first tap is being registered as a "mousedown" event and not a "touchstart" event (Tested on iOS 6/7 & chrome with touch events enabled).  I put in a check where you are checking for a touch event to see if we are releasing form elements and if the element is an input field.  I have not checked to see if other form elements have this same issue, for my purposes I had to make this change.  If you see a better way of implementing this check, feel free to make the change.
