### PR TITLE
Added a param cssWidthAndHeight that can be set to true to disable the a...

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -700,22 +700,23 @@ var Swiper = function (selector, params) {
                 if (_this.wrapperBottom>0) wrapper.style.paddingBottom = _this.wrapperBottom+'px';
             }
 
-            wrapperSize = isH ? wrapperWidth + _this.wrapperRight + _this.wrapperLeft : wrapperHeight + _this.wrapperTop + _this.wrapperBottom;
-            _this.snapGrid = [];
-            _this.slidesGrid = [];
-
+          wrapperSize = isH ? wrapperWidth + _this.wrapperRight + _this.wrapperLeft : wrapperHeight + _this.wrapperTop + _this.wrapperBottom;
+          if(!params.cssWidthAndHeight) {
+            wrapper.style.width = wrapperWidth+'px';
+            wrapper.style.height = wrapperHeight+'px';
+          }
+          var slideLeft = 0;
+          _this.snapGrid = [];
+          _this.slidesGrid = [];
+          for (var i=0; i<_this.slides.length; i++) {
+            _this.snapGrid.push(slideLeft);
+            _this.slidesGrid.push(slideLeft);
+            slideLeft+=slideSize;
             if(!params.cssWidthAndHeight) {
-                var slideLeft = 0;
-                wrapper.style.width = wrapperWidth+'px';
-                wrapper.style.height = wrapperHeight+'px';
-                for (var i=0; i<_this.slides.length; i++) {
-                    _this.snapGrid.push(slideLeft);
-                    _this.slidesGrid.push(slideLeft);
-                    slideLeft+=slideSize;
-                    _this.slides[i].style.width = slideWidth+'px';
-                    _this.slides[i].style.height = slideHeight+'px';
-                }
+              _this.slides[i].style.width = slideWidth+'px';
+              _this.slides[i].style.height = slideHeight+'px';
             }
+          }
 
         }
 


### PR DESCRIPTION
Hi.

Love this project.

A simple change where a param stops the writing of the width and height to the Swiper.  I found myself making this change on several occasions.
The Swiper widths and heights can be defined using css and the swipper will still function fine, this work for both fixed width and responsive swipers.
The main reason for this request though is it makes the swiper easier to integrate with other frame works that force styles onto objects. (unfortunately common)
An example would be a swiper that I created in conjunction with http://isotope.metafizzy.co/ (sorry the example isn't live yet)

You may or may not consider this part of the core direction but it does add a far bit of flexibility

Regards,
Pete
