### PR TITLE
Added onFirstInit and onInit callbacks

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -484,9 +484,14 @@ var Swiper = function (selector, params, callback) {
                 _this.setTransform( 0, _this.positions.current, 0);
             }
         }
-        
-        if (!firstInit) _this.callPlugins('onFirstInit');
-        else _this.callPlugins('onInit');
+        if (!_this.initialized) {
+            _this.callPlugins('onFirstInit');
+            if (params.onFirstInit) params.onFirstInit(_this);
+        }
+        else {
+            _this.callPlugins('onInit');
+            if (params.onInit) params.onInit(_this);
+        }
         firstInit = true;
     }
     _this.init()


### PR DESCRIPTION
I needed these callbacks because I need to lazyLoad images and initialize fastTouch listeners on my buttons, which  only works after the Swiper is initialized.  Using timeouts for this is clumsy, so I added these callbacks.

Thanks
-Lee
