### PR TITLE
Fix position issues caused by calculateHeight: true

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -647,9 +647,10 @@ var Swiper = function (selector, params) {
                     if (!isH) wrapperHeight+=_this.slides[i].getHeight(true);
                 }
                 var slideHeight = slideMaxHeight;
-                if (isH) var wrapperHeight = slideHeight;
-                containerSize = _this.height = slideHeight;
-                if (!isH) _this.container.style.height= containerSize+'px';
+                _this.height = slideHeight;
+
+                if (isH) wrapperHeight = slideHeight;
+                else containerSize = slideHeight, _this.container.style.height= containerSize+'px';
             }
             else {
                 var slideHeight = isH ? _this.height : _this.height/params.slidesPerView ;    


### PR DESCRIPTION
Fixes issues #254, #258 and probably #283

When `calculateHeight` is true, `containerSize` was set to the calculated height, rather than the width. 

I refactored the code to avoid the double assignment and assign `containerSize` to height, only for vertical mode (!isH)
