### PR TITLE
Adding RTL language support

### DIFF
--- a/src/idangerous.swiper.js
+++ b/src/idangerous.swiper.js
@@ -2544,6 +2544,11 @@ Swiper.prototype = {
             }
             coords[y] = x;
         }
+        
+        // Change the x position value to positive if the language direction is RTL
+        if (document.documentElement.dir == 'rtl') {
+            coords.x = Math.abs(coords.x);
+        }
 
         if (this.support.transforms && this.params.useCSS3Transforms) {
             translate = this.support.transforms3d ? 'translate3d(' + coords.x + 'px, ' + coords.y + 'px, ' + coords.z + 'px)' : 'translate(' + coords.x + 'px, ' + coords.y + 'px)';


### PR DESCRIPTION
Hi we are using this script on a site that supports both LTR and RTL languages.

The LTR or RTL gets set in the <html> dir="" attribute.

I spotted that the translate value was getting set as a negative value when it wants to be a positive value for RTL (note that .carousel-slide in the CSS is also set to float: right for RTL and float: left for LTR)

If the HTML dir attribute is set to RTL, I am altering the coords.x value. This value is only set to something other than 0 is the carousel mode is horizontal is far as I can tell.