### PR TITLE
Responsive issue due to rounding errors.

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -656,8 +656,8 @@ var Swiper = function (selector, params) {
                 var slideHeight = isH ? _this.height : _this.height/params.slidesPerView;
                 var wrapperHeight = isH ? _this.height : _this.slides.length*slideHeight;
             }
-            var slideWidth = isH ? _this.width/params.slidesPerView : _this.width;
-            var wrapperWidth = isH ? _this.slides.length*slideWidth : _this.width;
+            var slideWidth = isH ? Math.round(_this.width/params.slidesPerView) : _this.width;
+            var wrapperWidth = isH ? Math.round(_this.slides.length*slideWidth) : _this.width;
             slideSize = isH ? slideWidth : slideHeight;
 
             if (params.offsetSlidesBefore>0) {


### PR DESCRIPTION
Adding a Math.round on line numbers 659 and 670 around the division calculations. This solved an issue with having my slides wrapping due to rounding errors.
