### PR TITLE
updateActiveSlide bug fix

### DIFF
--- a/src/idangerous.swiper.js
+++ b/src/idangerous.swiper.js
@@ -1818,6 +1818,7 @@ var Swiper = function (selector, params) {
             newPosition = -index * slideSize;
         }
         if (newPosition < - maxWrapperPosition()) {
+            _this.updateActiveSlide(newPosition);
             newPosition = - maxWrapperPosition();
         }
 


### PR DESCRIPTION
the bug fix that updateActiveSlide method is not executed when newposition placed on the right of maxWrapperPosition.
