### PR TITLE
Expand cssWidthAndHeight option to support either width or height

### DIFF
--- a/src/idangerous.swiper.js
+++ b/src/idangerous.swiper.js
@@ -1,9 +1,9 @@
 var Swiper = function (selector, params) {
     'use strict';
-    
+
     /*=========================
-     A little bit dirty but required part for IE8 and old FF support
-     ===========================*/
+      A little bit dirty but required part for IE8 and old FF support
+      ===========================*/
     if (document.body.__defineGetter__) {
         if (HTMLElement) {
             var element = HTMLElement.prototype;
@@ -12,7 +12,7 @@ var Swiper = function (selector, params) {
             }
         }
     }
-    
+
     if (!window.getComputedStyle) {
         window.getComputedStyle = function (el, pseudo) {
             this.el = el;
@@ -21,8 +21,8 @@ var Swiper = function (selector, params) {
                 if (prop === 'float') prop = 'styleFloat';
                 if (re.test(prop)) {
                     prop = prop.replace(re, function () {
-                                        return arguments[2].toUpperCase();
-                                        });
+                        return arguments[2].toUpperCase();
+                    });
                 }
                 return el.currentStyle[prop] ? el.currentStyle[prop] : null;
             };
@@ -46,45 +46,45 @@ var Swiper = function (selector, params) {
         else
             return jQuery(selector, context);
     }
-    
+
     /*=========================
-     Check for correct selector
-     ===========================*/
+      Check for correct selector
+      ===========================*/
     if (typeof selector === 'undefined') return;
-    
+
     if (!(selector.nodeType)) {
         if ($$(selector).length === 0) return;
     }
-    
-    /*=========================
-     _this
-     ===========================*/
+
+     /*=========================
+      _this
+      ===========================*/
     var _this = this;
-    
-    /*=========================
-     Default Flags and vars
-     ===========================*/
+
+     /*=========================
+      Default Flags and vars
+      ===========================*/
     _this.touches = {
-    start: 0,
-    startX: 0,
-    startY: 0,
-    current: 0,
-    currentX: 0,
-    currentY: 0,
-    diff: 0,
-    abs: 0
+        start: 0,
+        startX: 0,
+        startY: 0,
+        current: 0,
+        currentX: 0,
+        currentY: 0,
+        diff: 0,
+        abs: 0
     };
     _this.positions = {
-    start: 0,
-    abs: 0,
-    diff: 0,
-    current: 0
+        start: 0,
+        abs: 0,
+        diff: 0,
+        current: 0
     };
     _this.times = {
-    start: 0,
-    end: 0
+        start: 0,
+        end: 0
     };
-    
+
     _this.id = (new Date()).getTime();
     _this.container = (selector.nodeType) ? selector : $$(selector)[0];
     _this.isTouched = false;
@@ -105,64 +105,64 @@ var Swiper = function (selector, params) {
     _this.wrapperBottom = 0;
     _this.isAndroid = navigator.userAgent.toLowerCase().indexOf('android') >= 0;
     var wrapper, slideSize, wrapperSize, direction, isScrolling, containerSize;
-    
+
     /*=========================
-     Default Parameters
-     ===========================*/
+      Default Parameters
+      ===========================*/
     var defaults = {
-    eventTarget: 'wrapper', // or 'container'
+        eventTarget: 'wrapper', // or 'container'
         mode : 'horizontal', // or 'vertical'
         touchRatio : 1,
         speed : 300,
         freeMode : false,
         freeModeFluid : false,
-    momentumRatio: 1,
-    momentumBounce: true,
-    momentumBounceRatio: 1,
+        momentumRatio: 1,
+        momentumBounce: true,
+        momentumBounceRatio: 1,
         slidesPerView : 1,
         slidesPerGroup : 1,
-    slidesPerViewFit: true, //Fit to slide when spv "auto" and slides larger than container
+        slidesPerViewFit: true, //Fit to slide when spv "auto" and slides larger than container
         simulateTouch : true,
         followFinger : true,
         shortSwipes : true,
-    longSwipesRatio: 0.5,
-    moveStartThreshold: false,
+        longSwipesRatio: 0.5,
+        moveStartThreshold: false,
         onlyExternal : false,
         createPagination : true,
         pagination : false,
-    paginationElement: 'span',
-    paginationClickable: false,
-    paginationAsRange: true,
+        paginationElement: 'span',
+        paginationClickable: false,
+        paginationAsRange: true,
         resistance : true, // or false or 100%
         scrollContainer : false,
         preventLinks : true,
-    preventLinksPropagation: false,
+        preventLinksPropagation: false,
         noSwiping : false, // or class
         noSwipingClass : 'swiper-no-swiping', //:)
-    initialSlide: 0,
-    keyboardControl: false,
+        initialSlide: 0,
+        keyboardControl: false,
         mousewheelControl : false,
         mousewheelControlForceToAxis : false,
         useCSS3Transforms : true,
         // Autoplay
-    autoplay: false,
-    autoplayDisableOnInteraction: true,
-    autoplayStopOnLast: false,
+        autoplay: false,
+        autoplayDisableOnInteraction: true,
+        autoplayStopOnLast: false,
         //Loop mode
-    loop: false,
-    loopAdditionalSlides: 0,
+        loop: false,
+        loopAdditionalSlides: 0,
         // Round length values
-    roundLengths: false,
+        roundLengths: false,
         //Auto Height
-    calculateHeight: false,
+        calculateHeight: false,
         //Apply CSS for width and/or height
-    cssWidthAndHeight: false, // or true or 'width' or 'height'
+        cssWidthAndHeight: false, // or true or 'width' or 'height'
         //Images Preloader
         updateOnImagesReady : true,
         //Form elements
         releaseFormElements : true,
         //Watch for active slide, useful when use effects on different slide states
-    watchActiveIndex: false,
+        watchActiveIndex: false,
         //Slides Visibility Fit
         visibilityFullFit : false,
         //Slides Offset
@@ -170,7 +170,7 @@ var Swiper = function (selector, params) {
         offsetPxAfter : 0,
         offsetSlidesBefore : 0,
         offsetSlidesAfter : 0,
-    centeredSlides: false,
+        centeredSlides: false,
         //Queue callbacks
         queueStartCallbacks : false,
         queueEndCallbacks : false,
@@ -180,23 +180,23 @@ var Swiper = function (selector, params) {
         //DOMAnimation
         DOMAnimation : true,
         //Slides Loader
-    loader: {
-    slides: [], //array with slides
-    slidesHTMLType: 'inner', // or 'outer'
-    surroundGroups: 1, //keep preloaded slides groups around view
-    logic: 'reload', //or 'change'
-    loadAllSlides: false
-    },
+        loader: {
+            slides: [], //array with slides
+            slidesHTMLType: 'inner', // or 'outer'
+            surroundGroups: 1, //keep preloaded slides groups around view
+            logic: 'reload', //or 'change'
+            loadAllSlides: false
+        },
         //Namespace
-    slideElement: 'div',
-    slideClass: 'swiper-slide',
-    slideActiveClass: 'swiper-slide-active',
-    slideVisibleClass: 'swiper-slide-visible',
-    slideDuplicateClass: 'swiper-slide-duplicate',
-    wrapperClass: 'swiper-wrapper',
-    paginationElementClass: 'swiper-pagination-switch',
-    paginationActiveClass: 'swiper-active-switch',
-    paginationVisibleClass: 'swiper-visible-switch'
+        slideElement: 'div',
+        slideClass: 'swiper-slide',
+        slideActiveClass: 'swiper-slide-active',
+        slideVisibleClass: 'swiper-slide-visible',
+        slideDuplicateClass: 'swiper-slide-duplicate',
+        wrapperClass: 'swiper-wrapper',
+        paginationElementClass: 'swiper-pagination-switch',
+        paginationActiveClass: 'swiper-active-switch',
+        paginationVisibleClass: 'swiper-visible-switch'
     };
     params = params || {};
     for (var prop in defaults) {
@@ -220,23 +220,23 @@ var Swiper = function (selector, params) {
         params.resistance = '100%';
     }
     var isH = params.mode === 'horizontal';
-    
+
     /*=========================
-     Define Touch Events
-     ===========================*/
+      Define Touch Events
+      ===========================*/
     var desktopEvents = ['mousedown', 'mousemove', 'mouseup'];
     if (_this.browser.ie10) desktopEvents = ['MSPointerDown', 'MSPointerMove', 'MSPointerUp'];
     if (_this.browser.ie11) desktopEvents = ['pointerdown', 'pointermove', 'pointerup'];
-    
+
     _this.touchEvents = {
         touchStart : _this.support.touch || !params.simulateTouch  ? 'touchstart' : desktopEvents[0],
         touchMove : _this.support.touch || !params.simulateTouch ? 'touchmove' : desktopEvents[1],
         touchEnd : _this.support.touch || !params.simulateTouch ? 'touchend' : desktopEvents[2]
     };
-    
+
     /*=========================
-     Wrapper
-     ===========================*/
+      Wrapper
+      ===========================*/
     for (var i = _this.container.childNodes.length - 1; i >= 0; i--) {
         if (_this.container.childNodes[i].className) {
             var _wrapperClasses = _this.container.childNodes[i].className.split(/\s+/);
@@ -247,11 +247,11 @@ var Swiper = function (selector, params) {
             }
         }
     }
-    
+
     _this.wrapper = wrapper;
     /*=========================
-     Slide API
-     ===========================*/
+      Slide API
+      ===========================*/
     _this._extendSwiperSlide = function  (el) {
         el.append = function () {
             if (params.loop) {
@@ -261,7 +261,7 @@ var Swiper = function (selector, params) {
                 _this.wrapper.appendChild(el);
                 _this.reInit();
             }
-            
+
             return el;
         };
         el.prepend = function () {
@@ -280,7 +280,7 @@ var Swiper = function (selector, params) {
         el.insertAfter = function (index) {
             if (typeof index === 'undefined') return false;
             var beforeSlide;
-            
+
             if (params.loop) {
                 beforeSlide = _this.slides[index + 1 + _this.loopedSlides];
                 if (beforeSlide) {
@@ -355,7 +355,7 @@ var Swiper = function (selector, params) {
         };
         return el;
     };
-    
+
     //Calculate information about number of slides
     _this.calcSlides = function (forceCalcSlides) {
         var oldNumber = _this.slides ? _this.slides.length : false;
@@ -377,7 +377,7 @@ var Swiper = function (selector, params) {
         }
         if (oldNumber === false) return;
         if (oldNumber !== _this.slides.length || forceCalcSlides) {
-            
+
             // Number of slides has been changed
             removeSlideEvents();
             addSlideEvents();
@@ -386,7 +386,7 @@ var Swiper = function (selector, params) {
             _this.callPlugins('numberOfSlidesChanged');
         }
     };
-    
+
     //Create Slide
     _this.createSlide = function (html, slideClassList, el) {
         slideClassList = slideClassList || _this.params.slideClass;
@@ -396,7 +396,7 @@ var Swiper = function (selector, params) {
         newSlide.className = slideClassList;
         return _this._extendSwiperSlide(newSlide);
     };
-    
+
     //Append Slide
     _this.appendSlide = function (html, slideClassList, el) {
         if (!html) return;
@@ -468,12 +468,12 @@ var Swiper = function (selector, params) {
     _this.getFirstSlide = function () {
         return _this.slides[0];
     };
-    
+
     //Currently Active Slide
     _this.activeSlide = function () {
         return _this.slides[_this.activeIndex];
     };
-    
+
     /*=========================
      Wrapper for Callbacks : Allows additive callbacks via function arrays
      ===========================*/
@@ -495,7 +495,7 @@ var Swiper = function (selector, params) {
         if (Object.prototype.toString.apply(obj) === '[object Array]') return true;
         return false;
     }
-    
+
     /**
      * Allows user to add callbacks, rather than replace them
      * @param callback
@@ -523,10 +523,10 @@ var Swiper = function (selector, params) {
             _this.params['on' + callback] = null;
         }
     };
-    
+
     /*=========================
-     Plugins API
-     ===========================*/
+      Plugins API
+      ===========================*/
     var _plugins = [];
     for (var plugin in _this.plugins) {
         if (params[plugin]) {
@@ -542,24 +542,24 @@ var Swiper = function (selector, params) {
             }
         }
     };
-    
+
     /*=========================
-     Windows Phone 8 Fix
-     ===========================*/
+      Windows Phone 8 Fix
+      ===========================*/
     if ((_this.browser.ie10 || _this.browser.ie11) && !params.onlyExternal) {
         _this.wrapper.classList.add('swiper-wp8-' + (isH ? 'horizontal' : 'vertical'));
     }
-    
+
     /*=========================
-     Free Mode Class
-     ===========================*/
+      Free Mode Class
+      ===========================*/
     if (params.freeMode) {
         _this.container.className += ' swiper-free-mode';
     }
-    
+
     /*==================================================
-     Init/Re-init/Resize Fix
-     ====================================================*/
+        Init/Re-init/Resize Fix
+    ====================================================*/
     _this.initialized = false;
     _this.init = function (force, forceCalcSlides) {
         var _width = _this.h.getWidth(_this.container, false, params.roundLengths);
@@ -568,21 +568,21 @@ var Swiper = function (selector, params) {
         
         _this.width = _width;
         _this.height = _height;
-        
+
         var slideWidth, slideHeight, slideMaxHeight, wrapperWidth, wrapperHeight, slideLeft;
         var i; // loop index variable to avoid JSHint W004 / W038
         containerSize = isH ? _width : _height;
         var wrapper = _this.wrapper;
-        
+
         if (force) {
             _this.calcSlides(forceCalcSlides);
         }
-        
+
         if (params.slidesPerView === 'auto') {
             //Auto mode
             var slidesWidth = 0;
             var slidesHeight = 0;
-            
+
             //Unset Styles
             if (params.slidesOffset > 0) {
                 wrapper.style.paddingLeft = '';
@@ -600,7 +600,7 @@ var Swiper = function (selector, params) {
                 if (isH) _this.wrapperRight = params.offsetPxAfter;
                 else _this.wrapperBottom = params.offsetPxAfter;
             }
-            
+
             if (params.centeredSlides) {
                 if (isH) {
                     _this.wrapperLeft = (containerSize - this.slides[0].getWidth(true, params.roundLengths)) / 2;
@@ -611,7 +611,7 @@ var Swiper = function (selector, params) {
                     _this.wrapperBottom = (containerSize - _this.slides[_this.slides.length - 1].getHeight(true, params.roundLengths)) / 2;
                 }
             }
-            
+
             if (isH) {
                 if (_this.wrapperLeft >= 0) wrapper.style.paddingLeft = _this.wrapperLeft + 'px';
                 if (_this.wrapperRight >= 0) wrapper.style.paddingRight = _this.wrapperRight + 'px';
@@ -624,7 +624,7 @@ var Swiper = function (selector, params) {
             var centeredSlideLeft = 0;
             _this.snapGrid = [];
             _this.slidesGrid = [];
-            
+
             slideMaxHeight = 0;
             for (i = 0; i < _this.slides.length; i++) {
                 slideWidth = _this.slides[i].getWidth(true, params.roundLengths);
@@ -672,16 +672,16 @@ var Swiper = function (selector, params) {
                                 _this.snapGrid.push(slideLeft);
                             }
                         }
-                        
+                            
                     }
                     else {
                         _this.snapGrid.push(slideLeft);
                     }
                     _this.slidesGrid.push(slideLeft);
                 }
-                
+
                 slideLeft += _slideSize;
-                
+
                 slidesWidth += slideWidth;
                 slidesHeight += slideHeight;
             }
@@ -696,7 +696,7 @@ var Swiper = function (selector, params) {
                 wrapper.style.width = (_this.width) + 'px';
                 wrapper.style.height = (slidesHeight) + 'px';
             }
-            
+
         }
         else if (params.scrollContainer) {
             //Scroll Container
@@ -708,7 +708,7 @@ var Swiper = function (selector, params) {
             wrapper.style.width = wrapperWidth + 'px';
             wrapper.style.height = wrapperHeight + 'px';
             slideSize = isH ? wrapperWidth : wrapperHeight;
-            
+
         }
         else {
             //For usual slides
@@ -718,7 +718,7 @@ var Swiper = function (selector, params) {
                 //ResetWrapperSize
                 if (!isH) _this.container.style.height = '';
                 wrapper.style.height = '';
-                
+
                 for (i = 0; i < _this.slides.length; i++) {
                     //ResetSlideSize
                     _this.slides[i].style.height = '';
@@ -727,7 +727,7 @@ var Swiper = function (selector, params) {
                 }
                 slideHeight = slideMaxHeight;
                 _this.height = slideHeight;
-                
+
                 if (isH) wrapperHeight = slideHeight;
                 else {
                     containerSize = slideHeight;
@@ -743,7 +743,7 @@ var Swiper = function (selector, params) {
             if (params.roundLengths) slideWidth = Math.ceil(slideWidth);
             wrapperWidth = isH ? _this.slides.length * slideWidth : _this.width;
             slideSize = isH ? slideWidth : slideHeight;
-            
+
             if (params.offsetSlidesBefore > 0) {
                 if (isH) _this.wrapperLeft = slideSize * params.offsetSlidesBefore;
                 else _this.wrapperTop = slideSize * params.offsetSlidesBefore;
@@ -778,7 +778,7 @@ var Swiper = function (selector, params) {
                 if (_this.wrapperTop > 0) wrapper.style.paddingTop = _this.wrapperTop + 'px';
                 if (_this.wrapperBottom > 0) wrapper.style.paddingBottom = _this.wrapperBottom + 'px';
             }
-            
+
             wrapperSize = isH ? wrapperWidth + _this.wrapperRight + _this.wrapperLeft : wrapperHeight + _this.wrapperTop + _this.wrapperBottom;
             if (parseFloat(wrapperWidth) > 0 && !params.cssWidthAndHeight || params.cssWidthAndHeight === 'height') {
                 wrapper.style.width = wrapperWidth + 'px';
@@ -800,9 +800,9 @@ var Swiper = function (selector, params) {
                     _this.slides[i].style.height = slideHeight + 'px';
                 }
             }
-            
+
         }
-        
+
         if (!_this.initialized) {
             _this.callPlugins('onFirstInit');
             if (params.onFirstInit) _this.fireCallback(params.onFirstInit, _this);
@@ -813,16 +813,16 @@ var Swiper = function (selector, params) {
         }
         _this.initialized = true;
     };
-    
+
     _this.reInit = function (forceCalcSlides) {
         _this.init(true, forceCalcSlides);
     };
-    
+
     _this.resizeFix = function (reInit) {
         _this.callPlugins('beforeResizeFix');
-        
+
         _this.init(params.resizeReInit || reInit);
-        
+
         // swipe to active slide in fixed mode
         if (!params.freeMode) {
             _this.swipeTo((params.loop ? _this.activeLoopIndex : _this.activeIndex), 0, false);
@@ -849,13 +849,13 @@ var Swiper = function (selector, params) {
             _this.setWrapperTransition(0);
             _this.setWrapperTranslate(-maxWrapperPosition());
         }
-        
+
         _this.callPlugins('afterResizeFix');
     };
-    
+
     /*==========================================
-     Max and Min Positions
-     ============================================*/
+        Max and Min Positions
+    ============================================*/
     function maxWrapperPosition() {
         var a = (wrapperSize - containerSize);
         if (params.freeMode) {
@@ -868,10 +868,10 @@ var Swiper = function (selector, params) {
         if (a < 0) a = 0;
         return a;
     }
-    
+
     /*==========================================
-     Event Listeners
-     ============================================*/
+        Event Listeners
+    ============================================*/
     function initEvents() {
         var bind = _this.h.addEventListener;
         var eventTarget = params.eventTarget === 'wrapper' ? _this.wrapper : _this.container;
@@ -893,7 +893,7 @@ var Swiper = function (selector, params) {
             bind(document, _this.touchEvents.touchMove, onTouchMove);
             bind(document, _this.touchEvents.touchEnd, onTouchEnd);
         }
-        
+
         //Resize Event
         if (params.autoResize) {
             bind(window, 'resize', _this.resizeFix);
@@ -919,7 +919,7 @@ var Swiper = function (selector, params) {
                 bind(_this.container, _this._wheelEvent, handleMousewheel);
             }
         }
-        
+
         //Keyboard
         function _loadImage(src) {
             var image = new Image();
@@ -932,19 +932,19 @@ var Swiper = function (selector, params) {
             };
             image.src = src;
         }
-        
+
         if (params.keyboardControl) {
             bind(document, 'keydown', handleKeyboardKeys);
         }
         if (params.updateOnImagesReady) {
             _this.imagesToLoad = $$('img', _this.container);
-            
+
             for (var i = 0; i < _this.imagesToLoad.length; i++) {
                 _loadImage(_this.imagesToLoad[i].getAttribute('src'));
             }
         }
     }
-    
+
     //Remove Event Listeners
     _this.destroy = function () {
         var unbind = _this.h.removeEventListener;
@@ -967,44 +967,44 @@ var Swiper = function (selector, params) {
             unbind(document, _this.touchEvents.touchMove, onTouchMove);
             unbind(document, _this.touchEvents.touchEnd, onTouchEnd);
         }
-        
+
         //Resize Event
         if (params.autoResize) {
             unbind(window, 'resize', _this.resizeFix);
         }
-        
+
         //Init Slide Events
         removeSlideEvents();
-        
+
         //Pagination
         if (params.paginationClickable) {
             removePaginationEvents();
         }
-        
+
         //Mousewheel
         if (params.mousewheelControl && _this._wheelEvent) {
             unbind(_this.container, _this._wheelEvent, handleMousewheel);
         }
-        
+
         //Keyboard
         if (params.keyboardControl) {
             unbind(document, 'keydown', handleKeyboardKeys);
         }
-        
+
         //Stop autoplay
         if (params.autoplay) {
             _this.stopAutoplay();
         }
         _this.callPlugins('onDestroy');
-        
+
         //Destroy variable
         _this = null;
     };
-    
+
     function addSlideEvents() {
         var bind = _this.h.addEventListener,
-        i;
-        
+            i;
+
         //Prevent Links Events
         if (params.preventLinks) {
             var links = $$('a', _this.container);
@@ -1019,7 +1019,7 @@ var Swiper = function (selector, params) {
                 bind(formElements[i], _this.touchEvents.touchStart, releaseForms, true);
             }
         }
-        
+
         //Slide Clicks & Touches
         if (params.onSlideClick) {
             for (i = 0; i < _this.slides.length; i++) {
@@ -1034,8 +1034,8 @@ var Swiper = function (selector, params) {
     }
     function removeSlideEvents() {
         var unbind = _this.h.removeEventListener,
-        i;
-        
+            i;
+
         //Slide Clicks & Touches
         if (params.onSlideClick) {
             for (i = 0; i < _this.slides.length; i++) {
@@ -1063,8 +1063,8 @@ var Swiper = function (selector, params) {
         }
     }
     /*==========================================
-     Keyboard Control
-     ============================================*/
+        Keyboard Control
+    ============================================*/
     function handleKeyboardKeys(e) {
         var kc = e.keyCode || e.charCode;
         if (e.shiftKey || e.altKey || e.ctrlKey || e.metaKey) return;
@@ -1077,20 +1077,20 @@ var Swiper = function (selector, params) {
             var windowWidth = _this.h.windowWidth();
             var windowHeight = _this.h.windowHeight();
             var swiperCoord = [
-                               [swiperOffset.left, swiperOffset.top],
-                               [swiperOffset.left + _this.width, swiperOffset.top],
-                               [swiperOffset.left, swiperOffset.top + _this.height],
-                               [swiperOffset.left + _this.width, swiperOffset.top + _this.height]
-                               ];
+                [swiperOffset.left, swiperOffset.top],
+                [swiperOffset.left + _this.width, swiperOffset.top],
+                [swiperOffset.left, swiperOffset.top + _this.height],
+                [swiperOffset.left + _this.width, swiperOffset.top + _this.height]
+            ];
             for (var i = 0; i < swiperCoord.length; i++) {
                 var point = swiperCoord[i];
                 if (
                     point[0] >= scrollLeft && point[0] <= scrollLeft + windowWidth &&
                     point[1] >= scrollTop && point[1] <= scrollTop + windowHeight
-                    ) {
+                ) {
                     inView = true;
                 }
-                
+
             }
             if (!inView) return;
         }
@@ -1111,25 +1111,25 @@ var Swiper = function (selector, params) {
             if (kc === 38) _this.swipePrev();
         }
     }
-    
+
     _this.disableKeyboardControl = function () {
         params.keyboardControl = false;
         _this.h.removeEventListener(document, 'keydown', handleKeyboardKeys);
     };
-    
+
     _this.enableKeyboardControl = function () {
         params.keyboardControl = true;
         _this.h.addEventListener(document, 'keydown', handleKeyboardKeys);
     };
-    
+
     /*==========================================
-     Mousewheel Control
-     ============================================*/
+        Mousewheel Control
+    ============================================*/
     var lastScrollTime = (new Date()).getTime();
     function handleMousewheel(e) {
         var we = _this._wheelEvent;
         var delta = 0;
-        
+
         //Opera & IE
         if (e.detail) delta = -e.detail;
         //WebKits
@@ -1166,31 +1166,31 @@ var Swiper = function (selector, params) {
                 delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? - e.deltaX : - e.deltaY;
             }
         }
-        
+
         if (!params.freeMode) {
             if ((new Date()).getTime() - lastScrollTime > 60) {
                 if (delta < 0) _this.swipeNext();
                 else _this.swipePrev();
             }
             lastScrollTime = (new Date()).getTime();
-            
+
         }
         else {
             //Freemode or scrollContainer:
             var position = _this.getWrapperTranslate() + delta;
-            
+
             if (position > 0) position = 0;
             if (position < -maxWrapperPosition()) position = -maxWrapperPosition();
-            
+
             _this.setWrapperTransition(0);
             _this.setWrapperTranslate(position);
             _this.updateActiveSlide(position);
-            
+
             // Return page scroll on edge positions
             if (position === 0 || position === -maxWrapperPosition()) return;
         }
         if (params.autoplay) _this.stopAutoplay(true);
-        
+
         if (e.preventDefault) e.preventDefault();
         else e.returnValue = false;
         return false;
@@ -1201,17 +1201,17 @@ var Swiper = function (selector, params) {
         _this.h.removeEventListener(_this.container, _this._wheelEvent, handleMousewheel);
         return true;
     };
-    
+
     _this.enableMousewheelControl = function () {
         if (!_this._wheelEvent) return false;
         params.mousewheelControl = true;
         _this.h.addEventListener(_this.container, _this._wheelEvent, handleMousewheel);
         return true;
     };
-    
+
     /*=========================
-     Grab Cursor
-     ===========================*/
+      Grab Cursor
+      ===========================*/
     if (params.grabCursor) {
         var containerStyle = _this.container.style;
         containerStyle.cursor = 'move';
@@ -1219,11 +1219,11 @@ var Swiper = function (selector, params) {
         containerStyle.cursor = '-moz-grab';
         containerStyle.cursor = '-webkit-grab';
     }
-    
+
     /*=========================
-     Slides Events Handlers
-     ===========================*/
-    
+      Slides Events Handlers
+      ===========================*/
+
     _this.allowSlideClick = true;
     function slideClick(event) {
         if (_this.allowSlideClick) {
@@ -1231,14 +1231,14 @@ var Swiper = function (selector, params) {
             _this.fireCallback(params.onSlideClick, _this, event);
         }
     }
-    
+
     function slideTouch(event) {
         setClickedSlide(event);
         _this.fireCallback(params.onSlideTouch, _this, event);
     }
-    
+
     function setClickedSlide(event) {
-        
+
         // IE 6-8 support
         if (!event.currentTarget) {
             var element = event.srcElement;
@@ -1253,11 +1253,11 @@ var Swiper = function (selector, params) {
         else {
             _this.clickedSlide = event.currentTarget;
         }
-        
+
         _this.clickedSlideIndex     = _this.slides.indexOf(_this.clickedSlide);
         _this.clickedSlideLoopIndex = _this.clickedSlideIndex - (_this.loopedSlides || 0);
     }
-    
+
     _this.allowLinks = true;
     function preventClick(e) {
         if (!_this.allowLinks) {
@@ -1273,12 +1273,12 @@ var Swiper = function (selector, params) {
         if (e.stopPropagation) e.stopPropagation();
         else e.returnValue = false;
         return false;
-        
+
     }
-    
+
     /*==================================================
-     Event Handlers
-     ====================================================*/
+        Event Handlers
+    ====================================================*/
     var isTouchEvent = false;
     var allowThresholdMove;
     var allowMomentumBounce = true;
@@ -1288,54 +1288,54 @@ var Swiper = function (selector, params) {
         if (_this.isTouched || params.onlyExternal) {
             return false;
         }
-        
+
         if (params.noSwiping && (event.target || event.srcElement) && noSwipingSlide(event.target || event.srcElement)) return false;
         allowMomentumBounce = false;
         //Check For Nested Swipers
         _this.isTouched = true;
         isTouchEvent = event.type === 'touchstart';
-        
+
         if (!isTouchEvent || event.targetTouches.length === 1) {
             _this.callPlugins('onTouchStartBegin');
-            
+
             if (!isTouchEvent && !_this.isAndroid) {
                 if (event.preventDefault) event.preventDefault();
                 else event.returnValue = false;
             }
-            
+
             var pageX = isTouchEvent ? event.targetTouches[0].pageX : (event.pageX || event.clientX);
             var pageY = isTouchEvent ? event.targetTouches[0].pageY : (event.pageY || event.clientY);
-            
+
             //Start Touches to check the scrolling
             _this.touches.startX = _this.touches.currentX = pageX;
             _this.touches.startY = _this.touches.currentY = pageY;
-            
+
             _this.touches.start = _this.touches.current = isH ? pageX : pageY;
-            
+
             //Set Transition Time to 0
             _this.setWrapperTransition(0);
-            
+
             //Get Start Translate Position
             _this.positions.start = _this.positions.current = _this.getWrapperTranslate();
-            
+
             //Set Transform
             _this.setWrapperTranslate(_this.positions.start);
-            
+
             //TouchStartTime
             _this.times.start = (new Date()).getTime();
-            
+
             //Unset Scrolling
             isScrolling = undefined;
-            
+
             //Set Treshold
             if (params.moveStartThreshold > 0) {
                 allowThresholdMove = false;
             }
-            
+
             //CallBack
             if (params.onTouchStart) _this.fireCallback(params.onTouchStart, _this, event);
             _this.callPlugins('onTouchStartEnd');
-            
+
         }
     }
     var velocityPrevPosition, velocityPrevTime;
@@ -1343,10 +1343,10 @@ var Swiper = function (selector, params) {
         // If slider is not touched - exit
         if (!_this.isTouched || params.onlyExternal) return;
         if (isTouchEvent && event.type === 'mousemove') return;
-        
+
         var pageX = isTouchEvent ? event.targetTouches[0].pageX : (event.pageX || event.clientX);
         var pageY = isTouchEvent ? event.targetTouches[0].pageY : (event.pageY || event.clientY);
-        
+
         //check for scrolling
         if (typeof isScrolling === 'undefined' && isH) {
             isScrolling = !!(isScrolling || Math.abs(pageY - _this.touches.startY) > Math.abs(pageX - _this.touches.startX));
@@ -1358,14 +1358,14 @@ var Swiper = function (selector, params) {
             _this.isTouched = false;
             return;
         }
-        
+
         //Check For Nested Swipers
         if (event.assignedToSwiper) {
             _this.isTouched = false;
             return;
         }
         event.assignedToSwiper = true;
-        
+
         //Block inner links
         if (params.preventLinks) {
             _this.allowLinks = false;
@@ -1373,17 +1373,17 @@ var Swiper = function (selector, params) {
         if (params.onSlideClick) {
             _this.allowSlideClick = false;
         }
-        
+
         //Stop AutoPlay if exist
         if (params.autoplay) {
             _this.stopAutoplay(true);
         }
         if (!isTouchEvent || event.touches.length === 1) {
-            
+
             //Moved Flag
             if (!_this.isMoved) {
                 _this.callPlugins('onTouchMoveStart');
-                
+
                 if (params.loop) {
                     _this.fixLoop();
                     _this.positions.start = _this.getWrapperTranslate();
@@ -1391,15 +1391,15 @@ var Swiper = function (selector, params) {
                 if (params.onTouchMoveStart) _this.fireCallback(params.onTouchMoveStart, _this);
             }
             _this.isMoved = true;
-            
+
             // cancel event
             if (event.preventDefault) event.preventDefault();
             else event.returnValue = false;
-            
+
             _this.touches.current = isH ? pageX : pageY;
-            
+
             _this.positions.current = (_this.touches.current - _this.touches.start) * params.touchRatio + _this.positions.start;
-            
+
             //Resistance Callbacks
             if (_this.positions.current > 0 && params.onResistanceBefore) {
                 _this.fireCallback(params.onResistanceBefore, _this, _this.positions.current);
@@ -1420,12 +1420,12 @@ var Swiper = function (selector, params) {
                 }
                 //Resistance for After-End Sliding
                 if (_this.positions.current < -maxWrapperPosition()) {
-                    
+
                     var diff = (_this.touches.current - _this.touches.start) * params.touchRatio + (maxWrapperPosition() + _this.positions.start);
                     resistance = (containerSize + diff) / (containerSize);
                     var newPos = _this.positions.current - diff * (1 - resistance) / 2;
                     var stopPos = -maxWrapperPosition() - containerSize / 2;
-                    
+
                     if (newPos < stopPos || resistance <= 0)
                         _this.positions.current = stopPos;
                     else
@@ -1444,7 +1444,7 @@ var Swiper = function (selector, params) {
             }
             //Move Slides
             if (!params.followFinger) return;
-            
+
             if (!params.moveStartThreshold) {
                 _this.setWrapperTranslate(_this.positions.current);
             }
@@ -1461,11 +1461,11 @@ var Swiper = function (selector, params) {
                     _this.positions.current = _this.positions.start;
                 }
             }
-            
+
             if (params.freeMode || params.watchActiveIndex) {
                 _this.updateActiveSlide(_this.positions.current);
             }
-            
+
             //Grab Cursor
             if (params.grabCursor) {
                 _this.container.style.cursor = 'move';
@@ -1483,7 +1483,7 @@ var Swiper = function (selector, params) {
             //Callbacks
             _this.callPlugins('onTouchMoveEnd');
             if (params.onTouchMove) _this.fireCallback(params.onTouchMove, _this, event);
-            
+
             return false;
         }
     }
@@ -1495,7 +1495,7 @@ var Swiper = function (selector, params) {
         // If slider is not touched exit
         if (params.onlyExternal || !_this.isTouched) return;
         _this.isTouched = false;
-        
+
         //Return Grab Cursor
         if (params.grabCursor) {
             _this.container.style.cursor = 'move';
@@ -1503,31 +1503,31 @@ var Swiper = function (selector, params) {
             _this.container.style.cursor = '-moz-grab';
             _this.container.style.cursor = '-webkit-grab';
         }
-        
+
         //Check for Current Position
         if (!_this.positions.current && _this.positions.current !== 0) {
             _this.positions.current = _this.positions.start;
         }
-        
+
         //For case if slider touched but not moved
         if (params.followFinger) {
             _this.setWrapperTranslate(_this.positions.current);
         }
-        
+
         // TouchEndTime
         _this.times.end = (new Date()).getTime();
-        
+
         //Difference
         _this.touches.diff = _this.touches.current - _this.touches.start;
         _this.touches.abs = Math.abs(_this.touches.diff);
-        
+
         _this.positions.diff = _this.positions.current - _this.positions.start;
         _this.positions.abs = Math.abs(_this.positions.diff);
-        
+
         var diff = _this.positions.diff;
         var diffAbs = _this.positions.abs;
         var timeDiff = _this.times.end - _this.times.start;
-        
+
         if (diffAbs < 5 && (timeDiff) < 300 && _this.allowLinks === false) {
             if (!params.freeMode && diffAbs !== 0) _this.swipeReset();
             //Release inner links
@@ -1538,19 +1538,19 @@ var Swiper = function (selector, params) {
                 _this.allowSlideClick = true;
             }
         }
-        
+
         setTimeout(function () {
-                   //Release inner links
-                   if (params.preventLinks) {
-                   _this.allowLinks = true;
-                   }
-                   if (params.onSlideClick) {
-                   _this.allowSlideClick = true;
-                   }
-                   }, 100);
-        
+            //Release inner links
+            if (params.preventLinks) {
+                _this.allowLinks = true;
+            }
+            if (params.onSlideClick) {
+                _this.allowSlideClick = true;
+            }
+        }, 100);
+
         var maxPosition = maxWrapperPosition();
-        
+
         //Not moved or Prevent Negative Back Sliding/After-End Sliding
         if (!_this.isMoved && params.freeMode) {
             _this.isMoved = false;
@@ -1564,9 +1564,9 @@ var Swiper = function (selector, params) {
             _this.callPlugins('onTouchEnd');
             return;
         }
-        
+
         _this.isMoved = false;
-        
+
         //Free Mode
         if (params.freeMode) {
             if (params.freeModeFluid) {
@@ -1596,45 +1596,45 @@ var Swiper = function (selector, params) {
                 }
                 //Fix duration
                 if (_this.velocity !== 0) momentumDuration = Math.abs((newPosition - _this.positions.current) / _this.velocity);
-                
+
                 _this.setWrapperTranslate(newPosition);
-                
+
                 _this.setWrapperTransition(momentumDuration);
-                
+
                 if (params.momentumBounce && doBounce) {
                     _this.wrapperTransitionEnd(function () {
-                                               if (!allowMomentumBounce) return;
-                                               if (params.onMomentumBounce) _this.fireCallback(params.onMomentumBounce, _this);
-                                               _this.callPlugins('onMomentumBounce');
-                                               
-                                               _this.setWrapperTranslate(afterBouncePosition);
-                                               _this.setWrapperTransition(300);
-                                               });
+                        if (!allowMomentumBounce) return;
+                        if (params.onMomentumBounce) _this.fireCallback(params.onMomentumBounce, _this);
+                        _this.callPlugins('onMomentumBounce');
+
+                        _this.setWrapperTranslate(afterBouncePosition);
+                        _this.setWrapperTransition(300);
+                    });
                 }
-                
+
                 _this.updateActiveSlide(newPosition);
             }
             if (!params.freeModeFluid || timeDiff >= 300) _this.updateActiveSlide(_this.positions.current);
-            
+
             if (params.onTouchEnd) _this.fireCallback(params.onTouchEnd, _this, event);
             _this.callPlugins('onTouchEnd');
             return;
         }
-        
+
         //Direction
         direction = diff < 0 ? 'toNext' : 'toPrev';
-        
+
         //Short Touches
         if (direction === 'toNext' && (timeDiff <= 300)) {
             if (diffAbs < 30 || !params.shortSwipes) _this.swipeReset();
             else _this.swipeNext(true);
         }
-        
+
         if (direction === 'toPrev' && (timeDiff <= 300)) {
             if (diffAbs < 30 || !params.shortSwipes) _this.swipeReset();
             else _this.swipePrev(true);
         }
-        
+
         //Long Touches
         var targetSlideSize = 0;
         if (params.slidesPerView === 'auto') {
@@ -1674,56 +1674,56 @@ var Swiper = function (selector, params) {
         if (params.onTouchEnd) _this.fireCallback(params.onTouchEnd, _this, event);
         _this.callPlugins('onTouchEnd');
     }
-    
-    
+
+
     /*==================================================
-     noSwiping Bubble Check by Isaac Strack
-     ====================================================*/
+        noSwiping Bubble Check by Isaac Strack
+    ====================================================*/
     function noSwipingSlide(el) {
         /*This function is specifically designed to check the parent elements for the noSwiping class, up to the wrapper.
-         We need to check parents because while onTouchStart bubbles, _this.isTouched is checked in onTouchStart, which stops the bubbling.
-         So, if a text box, for example, is the initial target, and the parent slide container has the noSwiping class, the _this.isTouched
-         check will never find it, and what was supposed to be noSwiping is able to be swiped.
-         This function will iterate up and check for the noSwiping class in parents, up through the wrapperClass.*/
-        
+        We need to check parents because while onTouchStart bubbles, _this.isTouched is checked in onTouchStart, which stops the bubbling.
+        So, if a text box, for example, is the initial target, and the parent slide container has the noSwiping class, the _this.isTouched
+        check will never find it, and what was supposed to be noSwiping is able to be swiped.
+        This function will iterate up and check for the noSwiping class in parents, up through the wrapperClass.*/
+
         // First we create a truthy variable, which is that swiping is allowd (noSwiping = false)
         var noSwiping = false;
-        
+
         // Now we iterate up (parentElements) until we reach the node with the wrapperClass.
         do {
-            
+
             // Each time, we check to see if there's a 'swiper-no-swiping' class (noSwipingClass).
             if (el.className.indexOf(params.noSwipingClass) > -1)
             {
                 noSwiping = true; // If there is, we set noSwiping = true;
             }
-            
+
             el = el.parentElement;  // now we iterate up (parent node)
-            
+
         } while (!noSwiping && el.parentElement && el.className.indexOf(params.wrapperClass) === -1); // also include el.parentElement truthy, just in case.
-        
+
         // because we didn't check the wrapper itself, we do so now, if noSwiping is false:
         if (!noSwiping && el.className.indexOf(params.wrapperClass) > -1 && el.className.indexOf(params.noSwipingClass) > -1)
             noSwiping = true; // if the wrapper has the noSwipingClass, we set noSwiping = true;
-        
+
         return noSwiping;
     }
-    
+
     function addClassToHtmlString(klass, outerHtml) {
         var par = document.createElement('div');
         var child;
-        
+
         par.innerHTML = outerHtml;
         child = par.firstChild;
         child.className += ' ' + klass;
-        
+
         return child.outerHTML;
     }
-    
-    
+
+
     /*==================================================
-     Swipe Functions
-     ====================================================*/
+        Swipe Functions
+    ====================================================*/
     _this.swipeNext = function (internal) {
         if (!internal && params.loop) _this.fixLoop();
         if (!internal && params.autoplay) _this.stopAutoplay(true);
@@ -1753,7 +1753,7 @@ var Swiper = function (selector, params) {
         if (!internal && params.loop) _this.fixLoop();
         if (!internal && params.autoplay) _this.stopAutoplay(true);
         _this.callPlugins('onSwipePrev');
-        
+
         var currentPosition = Math.ceil(_this.getWrapperTranslate());
         var newPosition;
         if (params.slidesPerView === 'auto') {
@@ -1773,13 +1773,13 @@ var Swiper = function (selector, params) {
             var groupSize = slideSize * params.slidesPerGroup;
             newPosition = -(Math.ceil(-currentPosition / groupSize) - 1) * groupSize;
         }
-        
+
         if (newPosition > 0) newPosition = 0;
-        
+
         if (newPosition === currentPosition) return false;
         swipeToPosition(newPosition, 'prev');
         return true;
-        
+
     };
     _this.swipeReset = function () {
         _this.callPlugins('onSwipeReset');
@@ -1812,13 +1812,13 @@ var Swiper = function (selector, params) {
         if (params.scrollContainer && (containerSize > slideSize)) {
             newPosition = 0;
         }
-        
+
         if (newPosition === currentPosition) return false;
-        
+
         swipeToPosition(newPosition, 'reset');
         return true;
     };
-    
+
     _this.swipeTo = function (index, speed, runCallbacks) {
         index = parseInt(index, 10);
         _this.callPlugins('onSwipeTo', {index: index, speed: speed});
@@ -1835,18 +1835,18 @@ var Swiper = function (selector, params) {
         if (newPosition < - maxWrapperPosition()) {
             newPosition = - maxWrapperPosition();
         }
-        
+
         if (newPosition === currentPosition) return false;
-        
+
         runCallbacks = runCallbacks === false ? false : true;
         swipeToPosition(newPosition, 'to', {index: index, speed: speed, runCallbacks: runCallbacks});
         return true;
     };
-    
+
     function swipeToPosition(newPosition, action, toOptions) {
         var speed = (action === 'to' && toOptions.speed >= 0) ? toOptions.speed : params.speed;
         var timeOld = + new Date();
-        
+
         function anim() {
             var timeNew = + new Date();
             var time = timeNew - timeOld;
@@ -1856,8 +1856,8 @@ var Swiper = function (selector, params) {
                 _this.setWrapperTranslate(Math.ceil(currentPosition));
                 _this._DOMAnimating = true;
                 window.setTimeout(function () {
-                                  anim();
-                                  }, 1000 / 60);
+                    anim();
+                }, 1000 / 60);
             }
             else {
                 if (params.onSlideChangeEnd) {
@@ -1873,7 +1873,7 @@ var Swiper = function (selector, params) {
                 _this._DOMAnimating = false;
             }
         }
-        
+
         if (_this.support.transitions || !params.DOMAnimation) {
             _this.setWrapperTranslate(newPosition);
             _this.setWrapperTransition(speed);
@@ -1885,13 +1885,13 @@ var Swiper = function (selector, params) {
             var direction = currentPosition > newPosition ? 'toNext' : 'toPrev';
             var condition = direction === 'toNext' ? currentPosition > newPosition : currentPosition < newPosition;
             if (_this._DOMAnimating) return;
-            
+
             anim();
         }
-        
+
         //Update Active Slide Index
         _this.updateActiveSlide(newPosition);
-        
+
         //Callbacks
         if (params.onSlideNext && action === 'next') {
             _this.fireCallback(params.onSlideNext, _this, newPosition);
@@ -1903,14 +1903,14 @@ var Swiper = function (selector, params) {
         if (params.onSlideReset && action === 'reset') {
             _this.fireCallback(params.onSlideReset, _this, newPosition);
         }
-        
+
         //'Next', 'Prev' and 'To' Callbacks
         if (action === 'next' || action === 'prev' || (action === 'to' && toOptions.runCallbacks === true))
             slideChangeCallbacks(action);
     }
     /*==================================================
-     Transition Callbacks
-     ====================================================*/
+        Transition Callbacks
+    ====================================================*/
     //Prevent Multiple Callbacks
     _this._queueStartCallbacks = false;
     _this._queueEndCallbacks = false;
@@ -1923,8 +1923,8 @@ var Swiper = function (selector, params) {
                 _this._queueStartCallbacks = true;
                 _this.fireCallback(params.onSlideChangeStart, _this, direction);
                 _this.wrapperTransitionEnd(function () {
-                                           _this._queueStartCallbacks = false;
-                                           });
+                    _this._queueStartCallbacks = false;
+                });
             }
             else _this.fireCallback(params.onSlideChangeStart, _this, direction);
         }
@@ -1935,28 +1935,28 @@ var Swiper = function (selector, params) {
                     if (_this._queueEndCallbacks) return;
                     _this._queueEndCallbacks = true;
                     _this.wrapperTransitionEnd(function (swiper) {
-                                               _this.fireCallback(params.onSlideChangeEnd, swiper, direction);
-                                               });
+                        _this.fireCallback(params.onSlideChangeEnd, swiper, direction);
+                    });
                 }
                 else {
                     _this.wrapperTransitionEnd(function (swiper) {
-                                               _this.fireCallback(params.onSlideChangeEnd, swiper, direction);
-                                               });
+                        _this.fireCallback(params.onSlideChangeEnd, swiper, direction);
+                    });
                 }
             }
             else {
                 if (!params.DOMAnimation) {
                     setTimeout(function () {
-                               _this.fireCallback(params.onSlideChangeEnd, _this, direction);
-                               }, 10);
+                        _this.fireCallback(params.onSlideChangeEnd, _this, direction);
+                    }, 10);
                 }
             }
         }
     }
-    
+
     /*==================================================
-     Update Active Slide Index
-     ====================================================*/
+        Update Active Slide Index
+    ====================================================*/
     _this.updateActiveSlide = function (position) {
         if (!_this.initialized) return;
         if (_this.slides.length === 0) return;
@@ -1982,16 +1982,16 @@ var Swiper = function (selector, params) {
         else {
             _this.activeIndex = Math[params.visibilityFullFit ? 'ceil' : 'round'](-position / slideSize);
         }
-        
+
         if (_this.activeIndex === _this.slides.length) _this.activeIndex = _this.slides.length - 1;
         if (_this.activeIndex < 0) _this.activeIndex = 0;
-        
+
         // Check for slide
         if (!_this.slides[_this.activeIndex]) return;
-        
+
         // Calc Visible slides
         _this.calcVisibleSlides(position);
-        
+
         // Mark visible and active slides with additonal classes
         if (_this.support.classList) {
             var slide;
@@ -2008,7 +2008,7 @@ var Swiper = function (selector, params) {
         } else {
             var activeClassRegexp = new RegExp('\\s*' + params.slideActiveClass);
             var inViewClassRegexp = new RegExp('\\s*' + params.slideVisibleClass);
-            
+
             for (i = 0; i < _this.slides.length; i++) {
                 _this.slides[i].className = _this.slides[i].className.replace(activeClassRegexp, '').replace(inViewClassRegexp, '');
                 if (_this.visibleSlides.indexOf(_this.slides[i]) >= 0) {
@@ -2017,7 +2017,7 @@ var Swiper = function (selector, params) {
             }
             _this.slides[_this.activeIndex].className += ' ' + params.slideActiveClass;
         }
-        
+
         //Update loop index
         if (params.loop) {
             var ls = _this.loopedSlides;
@@ -2039,8 +2039,8 @@ var Swiper = function (selector, params) {
         }
     };
     /*==================================================
-     Pagination
-     ====================================================*/
+        Pagination
+    ====================================================*/
     _this.createPagination = function (firstInit) {
         if (params.paginationClickable && _this.paginationButtons) {
             removePaginationEvents();
@@ -2093,14 +2093,14 @@ var Swiper = function (selector, params) {
         if (_this.slides.length < 1) return;
         var activePagers = $$('.' + params.paginationActiveClass, _this.paginationContainer);
         if (!activePagers) return;
-        
+
         //Reset all Buttons' class to not active
         var pagers = _this.paginationButtons;
         if (pagers.length === 0) return;
         for (var i = 0; i < pagers.length; i++) {
             pagers[i].className = params.paginationElementClass;
         }
-        
+
         var indexOffset = params.loop ? _this.loopedSlides : 0;
         if (params.paginationAsRange) {
             if (!_this.visibleSlides) _this.calcVisibleSlides(position);
@@ -2109,7 +2109,7 @@ var Swiper = function (selector, params) {
             var j; // lopp index - avoid JSHint W004 / W038
             for (j = 0; j < _this.visibleSlides.length; j++) {
                 var visIndex = _this.slides.indexOf(_this.visibleSlides[j]) - indexOffset;
-                
+
                 if (params.loop && visIndex < 0) {
                     visIndex = _this.slides.length - _this.loopedSlides * 2 + visIndex;
                 }
@@ -2119,11 +2119,11 @@ var Swiper = function (selector, params) {
                 }
                 visibleIndexes.push(visIndex);
             }
-            
+
             for (j = 0; j < visibleIndexes.length; j++) {
                 if (pagers[visibleIndexes[j]]) pagers[visibleIndexes[j]].className += ' ' + params.paginationVisibleClass;
             }
-            
+
             if (params.loop) {
                 if (pagers[_this.activeLoopIndex] !== undefined) {
                     pagers[_this.activeLoopIndex].className += ' ' + params.paginationActiveClass;
@@ -2147,13 +2147,13 @@ var Swiper = function (selector, params) {
         var _slideLeft = 0, _slideSize = 0, _slideRight = 0;
         if (isH && _this.wrapperLeft > 0) position = position + _this.wrapperLeft;
         if (!isH && _this.wrapperTop > 0) position = position + _this.wrapperTop;
-        
+
         for (var i = 0; i < _this.slides.length; i++) {
             _slideLeft += _slideSize;
             if (params.slidesPerView === 'auto')
                 _slideSize  = isH ? _this.h.getWidth(_this.slides[i], true, params.roundLengths) : _this.h.getHeight(_this.slides[i], true, params.roundLengths);
             else _slideSize = slideSize;
-            
+
             _slideRight = _slideLeft + _slideSize;
             var isVisibile = false;
             if (params.visibilityFullFit) {
@@ -2165,18 +2165,18 @@ var Swiper = function (selector, params) {
                 if (_slideLeft >= -position && _slideLeft < ((-position + containerSize))) isVisibile = true;
                 if (_slideLeft < -position && _slideRight > ((-position + containerSize))) isVisibile = true;
             }
-            
+
             if (isVisibile) visibleSlides.push(_this.slides[i]);
-            
+
         }
         if (visibleSlides.length === 0) visibleSlides = [_this.slides[_this.activeIndex]];
-        
+
         _this.visibleSlides = visibleSlides;
     };
-    
+
     /*==========================================
-     Autoplay
-     ============================================*/
+        Autoplay
+    ============================================*/
     var autoplayTimeoutId, autoplayIntervalId;
     _this.startAutoplay = function () {
         if (_this.support.transitions) {
@@ -2192,18 +2192,18 @@ var Swiper = function (selector, params) {
             _this.callPlugins('onAutoplayStart');
             if (params.onAutoplayStart) _this.fireCallback(params.onAutoplayStart, _this);
             autoplayIntervalId = setInterval(function () {
-                                             if (params.loop) {
-                                             _this.fixLoop();
-                                             _this.swipeNext(true);
-                                             }
-                                             else if (!_this.swipeNext(true)) {
-                                             if (!params.autoplayStopOnLast) _this.swipeTo(0);
-                                             else {
-                                             clearInterval(autoplayIntervalId);
-                                             autoplayIntervalId = undefined;
-                                             }
-                                             }
-                                             }, params.autoplay);
+                if (params.loop) {
+                    _this.fixLoop();
+                    _this.swipeNext(true);
+                }
+                else if (!_this.swipeNext(true)) {
+                    if (!params.autoplayStopOnLast) _this.swipeTo(0);
+                    else {
+                        clearInterval(autoplayIntervalId);
+                        autoplayIntervalId = undefined;
+                    }
+                }
+            }, params.autoplay);
         }
     };
     _this.stopAutoplay = function (internal) {
@@ -2213,8 +2213,8 @@ var Swiper = function (selector, params) {
             autoplayTimeoutId = undefined;
             if (internal && !params.autoplayDisableOnInteraction) {
                 _this.wrapperTransitionEnd(function () {
-                                           autoplay();
-                                           });
+                    autoplay();
+                });
             }
             _this.callPlugins('onAutoplayStop');
             if (params.onAutoplayStop) _this.fireCallback(params.onAutoplayStop, _this);
@@ -2228,25 +2228,25 @@ var Swiper = function (selector, params) {
     };
     function autoplay() {
         autoplayTimeoutId = setTimeout(function () {
-                                       if (params.loop) {
-                                       _this.fixLoop();
-                                       _this.swipeNext(true);
-                                       }
-                                       else if (!_this.swipeNext(true)) {
-                                       if (!params.autoplayStopOnLast) _this.swipeTo(0);
-                                       else {
-                                       clearTimeout(autoplayTimeoutId);
-                                       autoplayTimeoutId = undefined;
-                                       }
-                                       }
-                                       _this.wrapperTransitionEnd(function () {
-                                                                  if (typeof autoplayTimeoutId !== 'undefined') autoplay();
-                                                                  });
-                                       }, params.autoplay);
+            if (params.loop) {
+                _this.fixLoop();
+                _this.swipeNext(true);
+            }
+            else if (!_this.swipeNext(true)) {
+                if (!params.autoplayStopOnLast) _this.swipeTo(0);
+                else {
+                    clearTimeout(autoplayTimeoutId);
+                    autoplayTimeoutId = undefined;
+                }
+            }
+            _this.wrapperTransitionEnd(function () {
+                if (typeof autoplayTimeoutId !== 'undefined') autoplay();
+            });
+        }, params.autoplay);
     }
     /*==================================================
-     Loop
-     ====================================================*/
+        Loop
+    ====================================================*/
     _this.loopCreated = false;
     _this.removeLoopedSlides = function () {
         if (_this.loopCreated) {
@@ -2255,7 +2255,7 @@ var Swiper = function (selector, params) {
             }
         }
     };
-    
+
     _this.createLoop = function () {
         if (_this.slides.length === 0) return;
         if (params.slidesPerView === 'auto') {
@@ -2264,21 +2264,21 @@ var Swiper = function (selector, params) {
         else {
             _this.loopedSlides = params.slidesPerView + params.loopAdditionalSlides;
         }
-        
+
         if (_this.loopedSlides > _this.slides.length) {
             _this.loopedSlides = _this.slides.length;
         }
-        
+
         var slideFirstHTML = '',
-        slideLastHTML = '',
-        i;
+            slideLastHTML = '',
+            i;
         var slidesSetFullHTML = '';
         /**
-         loopedSlides is too large if loopAdditionalSlides are set.
-         Need to divide the slides by maximum number of slides existing.
-         
-         @author        Tomaz Lovrec <tomaz.lovrec@blanc-noir.at>
-         */
+                loopedSlides is too large if loopAdditionalSlides are set.
+                Need to divide the slides by maximum number of slides existing.
+
+                @author        Tomaz Lovrec <tomaz.lovrec@blanc-noir.at>
+        */
         var numSlides = _this.slides.length;
         var fullSlideSets = Math.floor(_this.loopedSlides / numSlides);
         var remainderSlides = _this.loopedSlides % numSlides;
@@ -2304,18 +2304,18 @@ var Swiper = function (selector, params) {
         var slides = slideFirstHTML + slidesSetFullHTML + wrapper.innerHTML + slidesSetFullHTML + slideLastHTML;
         // set the slides
         wrapper.innerHTML = slides;
-        
+
         _this.loopCreated = true;
         _this.calcSlides();
-        
+
         //Update Looped Slides with special class
         for (i = 0; i < _this.slides.length; i++) {
             if (i < _this.loopedSlides || i >= _this.slides.length - _this.loopedSlides) _this.slides[i].setData('looped', true);
         }
         _this.callPlugins('onCreateLoop');
-        
+
     };
-    
+
     _this.fixLoop = function () {
         var newIndex;
         //Fix For Negative Oversliding
@@ -2329,10 +2329,10 @@ var Swiper = function (selector, params) {
             _this.swipeTo(newIndex, 0, false);
         }
     };
-    
+
     /*==================================================
-     Slides Loader
-     ====================================================*/
+        Slides Loader
+    ====================================================*/
     _this.loadSlides = function () {
         var slidesHTML = '';
         _this.activeLoaderIndex = 0;
@@ -2351,7 +2351,7 @@ var Swiper = function (selector, params) {
             _this.wrapperTransitionEnd(_this.reloadSlides, true);
         }
     };
-    
+
     _this.reloadSlides = function () {
         var slides = params.loader.slides;
         var newActiveIndex = parseInt(_this.activeSlide().data('swiperindex'), 10);
@@ -2378,7 +2378,7 @@ var Swiper = function (selector, params) {
         else {
             var minExistIndex = 1000;
             var maxExistIndex = 0;
-            
+
             for (i = 0; i < _this.slides.length; i++) {
                 var index = _this.slides[i].data('swiperindex');
                 if (index < firstIndex || index > lastIndex) {
@@ -2410,10 +2410,10 @@ var Swiper = function (selector, params) {
         //reInit
         _this.reInit(true);
     };
-    
+
     /*==================================================
-     Make Swiper
-     ====================================================*/
+        Make Swiper
+    ====================================================*/
     function makeSwiper() {
         _this.calcSlides();
         if (params.loader.slides.length > 0 && _this.slides.length === 0) {
@@ -2427,7 +2427,7 @@ var Swiper = function (selector, params) {
         if (params.pagination) {
             _this.createPagination(true);
         }
-        
+
         if (params.loop || params.initialSlide > 0) {
             _this.swipeTo(params.initialSlide, 0, false);
         }
@@ -2443,28 +2443,28 @@ var Swiper = function (selector, params) {
          * @author        Tomaz Lovrec <tomaz.lovrec@gmail.com>
          */
         _this.centerIndex = _this.activeIndex;
-        
+
         // Callbacks
         if (params.onSwiperCreated) _this.fireCallback(params.onSwiperCreated, _this);
         _this.callPlugins('onSwiperCreated');
     }
-    
+
     makeSwiper();
 };
 
 Swiper.prototype = {
     plugins : {},
-    
+
     /*==================================================
-     Wrapper Operations
-     ====================================================*/
+        Wrapper Operations
+    ====================================================*/
     wrapperTransitionEnd : function (callback, permanent) {
         'use strict';
         var a = this,
-        el = a.wrapper,
-        events = ['webkitTransitionEnd', 'transitionend', 'oTransitionEnd', 'MSTransitionEnd', 'msTransitionEnd'],
-        i;
-        
+            el = a.wrapper,
+            events = ['webkitTransitionEnd', 'transitionend', 'oTransitionEnd', 'MSTransitionEnd', 'msTransitionEnd'],
+            i;
+
         function fireCallBack() {
             callback(a);
             if (a.params.queueEndCallbacks) a._queueEndCallbacks = false;
@@ -2474,24 +2474,24 @@ Swiper.prototype = {
                 }
             }
         }
-        
+
         if (callback) {
             for (i = 0; i < events.length; i++) {
                 a.h.addEventListener(el, events[i], fireCallBack);
             }
         }
     },
-    
+
     getWrapperTranslate : function (axis) {
         'use strict';
         var el = this.wrapper,
-        matrix, curTransform, curStyle, transformMatrix;
-        
+            matrix, curTransform, curStyle, transformMatrix;
+
         // automatic axis detection
         if (typeof axis === 'undefined') {
             axis = this.params.mode === 'horizontal' ? 'x' : 'y';
         }
-        
+
         if (this.support.transforms && this.params.useCSS3Transforms) {
             curStyle = window.getComputedStyle(el, null);
             if (window.WebKitCSSMatrix) {
@@ -2503,7 +2503,7 @@ Swiper.prototype = {
                 transformMatrix = curStyle.MozTransform || curStyle.OTransform || curStyle.MsTransform || curStyle.msTransform  || curStyle.transform || curStyle.getPropertyValue('transform').replace('translate(', 'matrix(1, 0, 0, 1,');
                 matrix = transformMatrix.toString().split(',');
             }
-            
+
             if (axis === 'x') {
                 //Latest Chrome and webkits Fix
                 if (window.WebKitCSSMatrix)
@@ -2533,20 +2533,20 @@ Swiper.prototype = {
         }
         return curTransform || 0;
     },
-    
+
     setWrapperTranslate : function (x, y, z) {
         'use strict';
         var es = this.wrapper.style,
-        coords = {x: 0, y: 0, z: 0},
-        translate;
-        
+            coords = {x: 0, y: 0, z: 0},
+            translate;
+
         // passed all coordinates
         if (arguments.length === 3) {
             coords.x = x;
             coords.y = y;
             coords.z = z;
         }
-        
+
         // passed one coordinate and optional axis
         else {
             if (typeof y === 'undefined') {
@@ -2554,7 +2554,7 @@ Swiper.prototype = {
             }
             coords[y] = x;
         }
-        
+
         if (this.support.transforms && this.params.useCSS3Transforms) {
             translate = this.support.transforms3d ? 'translate3d(' + coords.x + 'px, ' + coords.y + 'px, ' + coords.z + 'px)' : 'translate(' + coords.x + 'px, ' + coords.y + 'px)';
             es.webkitTransform = es.MsTransform = es.msTransform = es.MozTransform = es.OTransform = es.transform = translate;
@@ -2566,64 +2566,64 @@ Swiper.prototype = {
         this.callPlugins('onSetWrapperTransform', coords);
         if (this.params.onSetWrapperTransform) this.fireCallback(this.params.onSetWrapperTransform, this, coords);
     },
-    
+
     setWrapperTransition : function (duration) {
         'use strict';
         var es = this.wrapper.style;
         es.webkitTransitionDuration = es.MsTransitionDuration = es.msTransitionDuration = es.MozTransitionDuration = es.OTransitionDuration = es.transitionDuration = (duration / 1000) + 's';
         this.callPlugins('onSetWrapperTransition', {duration: duration});
         if (this.params.onSetWrapperTransition) this.fireCallback(this.params.onSetWrapperTransition, this, duration);
-        
+
     },
-    
+
     /*==================================================
-     Helpers
-     ====================================================*/
+        Helpers
+    ====================================================*/
     h : {
-    getWidth: function (el, outer, round) {
-        'use strict';
-        var width = window.getComputedStyle(el, null).getPropertyValue('width');
-        var returnWidth = parseFloat(width);
-        //IE Fixes
-        if (isNaN(returnWidth) || width.indexOf('%') > 0 || returnWidth < 0) {
-            returnWidth = el.offsetWidth - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-left')) - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-right'));
-        }
-        if (outer) returnWidth += parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-left')) + parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-right'));
-        if (round) return Math.ceil(returnWidth);
-        else return returnWidth;
-    },
-    getHeight: function (el, outer, round) {
-        'use strict';
-        if (outer) return el.offsetHeight;
-        
-        var height = window.getComputedStyle(el, null).getPropertyValue('height');
-        var returnHeight = parseFloat(height);
-        //IE Fixes
-        if (isNaN(returnHeight) || height.indexOf('%') > 0 || returnHeight < 0) {
-            returnHeight = el.offsetHeight - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-top')) - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-bottom'));
-        }
-        if (outer) returnHeight += parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-top')) + parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-bottom'));
-        if (round) return Math.ceil(returnHeight);
-        else return returnHeight;
-    },
-    getOffset: function (el) {
-        'use strict';
-        var box = el.getBoundingClientRect();
-        var body = document.body;
-        var clientTop  = el.clientTop  || body.clientTop  || 0;
-        var clientLeft = el.clientLeft || body.clientLeft || 0;
-        var scrollTop  = window.pageYOffset || el.scrollTop;
-        var scrollLeft = window.pageXOffset || el.scrollLeft;
-        if (document.documentElement && !window.pageYOffset) {
-            //IE7-8
-            scrollTop  = document.documentElement.scrollTop;
-            scrollLeft = document.documentElement.scrollLeft;
-        }
-        return {
-        top: box.top  + scrollTop  - clientTop,
-        left: box.left + scrollLeft - clientLeft
-        };
-    },
+        getWidth: function (el, outer, round) {
+            'use strict';
+            var width = window.getComputedStyle(el, null).getPropertyValue('width');
+            var returnWidth = parseFloat(width);
+            //IE Fixes
+            if (isNaN(returnWidth) || width.indexOf('%') > 0 || returnWidth < 0) {
+                returnWidth = el.offsetWidth - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-left')) - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-right'));
+            }
+            if (outer) returnWidth += parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-left')) + parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-right'));
+            if (round) return Math.ceil(returnWidth);
+            else return returnWidth;
+        },
+        getHeight: function (el, outer, round) {
+            'use strict';
+            if (outer) return el.offsetHeight;
+
+            var height = window.getComputedStyle(el, null).getPropertyValue('height');
+            var returnHeight = parseFloat(height);
+            //IE Fixes
+            if (isNaN(returnHeight) || height.indexOf('%') > 0 || returnHeight < 0) {
+                returnHeight = el.offsetHeight - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-top')) - parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-bottom'));
+            }
+            if (outer) returnHeight += parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-top')) + parseFloat(window.getComputedStyle(el, null).getPropertyValue('padding-bottom'));
+            if (round) return Math.ceil(returnHeight);
+            else return returnHeight;
+        },
+        getOffset: function (el) {
+            'use strict';
+            var box = el.getBoundingClientRect();
+            var body = document.body;
+            var clientTop  = el.clientTop  || body.clientTop  || 0;
+            var clientLeft = el.clientLeft || body.clientLeft || 0;
+            var scrollTop  = window.pageYOffset || el.scrollTop;
+            var scrollLeft = window.pageXOffset || el.scrollLeft;
+            if (document.documentElement && !window.pageYOffset) {
+                //IE7-8
+                scrollTop  = document.documentElement.scrollTop;
+                scrollLeft = document.documentElement.scrollLeft;
+            }
+            return {
+                top: box.top  + scrollTop  - clientTop,
+                left: box.left + scrollLeft - clientLeft
+            };
+        },
         windowWidth : function () {
             'use strict';
             if (window.innerWidth) return window.innerWidth;
@@ -2638,24 +2638,24 @@ Swiper.prototype = {
             'use strict';
             if (typeof pageYOffset !== 'undefined') {
                 return {
-                left: window.pageXOffset,
-                top: window.pageYOffset
+                    left: window.pageXOffset,
+                    top: window.pageYOffset
                 };
             }
             else if (document.documentElement) {
                 return {
-                left: document.documentElement.scrollLeft,
-                top: document.documentElement.scrollTop
+                    left: document.documentElement.scrollLeft,
+                    top: document.documentElement.scrollTop
                 };
             }
         },
-        
+
         addEventListener : function (el, event, listener, useCapture) {
             'use strict';
             if (typeof useCapture === 'undefined') {
                 useCapture = false;
             }
-            
+
             if (el.addEventListener) {
                 el.addEventListener(event, listener, useCapture);
             }
@@ -2663,13 +2663,13 @@ Swiper.prototype = {
                 el.attachEvent('on' + event, listener);
             }
         },
-        
+
         removeEventListener : function (el, event, listener, useCapture) {
             'use strict';
             if (typeof useCapture === 'undefined') {
                 useCapture = false;
             }
-            
+
             if (el.removeEventListener) {
                 el.removeEventListener(event, listener, useCapture);
             }
@@ -2704,71 +2704,71 @@ Swiper.prototype = {
         es.webkitTransitionDuration = es.MsTransitionDuration = es.msTransitionDuration = es.MozTransitionDuration = es.OTransitionDuration = es.transitionDuration = duration + 'ms';
     },
     /*==================================================
-     Feature Detection
-     ====================================================*/
-support: {
-    
-    touch : (window.Modernizr && Modernizr.touch === true) || (function () {
-                                                               'use strict';
-                                                               return !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch);
-                                                               })(),
-    
-    transforms3d : (window.Modernizr && Modernizr.csstransforms3d === true) || (function () {
-                                                                                'use strict';
-                                                                                var div = document.createElement('div').style;
-                                                                                return ('webkitPerspective' in div || 'MozPerspective' in div || 'OPerspective' in div || 'MsPerspective' in div || 'perspective' in div);
-                                                                                })(),
-    
-    transforms : (window.Modernizr && Modernizr.csstransforms === true) || (function () {
-                                                                            'use strict';
-                                                                            var div = document.createElement('div').style;
-                                                                            return ('transform' in div || 'WebkitTransform' in div || 'MozTransform' in div || 'msTransform' in div || 'MsTransform' in div || 'OTransform' in div);
-                                                                            })(),
-    
-    transitions : (window.Modernizr && Modernizr.csstransitions === true) || (function () {
-                                                                              'use strict';
-                                                                              var div = document.createElement('div').style;
-                                                                              return ('transition' in div || 'WebkitTransition' in div || 'MozTransition' in div || 'msTransition' in div || 'MsTransition' in div || 'OTransition' in div);
-                                                                              })(),
-    
-    classList : (function () {
-                 'use strict';
-                 var div = document.createElement('div').style;
-                 return 'classList' in div;
-                 })()
-},
-    
+        Feature Detection
+    ====================================================*/
+    support: {
+
+        touch : (window.Modernizr && Modernizr.touch === true) || (function () {
+            'use strict';
+            return !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch);
+        })(),
+
+        transforms3d : (window.Modernizr && Modernizr.csstransforms3d === true) || (function () {
+            'use strict';
+            var div = document.createElement('div').style;
+            return ('webkitPerspective' in div || 'MozPerspective' in div || 'OPerspective' in div || 'MsPerspective' in div || 'perspective' in div);
+        })(),
+
+        transforms : (window.Modernizr && Modernizr.csstransforms === true) || (function () {
+            'use strict';
+            var div = document.createElement('div').style;
+            return ('transform' in div || 'WebkitTransform' in div || 'MozTransform' in div || 'msTransform' in div || 'MsTransform' in div || 'OTransform' in div);
+        })(),
+
+        transitions : (window.Modernizr && Modernizr.csstransitions === true) || (function () {
+            'use strict';
+            var div = document.createElement('div').style;
+            return ('transition' in div || 'WebkitTransition' in div || 'MozTransition' in div || 'msTransition' in div || 'MsTransition' in div || 'OTransition' in div);
+        })(),
+
+        classList : (function () {
+            'use strict';
+            var div = document.createElement('div').style;
+            return 'classList' in div;
+        })()
+    },
+
     browser : {
-        
+
         ie8 : (function () {
-               'use strict';
-               var rv = -1; // Return value assumes failure.
-               if (navigator.appName === 'Microsoft Internet Explorer') {
-               var ua = navigator.userAgent;
-               var re = new RegExp(/MSIE ([0-9]{1,}[\.0-9]{0,})/);
-               if (re.exec(ua) !== null)
-               rv = parseFloat(RegExp.$1);
-               }
-               return rv !== -1 && rv < 9;
-               })(),
-        
+            'use strict';
+            var rv = -1; // Return value assumes failure.
+            if (navigator.appName === 'Microsoft Internet Explorer') {
+                var ua = navigator.userAgent;
+                var re = new RegExp(/MSIE ([0-9]{1,}[\.0-9]{0,})/);
+                if (re.exec(ua) !== null)
+                    rv = parseFloat(RegExp.$1);
+            }
+            return rv !== -1 && rv < 9;
+        })(),
+
         ie10 : window.navigator.msPointerEnabled,
         ie11 : window.navigator.pointerEnabled
     }
 };
 
 /*=========================
- jQuery & Zepto Plugins
- ===========================*/
+  jQuery & Zepto Plugins
+  ===========================*/
 if (window.jQuery || window.Zepto) {
     (function ($) {
-     'use strict';
-     $.fn.swiper = function (params) {
-     var s = new Swiper($(this)[0], params);
-     $(this).data('swiper', s);
-     return s;
-     };
-     })(window.jQuery || window.Zepto);
+        'use strict';
+        $.fn.swiper = function (params) {
+            var s = new Swiper($(this)[0], params);
+            $(this).data('swiper', s);
+            return s;
+        };
+    })(window.jQuery || window.Zepto);
 }
 
 // component
@@ -2780,7 +2780,7 @@ if (typeof(module) !== 'undefined')
 // requirejs support
 if (typeof define === 'function' && define.amd) {
     define([], function () {
-           'use strict';
-           return Swiper;
-           });
+        'use strict';
+        return Swiper;
+    });
 }


### PR DESCRIPTION
I have found situations when I need the script to calculate the width of the slides and their container, but not the height to allow more flexibility. So I expanded the cssWidthAndHeight option to support now both or none of those elements, and either one of them by indicating which one should use CSS.
