### PR TITLE
Fix path to js file in custom plugin demo

### DIFF
--- a/demos/31-custom-plugin.html
+++ b/demos/31-custom-plugin.html
@@ -70,7 +70,7 @@
     </div>
 
     <!-- Swiper JS -->
-    <script src="../build/js/swiper.js"></script>
+    <script src="../dist/js/swiper.min.js"></script>
 
     <!-- Include plugin after Swiper -->
     <script>


### PR DESCRIPTION
The custom plugin uses a path to the build directory which is not available in the normal download.