### PR TITLE
Fixing paths to dist files in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,14 +12,14 @@
   "dependencies": {
   },
   "scripts": [
-    "dist/swiper.js"
+    "dist/js/swiper.js"
   ],
   "main": [
-    "dist/swiper.js",
-    "dist/swiper.css"
+    "dist/js/swiper.js",
+    "dist/css/swiper.css"
   ],
   "styles": [
-    "dist/swiper.css"
+    "dist/css/swiper.css"
   ],
   "license": ["MIT"],
   "dependencies": {},


### PR DESCRIPTION
The current paths don't compile correctly because they point to the wrong place.