### PR TITLE
Keyboard accessibility

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 (function(){
-    'use strict';    
+    'use strict';
     var gulp = require('gulp'),
         gutil = require('gulp-util'),
         connect = require('gulp-connect'),
@@ -42,6 +42,7 @@
             jsFiles: [
                 'src/js/wrap-start.js',
                 'src/js/swiper-intro.js',
+                'src/js/a11y.js',
                 'src/js/core.js',
                 'src/js/effects.js',
                 'src/js/lazy-load.js',
@@ -64,6 +65,7 @@
             jQueryFiles : [
                 'src/js/wrap-start.js',
                 'src/js/swiper-intro.js',
+                'src/js/a11y.js',
                 'src/js/core.js',
                 'src/js/effects.js',
                 'src/js/lazy-load.js',
@@ -84,6 +86,7 @@
             ],
             Framework7Files : [
                 'src/js/swiper-intro.js',
+                'src/js/a11y.js',
                 'src/js/core.js',
                 'src/js/effects.js',
                 'src/js/lazy-load.js',
@@ -119,7 +122,7 @@
                 day: new Date().getDate()
             }
         };
-        
+
     function addJSIndent (file, t, minusIndent) {
         var addIndent = '        ';
         var filename = file.path.split('src/js/')[1];
@@ -144,7 +147,7 @@
             .pipe(tap(function (file, t){
                 addJSIndent (file, t);
             }))
-            .pipe(concat(swiper.filename + '.js'))            
+            .pipe(concat(swiper.filename + '.js'))
             .pipe(header(swiper.banner, { pkg : swiper.pkg, date: swiper.date } ))
             .pipe(gulp.dest(paths.build.scripts))
 
@@ -241,7 +244,7 @@
             port:'3000'
         });
     });
-    
+
     gulp.task('open', function () {
         return gulp.src(paths.playground.root + 'index.html').pipe(open('', { url: 'http://localhost:3000/' + paths.playground.root + 'index.html'}));
     });

--- a/src/js/a11y.js
+++ b/src/js/a11y.js
@@ -1,0 +1,16 @@
+// Accessibility tools
+var a11y = {
+
+    makeFocusable: function (el) {
+        el[0].tabIndex = '0';
+        return el;
+    },
+
+    onEnterKey: function (fn, event) {
+        if (event.keyCode === 13) fn(event);
+    },
+
+    init: function() {
+
+    }
+};

--- a/src/js/a11y.js
+++ b/src/js/a11y.js
@@ -1,16 +1,40 @@
 // Accessibility tools
 var a11y = {
 
-    makeFocusable: function (el) {
-        el[0].tabIndex = '0';
-        return el;
+    makeFocusable: function ($el) {
+        $el[0].tabIndex = '0';
+        return $el;
+    },
+
+    addRole: function ($el, role) {
+        $el.attr('role', role);
+        return $el;
+    },
+
+    addLabel: function ($el, label) {
+        $el.attr('aria-label', label);
+        return $el;
+    },
+
+    disable: function ($el) {
+        $el.attr('aria-disabled', true);
+        return $el;
+    },
+
+    enable: function ($el) {
+        $el.attr('aria-disabled', false);
+        return $el;
     },
 
     onEnterKey: function (fn, event) {
         if (event.keyCode === 13) fn(event);
     },
 
-    init: function() {
+    liveRegion: '<span class="swiper-notification" aria-live="assertive" aria-atomic="true"></span>',
 
+    notify: function (message) {
+        var notification = $('.swiper-notification');
+        notification.html('');
+        notification.html(message);
     }
 };

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -149,7 +149,11 @@ var defaults = {
     onLazyImageReady: function (swiper, slide, image)
     */
     // Accessibility
-    a11y: true
+    a11y: true,
+    prevSlideMsg: 'Previous slide.',
+    nextSlideMsg: 'Next slide.',
+    firstSlideMsg: 'This is the first slide.',
+    lastSlideMsg: 'This is the last slide.'
 };
 params = params || {};
 for (var def in defaults) {
@@ -292,8 +296,20 @@ if (s.device.android) {
 
 // Setup accessibility
 if (s.params.a11y) {
-    if (s.params.nextButton) a11y.makeFocusable($(s.params.nextButton));
-    if (s.params.prevButton) a11y.makeFocusable($(s.params.prevButton));
+    if (s.params.nextButton) {
+        var nextButton = $(s.params.nextButton);
+        a11y.makeFocusable(nextButton);
+        a11y.addRole(nextButton, 'button');
+        a11y.addLabel(nextButton, s.nextSlideMsg);
+    }
+    if (s.params.prevButton) {
+        var prevButton = $(s.params.prevButton);
+        a11y.makeFocusable(prevButton);
+        a11y.addRole(prevButton, 'button');
+        a11y.addLabel(prevButton, s.prevSlideMsg);
+    }
+
+    $(container).append($(a11y.liveRegion));
 }
 
 // Add classes
@@ -751,12 +767,24 @@ s.updateClasses = function () {
     // Next/active buttons
     if (!s.params.loop) {
         if (s.params.prevButton) {
-            if (s.isBeginning) $(s.params.prevButton).addClass(s.params.buttonDisabledClass);
-            else $(s.params.prevButton).removeClass(s.params.buttonDisabledClass);
+            if (s.isBeginning) {
+                $(s.params.prevButton).addClass(s.params.buttonDisabledClass);
+                if (s.params.a11y) a11y.disable($(s.params.prevButton));
+            }
+            else {
+                $(s.params.prevButton).removeClass(s.params.buttonDisabledClass);
+                if (s.params.a11y) a11y.enable($(s.params.prevButton));
+            }
         }
         if (s.params.nextButton) {
-            if (s.isEnd) $(s.params.nextButton).addClass(s.params.buttonDisabledClass);
-            else $(s.params.nextButton).removeClass(s.params.buttonDisabledClass);
+            if (s.isEnd) {
+                $(s.params.nextButton).addClass(s.params.buttonDisabledClass);
+                if (s.params.a11y) a11y.disable($(s.params.nextButton));
+            }
+            else {
+                $(s.params.nextButton).removeClass(s.params.buttonDisabledClass);
+                if (s.params.a11y) a11y.enable($(s.params.nextButton));
+            }
         }
     }
 };
@@ -900,11 +928,29 @@ s.initEvents = function (detach) {
     // Next, Prev, Index
     if (s.params.nextButton) {
         $(s.params.nextButton)[actionDom]('click', s.onClickNext);
-        if (s.params.a11y) $(s.params.nextButton)[actionDom]('keydown', a11y.onEnterKey.bind(null, s.onClickNext));
+        if (s.params.a11y) $(s.params.nextButton)[actionDom]('keydown', a11y.onEnterKey.bind(null, function (event) {
+            s.onClickNext(event);
+
+            if (s.isEnd) {
+                a11y.notify(s.params.lastSlideMsg);
+            }
+            else {
+                a11y.notify(s.params.nextSlideMsg);
+            }
+        }));
     }
     if (s.params.prevButton) {
         $(s.params.prevButton)[actionDom]('click', s.onClickPrev);
-        if (s.params.a11y) $(s.params.prevButton)[actionDom]('keydown', a11y.onEnterKey.bind(null, s.onClickPrev));
+        if (s.params.a11y) $(s.params.prevButton)[actionDom]('keydown', a11y.onEnterKey.bind(null, function (event) {
+            s.onClickPrev(event);
+
+            if (s.isBeginning) {
+                a11y.notify(s.params.firstSlideMsg);
+            }
+            else {
+                a11y.notify(s.params.prevSlideMsg);
+            }
+        }));
     }
     if (s.params.pagination && s.params.paginationClickable) {
         $(s.paginationContainer)[actionDom]('click', '.' + s.params.bulletClass, s.onClickIndex);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -125,29 +125,31 @@ var defaults = {
     Callbacks:
     onInit: function (swiper)
     onDestroy: function (swiper)
-    onClick: function (swiper, e) 
-    onTap: function (swiper, e) 
-    onDoubleTap: function (swiper, e) 
-    onSliderMove: function (swiper, e) 
-    onSlideChangeStart: function (swiper) 
-    onSlideChangeEnd: function (swiper) 
-    onTransitionStart: function (swiper) 
-    onTransitionEnd: function (swiper) 
-    onImagesReady: function (swiper) 
-    onProgress: function (swiper, progress) 
-    onTouchStart: function (swiper, e) 
-    onTouchMove: function (swiper, e) 
-    onTouchMoveOpposite: function (swiper, e) 
-    onTouchEnd: function (swiper, e) 
-    onReachBeginning: function (swiper) 
-    onReachEnd: function (swiper) 
-    onSetTransition: function (swiper, duration) 
-    onSetTranslate: function (swiper, translate) 
+    onClick: function (swiper, e)
+    onTap: function (swiper, e)
+    onDoubleTap: function (swiper, e)
+    onSliderMove: function (swiper, e)
+    onSlideChangeStart: function (swiper)
+    onSlideChangeEnd: function (swiper)
+    onTransitionStart: function (swiper)
+    onTransitionEnd: function (swiper)
+    onImagesReady: function (swiper)
+    onProgress: function (swiper, progress)
+    onTouchStart: function (swiper, e)
+    onTouchMove: function (swiper, e)
+    onTouchMoveOpposite: function (swiper, e)
+    onTouchEnd: function (swiper, e)
+    onReachBeginning: function (swiper)
+    onReachEnd: function (swiper)
+    onSetTransition: function (swiper, duration)
+    onSetTranslate: function (swiper, translate)
     onAutoplayStart: function (swiper)
     onAutoplayStop: function (swiper),
     onLazyImageLoad: function (swiper, slide, image)
     onLazyImageReady: function (swiper, slide, image)
     */
+    // Accessibility
+    a11y: true
 };
 params = params || {};
 for (var def in defaults) {
@@ -286,6 +288,12 @@ if (s.params.slidesPerColumn > 1) {
 // Check for Android
 if (s.device.android) {
     s.classNames.push('swiper-container-android');
+}
+
+// Setup accessibility
+if (s.params.a11y) {
+    if (s.params.nextButton) a11y.makeFocusable($(s.params.nextButton));
+    if (s.params.prevButton) a11y.makeFocusable($(s.params.prevButton));
 }
 
 // Add classes
@@ -890,8 +898,14 @@ s.initEvents = function (detach) {
     window[action]('resize', s.onResize);
 
     // Next, Prev, Index
-    if (s.params.nextButton) $(s.params.nextButton)[actionDom]('click', s.onClickNext);
-    if (s.params.prevButton) $(s.params.prevButton)[actionDom]('click', s.onClickPrev);
+    if (s.params.nextButton) {
+        $(s.params.nextButton)[actionDom]('click', s.onClickNext);
+        if (s.params.a11y) $(s.params.nextButton)[actionDom]('keydown', a11y.onEnterKey.bind(null, s.onClickNext));
+    }
+    if (s.params.prevButton) {
+        $(s.params.prevButton)[actionDom]('click', s.onClickPrev);
+        if (s.params.a11y) $(s.params.prevButton)[actionDom]('keydown', a11y.onEnterKey.bind(null, s.onClickPrev));
+    }
     if (s.params.pagination && s.params.paginationClickable) {
         $(s.paginationContainer)[actionDom]('click', '.' + s.params.bulletClass, s.onClickIndex);
     }


### PR DESCRIPTION
This PR closes #1130 

- Focusable navigation arrows (not bullets, I thinks arrows are enough)
- Visual feedback when focused on navigation arrows. Currently uses default platform outline, but can be changed to specific arrow color/opacity level.
- Navigation arrows are interactive via keyboard (Enter key).

Also there's a basic ARIA applied for screen readers:
- Notify about prev/next slide
- Notify about first/last slide