### PR TITLE
Make onSlideChangeEnd work on Window Phone 8x

### DIFF
--- a/src/idangerous.swiper.js
+++ b/src/idangerous.swiper.js
@@ -1963,8 +1963,8 @@ var Swiper = function (selector, params) {
         }
 
         if (_this.support.transitions || !params.DOMAnimation) {
-            _this.setWrapperTranslate(newPosition);
             _this.setWrapperTransition(speed);
+            _this.setWrapperTranslate(newPosition);
         }
         else {
             //Try the DOM animation


### PR DESCRIPTION
Device: Nokia Luma 920
OS: Windows Phone 8.1 Update
Problem: onSlideChangeEnd callback is not executed

Reproduction:
1. You touch a slide and swipe (let's say left)
2. You let the slide go
3. An animation should happen now, but it doesn't, the slide just snaps into it's new position

Description of Solution:
Since there is no animation happening after letting a slide go, the onSlideChangeEnd event is also not fired.
So why there is no animation? Answer: Currently the library starts the animation before setting the duration of the animation. WP8 doesn't like this and skips the animation. By setting the duration of the animation BEFORE starting the animation, everything works as expected.