### PR TITLE
Fix Overflow Bug for very big width in IE, replaced Math.round with Math.ceil

### DIFF
--- a/src/idangerous.swiper.js
+++ b/src/idangerous.swiper.js
@@ -735,11 +735,11 @@ var Swiper = function (selector, params) {
             }
             else {
                 slideHeight = isH ? _this.height : _this.height / params.slidesPerView;
-                if (params.roundLengths) slideHeight = Math.round(slideHeight);
+                if (params.roundLengths) slideHeight = Math.ceil(slideHeight);
                 wrapperHeight = isH ? _this.height : _this.slides.length * slideHeight;
             }
             slideWidth = isH ? _this.width / params.slidesPerView : _this.width;
-            if (params.roundLengths) slideWidth = Math.round(slideWidth);
+            if (params.roundLengths) slideWidth = Math.ceil(slideWidth);
             wrapperWidth = isH ? _this.slides.length * slideWidth : _this.width;
             slideSize = isH ? slideWidth : slideHeight;
 
@@ -1804,7 +1804,7 @@ var Swiper = function (selector, params) {
             if (currentPosition <= -maxWrapperPosition()) newPosition = -maxWrapperPosition();
         }
         else {
-            newPosition = currentPosition < 0 ? Math.round(currentPosition / groupSize) * groupSize : 0;
+            newPosition = currentPosition < 0 ? Math.ceil(currentPosition / groupSize) * groupSize : 0;
         }
         if (params.scrollContainer)  {
             newPosition = currentPosition < 0 ? currentPosition : 0;
@@ -1856,7 +1856,7 @@ var Swiper = function (selector, params) {
             currentPosition += animationStep * time / (1000 / 60);
             condition = direction === 'toNext' ? currentPosition > newPosition : currentPosition < newPosition;
             if (condition) {
-                _this.setWrapperTranslate(Math.round(currentPosition));
+                _this.setWrapperTranslate(Math.ceil(currentPosition));
                 _this._DOMAnimating = true;
                 window.setTimeout(function () {
                     anim();
@@ -2592,7 +2592,7 @@ Swiper.prototype = {
                 returnWidth = el.offsetWidth - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-left')) - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-right'));
             }
             if (outer) returnWidth += parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-left')) + parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-right'));
-            if (round) return Math.round(returnWidth);
+            if (round) return Math.ceil(returnWidth);
             else return returnWidth;
         },
         getHeight: function (el, outer, round) {
@@ -2606,7 +2606,7 @@ Swiper.prototype = {
                 returnHeight = el.offsetHeight - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-top')) - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-bottom'));
             }
             if (outer) returnHeight += parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-top')) + parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-bottom'));
-            if (round) return Math.round(returnHeight);
+            if (round) return Math.ceil(returnHeight);
             else return returnHeight;
         },
         getOffset: function (el) {


### PR DESCRIPTION
I  fixed the bug with very big sizes in Internet Explorer, (getComputedStyle returns negative values).
Because it was already provided an alternative method for calculating sizes in IE, I add a control to use it:
 if (isNaN(returnWidth) || width.indexOf('%') > 0 || returnWidth < 0) { //checks invalid sizes.

Also I fixed a Math.round bug, (math.round rounds values both in excess and in defect), in excess there aren't problems, when defect it clips slides. 
Because of that i replaced Math.round with Math.ceil.
