### PR TITLE
Added allowSlideToPrev and allowSlideToNext

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1485,6 +1485,14 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
 
     var translate = - s.snapGrid[s.snapIndex];
 
+    // Directions locks
+    if (!s.params.allowSlideToNext && translate < s.translate) {
+        return false;
+    }
+    if (!s.params.allowSlideToPrev && translate > s.translate) {
+        return false;
+    }
+
     // Stop autoplay
 
     if (s.params.autoplay && s.autoplaying) {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -101,8 +101,6 @@ var defaults = {
     // Swiping/no swiping
     allowSwipeToPrev: true,
     allowSwipeToNext: true,
-    allowSlideToPrev: true,
-    allowSlideToNext: true,
     swipeHandler: null, //'.swipe-handler',
     noSwiping: true,
     noSwipingClass: 'swiper-no-swiping',
@@ -331,25 +329,6 @@ s.unlockSwipeToPrev = function () {
 };
 s.unlockSwipes = function () {
     s.params.allowSwipeToNext = s.params.allowSwipeToPrev = true;
-};
-
-s.lockSlideToNext = function () {
-    s.params.allowSlideToNext = false;
-};
-s.lockSlideToPrev = function () {
-    s.params.allowSlideToPrev = false;
-};
-s.lockSlideTo = function () {
-    s.params.allowSlideToNext = s.params.allowSlideToPrev = false;
-};
-s.unlockSlideToNext = function () {
-    s.params.allowSlideToNext = true;
-};
-s.unlockSlideToPrev = function () {
-    s.params.allowSlideToPrev = true;
-};
-s.unlockSlideTo = function () {
-    s.params.allowSlideToNext = s.params.allowSlideToPrev = true;
 };
 
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1486,10 +1486,10 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
     var translate = - s.snapGrid[s.snapIndex];
 
     // Directions locks
-    if (!s.params.allowSlideToNext && translate < s.translate) {
+    if (!s.params.allowSwipeToNext && translate < s.translate) {
         return false;
     }
-    if (!s.params.allowSlideToPrev && translate > s.translate) {
+    if (!s.params.allowSwipeToPrev && translate > s.translate) {
         return false;
     }
 


### PR DESCRIPTION
Hi!
 
I noticed that allowSwipeToPrev -and Next only is used in onTouchMove.

My application is an e-reader for newspapers, and I have placed a empty page first so that page nr.1 is placed to the right. But I want to disable swipeToPrev in portrait-mode. because otherwise my users would be able to swipe to a empty page. And allowSwipePrev works great for this. But they can still navigate their with the keyboard arrow keys!

So my idea is so add allowSlideToPrev -and Next properties, and then check for these in the slideTo-function, and this works really good for me.

What do you think?