### PR TITLE
Add API support for enabling and disabling keyboardControls

### DIFF
--- a/dev/idangerous.swiper.js
+++ b/dev/idangerous.swiper.js
@@ -1069,6 +1069,16 @@ var Swiper = function (selector, params) {
         }
     }
 
+    _this.disableKeyboardControl = function () {
+        params.keyboardControl = false;
+        _this.h.removeEventListener(document, 'keydown', handleKeyboardKeys);
+    };
+
+    _this.enableKeyboardControl = function () {
+        params.keyboardControl = true;
+        _this.h.addEventListener(document, 'keydown', handleKeyboardKeys);
+    };
+
     /*==========================================
         Mousewheel Control
     ============================================*/


### PR DESCRIPTION
While you can disable swiping, there is currently no way (that I could find) to disable keyboard controls after initialization. These two short functions allow you to do so.
