### PR TITLE
Update idangerous.swiper.css

### DIFF
--- a/src/idangerous.swiper.css
+++ b/src/idangerous.swiper.css
@@ -57,7 +57,10 @@ Basic Swiper Styles
 .swiper-slide {
 	float: left;
 }
-
+/* Bootstrap fix */
+.swiper-slide img {
+	height:none;
+}
 /* IE10 Windows Phone 8 Fixes */
 .swiper-wp8-horizontal {
 	-ms-touch-action: pan-y;


### PR DESCRIPTION
When using this swiper along with Bootstrap 2.3.2, it would not display properly in IE11 due to bootstrap's img { height:auto } styling and lack of any default styling on the swiper images.  Overwriting bootstrap's img style corrects the issue without requiring dimensions to be set by the user.
