### PR TITLE
Fix Loop-Mode with fractional slidesPerView-setting

### DIFF
--- a/src/idangerous.swiper.js
+++ b/src/idangerous.swiper.js
@@ -2351,7 +2351,7 @@ var Swiper = function (selector, params) {
             _this.loopedSlides = params.loopedSlides || 1;
         }
         else {
-            _this.loopedSlides = params.slidesPerView + params.loopAdditionalSlides;
+            _this.loopedSlides = Math.floor(params.slidesPerView) + params.loopAdditionalSlides;
         }
 
         if (_this.loopedSlides > _this.slides.length) {


### PR DESCRIPTION
If you define slidePerView 1.22 together with loop mode the library throws an undefined object exception.
This should fix the loop mode.