### PR TITLE
slidesPerView = 'auto' infinite loop fix

### DIFF
--- a/dist/idangerous.swiper-2.4.2.js
+++ b/dist/idangerous.swiper-2.4.2.js
@@ -658,7 +658,7 @@ var Swiper = function (selector, params) {
 
                 }
                 else {
-                    if (_slideSize>containerSize) {
+                    if (_slideSize>containerSize && containerSize > 0) {
                         for (var j=0; j<=Math.floor(_slideSize/containerSize); j++) {
                             _this.snapGrid.push(slideLeft+containerSize*j);
                         }


### PR DESCRIPTION
I had a setup where containerSize was 0 for some reason. No matter the cause I think it's good to check that code does not go to infinite loop which can happen without this fix. There is probably a better way to fix this issue, but this atleas stopes browsers from crashing and everything seemed to work just fine.
