### PR TITLE
Make smoother animation when swiping

### DIFF
--- a/lib/idangerous.swiper.js
+++ b/lib/idangerous.swiper.js
@@ -1839,6 +1839,10 @@ var Swiper = function (selector, params) {
         if (_this.support.transitions || !params.DOMAnimation) {
             _this.setWrapperTranslate(newPosition);
             _this.setWrapperTransition(speed);
+            //Update Active Slide Index
+            _this.wrapperTransitionEnd(function() {
+                _this.updateActiveSlide(newPosition);
+            }, false);
         }
         else {
             //Try the DOM animation
@@ -1849,10 +1853,10 @@ var Swiper = function (selector, params) {
             if (_this._DOMAnimating) return;
 
             anim();
-        }
 
-        //Update Active Slide Index
-        _this.updateActiveSlide(newPosition);
+            //Update Active Slide Index
+            _this.updateActiveSlide(newPosition);
+        }
 
         //Callbacks
         if (params.onSlideNext && action === 'next') {


### PR DESCRIPTION
Calling updateActiveSlide() method right after css transition makes pause a short moment while animating to next page when swiping.
In updateActiveSlide() method, classes of slides are modified and occur style recalculation and it was cause.
I have moved updateActiveSlide to transitionend event.
