### PR TITLE
Fix class detection

### DIFF
--- a/lib/idangerous.swiper.js
+++ b/lib/idangerous.swiper.js
@@ -235,7 +235,7 @@ var Swiper = function (selector, params) {
       ===========================*/
     for (var i = _this.container.childNodes.length - 1; i >= 0; i--) {
         if (_this.container.childNodes[i].className) {
-            var _wrapperClasses = _this.container.childNodes[i].className.split(' ');
+            var _wrapperClasses = _this.container.childNodes[i].className.split(/\s+/);
             for (var j = 0; j < _wrapperClasses.length; j++) {
                 if (_wrapperClasses[j] === params.wrapperClass) {
                     wrapper = _this.container.childNodes[i];
@@ -360,7 +360,7 @@ var Swiper = function (selector, params) {
         for (var i = 0; i < _this.wrapper.childNodes.length; i++) {
             if (_this.wrapper.childNodes[i].className) {
                 var _className = _this.wrapper.childNodes[i].className;
-                var _slideClasses = _className.split(' ');
+                var _slideClasses = _className.split(/\s+/);
                 for (var j = 0; j < _slideClasses.length; j++) {
                     if (_slideClasses[j] === params.slideClass) {
                         _this.slides.push(_this.wrapper.childNodes[i]);


### PR DESCRIPTION
Split style attributes on any combination of whitespace rather than
just on single space characters.

This allows class attributes which have newlines and other whitespace
in them for markup formatting purposes.
