### PR TITLE
Mousewheel: added debounce delay - for the duration of mousewheelDebounc...

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -10,6 +10,27 @@
  *
  * Updated on: June 9, 2013
 */
+// debounce function taken from underscore.js (https://raw.github.com/jashkenas/underscore/master/underscore.js)
+// Returns a function, that, as long as it continues to be invoked, will not
+// be triggered. The function will be called after it stops being called for
+// N milliseconds. If `immediate` is passed, trigger the function on the
+// leading edge, instead of the trailing.
+var debounce = function(func, wait, immediate) {
+  var result;
+  var timeout = null;
+  return function() {
+    var context = this, args = arguments;
+    var later = function() {
+      timeout = null;
+      if (!immediate) result = func.apply(context, args);
+    };
+    var callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) result = func.apply(context, args);
+    return result;
+  };
+};
 var Swiper = function (selector, params) {
     /*=========================
       A little bit dirty but required part for IE8 and old FF support
@@ -147,6 +168,7 @@ var Swiper = function (selector, params) {
         initialSlide: 0,
         keyboardControl: false,
         mousewheelControl : false,
+        mousewheelDebounce: 600,
         useCSS3Transforms : true,
         //Loop mode
         loop:false,
@@ -799,7 +821,7 @@ var Swiper = function (selector, params) {
             }
             
             if (_this._wheelEvent) {
-                _this.h.addEventListener(_this.container, _this._wheelEvent, handleMousewheel, false);
+                _this.h.addEventListener(_this.container, _this._wheelEvent, debounce(handleMousewheel, params.mousewheelDebounce), false);
             }
         }
 


### PR DESCRIPTION
...e (600ms by default) all additional mousewheel events will be ignored - fixes the problem that when using e.g. an apple track pad and scrolling down >5cms with acceleration, swipeNext gets triggered 3-5 times instead of just once.

Ideally we'd only handle this without any delay and just wait until the touch has stopped but this fixes my problem very well so far and is a relatively easy fix.
Also for simplicity's sake I just imported Underscore.js's debounce function - maybe not the best idea - feel free to handle this differently.
