### PR TITLE
Add RTL language support

### DIFF
--- a/src/idangerous.swiper.css
+++ b/src/idangerous.swiper.css
@@ -20,6 +20,7 @@ Basic Swiper Styles
 	margin:0 auto;
 	position:relative;
 	overflow:hidden;
+	direction:ltr;
 	-webkit-backface-visibility:hidden;
 	-moz-backface-visibility:hidden;
 	-ms-backface-visibility:hidden;


### PR DESCRIPTION
If your document direction is RTL,
You most add "direction: ltr" to 'swiper-container' for fix working Swiper.