### PR TITLE
fix not passing correct 'this' to onSwiperCreated callback

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -2173,7 +2173,7 @@ var Swiper = function (selector, params) {
         _this.centerIndex = _this.activeIndex;
 
         // Callbacks
-        if (params.onSwiperCreated) params.onSwiperCreated(this);
+        if (params.onSwiperCreated) params.onSwiperCreated(_this);
         _this.callPlugins('onSwiperCreated');
     }
     


### PR DESCRIPTION
does what it says on the tin, currently onSwiperCreated receives the wrong context.
