### PR TITLE
Don't pass 'none' to WebKitCSSMatrix constructor

### DIFF
--- a/src/idangerous.swiper.js
+++ b/src/idangerous.swiper.js
@@ -2485,7 +2485,9 @@ Swiper.prototype = {
         if (this.support.transforms && this.params.useCSS3Transforms) {
             curStyle = window.getComputedStyle(el, null);
             if (window.WebKitCSSMatrix) {
-                transformMatrix = new WebKitCSSMatrix(curStyle.webkitTransform);
+                // Some old versions of Webkit choke when 'none' is passed; pass
+                // empty string instead in this case
+                transformMatrix = new WebKitCSSMatrix(curStyle.webkitTransform === 'none' ? '' : curStyle.webkitTransform);
             }
             else {
                 transformMatrix = curStyle.MozTransform || curStyle.OTransform || curStyle.MsTransform || curStyle.msTransform  || curStyle.transform || curStyle.getPropertyValue('transform').replace('translate(', 'matrix(1, 0, 0, 1,');


### PR DESCRIPTION
This fixes an issue in some versions of Webkit. On affected versions a DOM
error 12 (syntax error) is thrown when 'none' is passed as the argument to
WebKitCSSMatrix's constructor. A commit fixing this issue in Chromium is at
https://chromium.googlesource.com/chromium/blink/+/6d50d9cd8b1df3190d67fbc4767a6c466d8dcbf9^!/

In particular, I see this issue in the stock browser on a Samsung GT-P6210
tablet.
