### PR TITLE
Fixing null exception when destroying Swiper before transition callbacks...

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -433,6 +433,7 @@ s.pauseAutoplay = function (speed) {
     }
     else {
         s.wrapper.transitionEnd(function () {
+            if (!s) return;
             s.autoplayPaused = false;
             if (!s.autoplaying) {
                 s.stopAutoplay();
@@ -1385,12 +1386,13 @@ s.onTouchEnd = function (e) {
                 s.onTransitionStart();
                 s.animating = true;
                 s.wrapper.transitionEnd(function () {
-                    if (!allowMomentumBounce) return;
+                    if (!s || !allowMomentumBounce) return;
                     s.emit('onMomentumBounce', s);
 
                     s.setWrapperTransition(s.params.speed);
                     s.setWrapperTranslate(afterBouncePosition);
                     s.wrapper.transitionEnd(function () {
+                        if (!s) return;
                         s.onTransitionEnd();
                     });
                 });
@@ -1402,6 +1404,7 @@ s.onTouchEnd = function (e) {
                 if (!s.animating) {
                     s.animating = true;
                     s.wrapper.transitionEnd(function () {
+                        if (!s) return;
                         s.onTransitionEnd();
                     });
                 }
@@ -1534,6 +1537,7 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
         if (!s.animating) {
             s.animating = true;
             s.wrapper.transitionEnd(function () {
+                if (!s) return;
                 s.onTransitionEnd(runCallbacks);
             });
         }

--- a/src/js/effects.js
+++ b/src/js/effects.js
@@ -37,6 +37,7 @@ s.effects = {
                     fadeIndex = s.slides.length - 1;
                 }
                 s.slides.eq(fadeIndex).transitionEnd(function () {
+                    if (!s) return;
                     var triggerEvents = ['webkitTransitionEnd', 'transitionend', 'oTransitionEnd', 'MSTransitionEnd', 'msTransitionEnd'];
                     for (var i = 0; i < triggerEvents.length; i++) {
                         s.wrapper.trigger(triggerEvents[i]);


### PR DESCRIPTION
Here is an example:
https://jsfiddle.net/mwvv9qag/6/

When 'Start' button is pressed, slideNext() method is triggered and then swiper is immediately destroyed.

A 'Transition End' event handler is registered and when it is resolved swiper is already destroyed. Any callback which references the swiper and (the 's' variable) and its methods will cause an error.
