### PR TITLE
enableKeyboardControl() called more than once

### DIFF
--- a/src/js/keyboard.js
+++ b/src/js/keyboard.js
@@ -70,6 +70,6 @@ s.disableKeyboardControl = function () {
     $(document).off('keydown', handleKeyboard);
 };
 s.enableKeyboardControl = function () {
-	s.disableKeyboardControl();
-	$(document).on('keydown', handleKeyboard);
+    s.disableKeyboardControl();
+    $(document).on('keydown', handleKeyboard);
 };

--- a/src/js/keyboard.js
+++ b/src/js/keyboard.js
@@ -70,5 +70,6 @@ s.disableKeyboardControl = function () {
     $(document).off('keydown', handleKeyboard);
 };
 s.enableKeyboardControl = function () {
-    $(document).on('keydown', handleKeyboard);
+	s.disableKeyboardControl();
+	$(document).on('keydown', handleKeyboard);
 };


### PR DESCRIPTION
I ran into this issue:

Due to conflicts with Twitter Bootstrap's modal, I had to re-initialize keyboard navigation by calling enableKeyboardControl() again.

By pressing left arrow I would then jump to the next next slide! And so on... if you call enableKeyboardControl() again, you would browse slide 3 by 3...

Do you need a jsfiddle to reproduce this behavior?