### PR TITLE
added is-duplicate class to all duplicate slides

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -1646,8 +1646,8 @@ var Swiper = function (selector, params) {
         return noSwiping;
     }
     
-    function addClassToHtmlString(parent, klass, outerHtml) {
-        var par = document.createElement(parent);
+    function addClassToHtmlString(klass, outerHtml) {
+        var par = document.createElement('div');
         var child;
 
         par.innerHTML = outerHtml;
@@ -2161,11 +2161,11 @@ var Swiper = function (selector, params) {
         // assemble remainder slides
         // assemble remainder appended to existing slides
         for(i = 0;i<remainderSlides;i++) {
-                slideLastHTML += addClassToHtmlString('ul', slideDuplicateClass, _this.slides[i].outerHTML);
+                slideLastHTML += addClassToHtmlString(slideDuplicateClass, _this.slides[i].outerHTML);
         }
         // assemble slides that get preppended to existing slides
         for(i = numSlides - remainderSlides;i<numSlides;i++) {
-                slideFirstHTML += addClassToHtmlString('ul', slideDuplicateClass, _this.slides[i].outerHTML);
+                slideFirstHTML += addClassToHtmlString(slideDuplicateClass, _this.slides[i].outerHTML);
         }
         // assemble all slides
         var slides = slideFirstHTML + slidesSetFullHTML + wrapper.innerHTML + slidesSetFullHTML + slideLastHTML;


### PR DESCRIPTION
added is-duplicate slides to all the duplicates to that they can be easily picked out in situations where developers need direct access to them.

Example use case: generating a print friendly version of the page depending on the content. Maybe you want to list the slides, but avoid the duplicates. 
