### PR TITLE
Allow instantiation on every jQuery object and methods chaining

### DIFF
--- a/demos/19-chaining.html
+++ b/demos/19-chaining.html
@@ -113,12 +113,12 @@ body {
   <script src="js/jquery-1.10.1.min.js"></script>
   <script src="../src/idangerous.swiper.js"></script>
   <script>
-  $('.swiper-container').swiper({
+  var mySwiper = $('.swiper-container').swiper({
     pagination: '.pagination',
     loop:true,
     grabCursor: true,
     paginationClickable: true
-  }).addClass('test-chaining');
+  });
   $('.arrow-left').on('click', function(e){
     e.preventDefault()
     var swiper = $(this).siblings('.swiper-container').data('swiper');

--- a/src/idangerous.swiper.js
+++ b/src/idangerous.swiper.js
@@ -2809,13 +2809,16 @@ if (window.jQuery || window.Zepto) {
     (function ($) {
         'use strict';
         $.fn.swiper = function (params) {
-            return this.each(function() {
+            var firstInstance;
+            this.each(function(i) {
                 var that = $(this);
                 if (!that.data('swiper')) {
                     var s = new Swiper(that[0], params);
+                    if (!i) firstInstance = s;
                     that.data('swiper', s);
                 }
             });
+            return firstInstance;
         };
     })(window.jQuery || window.Zepto);
 }


### PR DESCRIPTION
Allow instantiation of swiper on every jQuery / Zepto object (it was only the first element of the collection) and allow to chain methods because it returns the object (the return was the instance).
Instance can be used with method .data('swiper') on the jQuery / Zepto object.
Example can be seen on 19-chaining.html
