### PR TITLE
Return false from handleKeyboard if keycode is equal to not allowed direction

### DIFF
--- a/src/js/keyboard.js
+++ b/src/js/keyboard.js
@@ -4,6 +4,13 @@
 function handleKeyboard(e) {
     if (e.originalEvent) e = e.originalEvent; //jquery fix
     var kc = e.keyCode || e.charCode;
+    // Directions locks
+    if (!s.params.allowSwipeToNext && (isH() && kc === 39 || !isH() && kc === 40)) {
+        return false;
+    }
+    if (!s.params.allowSwipeToPrev && (isH() && kc === 37 || !isH() && kc === 38)) {
+        return false;
+    }
     if (e.shiftKey || e.altKey || e.ctrlKey || e.metaKey) {
         return;
     }


### PR DESCRIPTION
I'm swiping between pretty heavy canvas data, and thought about optimizing navigation with keyboard. So I lock swipes in "onTransitionStart " and then on "onTransitionEnd" I unlock swipes again. This way I  (and with my updated code in handleKeyboard) I can disable stacking of slideTo-calls.

Next slideTo if holding down arrow key will be called when current transition is done.