### PR TITLE
Restrict list of exported files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.7.5",
   "description": "Mobile touch slider and framework with hardware accelerated transitions",
   "main": "dist/idangerous.swiper.js",
+  "files": ["dist", "src", "*.json"],
   "repository": {
     "type": "git",
     "url": "https://github.com/nolimits4web/Swiper.git"


### PR DESCRIPTION
There's really no need to store all the project files as a package resources.