### PR TITLE
removePaginationEvents() fix

### DIFF
--- a/lib/idangerous.swiper.js
+++ b/lib/idangerous.swiper.js
@@ -2003,14 +2003,18 @@ var Swiper = function (selector, params) {
     };
     function removePaginationEvents() {
         var pagers = _this.paginationButtons;
-        for (var i = 0; i < pagers.length; i++) {
-            _this.h.removeEventListener(pagers[i], 'click', paginationClick);
+        if (pagers) {
+            for (var i = 0; i < pagers.length; i++) {
+                _this.h.removeEventListener(pagers[i], 'click', paginationClick);
+            }
         }
     }
     function addPaginationEvents() {
         var pagers = _this.paginationButtons;
-        for (var i = 0; i < pagers.length; i++) {
-            _this.h.addEventListener(pagers[i], 'click', paginationClick);
+        if (pagers) {
+            for (var i = 0; i < pagers.length; i++) {
+                _this.h.addEventListener(pagers[i], 'click', paginationClick);
+            }
         }
     }
     function paginationClick(e) {


### PR DESCRIPTION
The pagers.length threw an error on my site when the pagers were null. Checking for pagers existence fixed it.
