### PR TITLE
Leave height totally alone when calculateHeight = true

### DIFF
--- a/lib/idangerous.swiper.js
+++ b/lib/idangerous.swiper.js
@@ -685,7 +685,7 @@ var Swiper = function (selector, params) {
             wrapperHeight = _this.slides[0].getHeight(true);
             wrapperSize = isH ? wrapperWidth : wrapperHeight;
             wrapper.style.width = wrapperWidth + 'px';
-            if (params.calculateHeight) wrapper.style.height = wrapperHeight + 'px'; / MaxM: Leave height totally alone when calculateHeight = true
+            if (params.calculateHeight) wrapper.style.height = wrapperHeight + 'px'; // MaxM: Leave height totally alone when calculateHeight = true
             slideSize = isH ? wrapperWidth : wrapperHeight;
 
         }

--- a/lib/idangerous.swiper.js
+++ b/lib/idangerous.swiper.js
@@ -586,7 +586,7 @@ var Swiper = function (selector, params) {
                 wrapper.style.paddingBottom = '';
             }
             wrapper.style.width = '';
-            wrapper.style.height = '';
+            if (params.calculateHeight) wrapper.style.height = ''; // MaxM: Leave height totally alone when calculateHeight = true
             if (params.offsetPxBefore > 0) {
                 if (isH) _this.wrapperLeft = params.offsetPxBefore;
                 else _this.wrapperTop = params.offsetPxBefore;
@@ -668,24 +668,24 @@ var Swiper = function (selector, params) {
             if (isH) {
                 wrapperSize = slidesWidth + _this.wrapperRight + _this.wrapperLeft;
                 wrapper.style.width = (slidesWidth) + 'px';
-                wrapper.style.height = (_this.height) + 'px';
+                if (params.calculateHeight) wrapper.style.height = (_this.height) + 'px'; // MaxM: Leave height totally alone when calculateHeight = true
             }
             else {
                 wrapperSize = slidesHeight + _this.wrapperTop + _this.wrapperBottom;
                 wrapper.style.width = (_this.width) + 'px';
-                wrapper.style.height = (slidesHeight) + 'px';
+                wrapper.style.height = (slidesHeight) + 'px'; 
             }
 
         }
         else if (params.scrollContainer) {
             //Scroll Container
             wrapper.style.width = '';
-            wrapper.style.height = '';
+            if (params.calculateHeight) wrapper.style.height = ''; // MaxM: Leave height totally alone when calculateHeight = true
             wrapperWidth = _this.slides[0].getWidth(true);
             wrapperHeight = _this.slides[0].getHeight(true);
             wrapperSize = isH ? wrapperWidth : wrapperHeight;
             wrapper.style.width = wrapperWidth + 'px';
-            wrapper.style.height = wrapperHeight + 'px';
+            if (params.calculateHeight) wrapper.style.height = wrapperHeight + 'px'; / MaxM: Leave height totally alone when calculateHeight = true
             slideSize = isH ? wrapperWidth : wrapperHeight;
 
         }


### PR DESCRIPTION
When using the Swiper within responsive context I found it useful NOT to have the plugin touch the height of the wrapper at any time.

Does this interfere with any internal logic of the plugin?