### PR TITLE
Improve nested swipers support and noSwiping logic. Added new demo for nested horizontal swipers.

### DIFF
--- a/demos/main-demos/08-nested-horizontal.html
+++ b/demos/main-demos/08-nested-horizontal.html
@@ -117,13 +117,13 @@
 <script src="js/idangerous.swiper-2.1.min.js"></script>
 <!--<script src="../../dev/idangerous.swiper.js"></script>-->
 <script>
+  var swiperNested1 = new Swiper('.swiper-nested-1', {
+    slidesPerView: 'auto',
+    noSwiping: true
+  });
   var swiperParent = new Swiper('.swiper-parent', {
     pagination: '.pagination-parent',
     paginationClickable: true,
-    noSwiping: true
-  });
-  var swiperNested1 = new Swiper('.swiper-nested-1', {
-    slidesPerView: 'auto',
     noSwiping: true
   });
   $(".toggle-parent").click(function () {

--- a/demos/main-demos/08-nested-vertical.html
+++ b/demos/main-demos/08-nested-vertical.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Demo</title>
+  <link rel="stylesheet" href="css/idangerous.swiper.css">
+  <style>body {
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .swiper-container {
+    width: 660px;
+    height: 250px;
+    color: #fff;
+    text-align: center;
+  }
+
+  .swiper-nested-1 {
+    width: 100%;
+  }
+
+  .red-slide {
+    background: #ca4040;
+  }
+
+  .blue-slide {
+    background: #4390ee;
+  }
+
+  .orange-slide {
+    background: #ff8604;
+  }
+
+  .green-slide {
+    background: #49a430;
+  }
+
+  .pink-slide {
+    background: #973e76;
+  }
+
+  .swiper-slide {
+    font-style: italic;
+    font-size: 42px;
+    margin-bottom: 0;
+    line-height: 250px;
+  }
+
+  .swiper-nested-1 .swiper-slide {
+    line-height: 125px;
+    font-size: 21px
+  }
+
+  .pagination {
+    position: absolute;
+    z-index: 100;
+    left: 10px;
+    bottom: 10px;
+  }
+
+  .swiper-pagination-switch {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 8px;
+    background: #222;
+    margin-right: 5px;
+    opacity: 0.8;
+    border: 1px solid #fff;
+    cursor: pointer;
+  }
+
+  .swiper-visible-switch {
+    background: #aaa;
+  }
+
+  .swiper-active-switch {
+    background: #fff;
+  }
+
+  .buttons {
+    text-align: center;
+    color: #333;
+  }
+  </style>
+</head>
+<body>
+
+
+<div class="swiper-container swiper-parent">
+  <div class="pagination pagination-parent"></div>
+  <div class="swiper-wrapper">
+    <div class="swiper-slide red-slide">
+      <div class="swiper-container swiper-nested-1" style="width: 500px; height: 100px">
+        <div class="swiper-wrapper">
+          <div class="swiper-slide green-slide" style="width: 200px">Nested Slide 1</div>
+          <div class="swiper-slide blue-slide" style="width: 200px">Nested Slide 2</div>
+          <div class="swiper-slide pink-slide" style="width: 400px">Nested Slide 3</div>
+        </div>
+      </div>
+    </div>
+
+
+    <div class="swiper-slide orange-slide"> Slide 2</div>
+  </div>
+</div>
+<div class="buttons">
+  <input type="submit" class="toggle-parent" value="Toggle no-swipe on parent's first slide"/>
+  <input type="submit" class="toggle-nested" value="Toggle no-swipe on nested swiper"/>
+</div>
+
+
+<script src="js/jquery-1.10.1.min.js"></script>
+<script src="js/idangerous.swiper-2.1.min.js"></script>
+<!--<script src="../../dev/idangerous.swiper.js"></script>-->
+<script>
+  var swiperParent = new Swiper('.swiper-parent', {
+    pagination: '.pagination-parent',
+    paginationClickable: true,
+    noSwiping: true
+  });
+  var swiperNested1 = new Swiper('.swiper-nested-1', {
+    slidesPerView: 'auto',
+    noSwiping: true
+  });
+  $(".toggle-parent").click(function () {
+    $(".red-slide").toggleClass("swiper-no-swiping");
+    return false;
+  });
+  $(".toggle-nested").click(function () {
+    $('.swiper-nested-1').toggleClass("swiper-no-swiping");
+    return false;
+  })
+</script>
+</body>
+</html>

--- a/demos/main-demos/08-nested.html
+++ b/demos/main-demos/08-nested.html
@@ -120,6 +120,7 @@ body {
   </div>
   <script src="js/jquery-1.10.1.min.js"></script>
   <script src="js/idangerous.swiper-2.1.min.js"></script>
+  <!--<script src="../../dev/idangerous.swiper.js"></script>-->
   <script>
   var swiperParent = new Swiper('.swiper-parent',{
     pagination: '.pagination-parent',

--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -1132,7 +1132,8 @@ var Swiper = function (selector, params) {
         }
 
         target = (event.target || event.srcElement);
-        if (target && !canBeSwiped(target)) return false;
+        _this.canBeSwiped = target && canBeSwiped(target);
+        if (!_this.canBeSwiped) return false;
         allowMomentumBounce = false;
 
         //Check For Nested Swipers
@@ -1202,7 +1203,7 @@ var Swiper = function (selector, params) {
         if ( typeof isScrolling === 'undefined' && !isH) {
           isScrolling = !!( isScrolling || Math.abs(pageY - _this.touches.startY) < Math.abs( pageX - _this.touches.startX ) );
         }
-        if (isScrolling ) {
+        if (isScrolling || !_this.canBeSwiped) {
             _this.isTouched = false;
             return
         }
@@ -1523,14 +1524,11 @@ var Swiper = function (selector, params) {
 
     // Iterate up the DOM tree and check if slide can be swiped.
     // Slide can be swiped if:
-    // - closest el's parent slide is this swiper's slide
-    // - slide has not noSwipingClass
+    // - slide belongs to this swiper and has not noSwipingClass
     // - wrapper nor container doesn't have noSwipingClass
     // NoSwipingClass can be set only on this swiper's slides, container or wrapper.
     function canBeSwiped(el) {
         while (true) {
-            // Return false if closest el's parent slide doesn't belong to this swiper
-            if (el.className.indexOf(params.slideClass) > -1 && !_this.isInSlides(el)) return false;
             if (params.noSwiping && el.className.indexOf(params.noSwipingClass) > -1 && (_this.isInSlides(el) || el == _this.wrapper || el == _this.container)) return false;
             if (el == _this.container) return true;
             el = el.parentElement;


### PR DESCRIPTION
I've improved Isaac Strack's noSwiping logic and it's now possible to have nested horizontal (I guess vertical too) swipers. There are two main changes:
- when you touch somewhere, the most nested swiper grabs this event, it was ambigous previously,
- noSwipingClass is checked by swiper only on it's own slides, wrapper and container. Previously it checked all nested slides, wrappers and containters which was faulty.

I've attached a new demo that shows this clearly. Play with this, then comment out current 2.1 version JS file and use development JS to see improvements.