### PR TITLE
fixed issue with running mocha tests that include this library

### DIFF
--- a/src/js/amd.js
+++ b/src/js/amd.js
@@ -3,11 +3,11 @@ Swiper AMD Export
 ===========================*/
 if (typeof(module) !== 'undefined')
 {
-    module.exports = Swiper;
+    module.exports = window.Swiper;
 }
 else if (typeof define === 'function' && define.amd) {
     define([], function () {
         'use strict';
-        return Swiper;
+        return window.Swiper;
     });
 }

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -354,7 +354,7 @@ s.loadImage = function (imgElement, src, checkForComplete, callback) {
     }
     if (!imgElement.complete || !checkForComplete) {
         if (src) {
-            image = new Image();
+            image = new window.Image();
             image.onload = onReady;
             image.onerror = onReady;
             image.src = src;
@@ -1241,7 +1241,7 @@ s.onTouchMove = function (e) {
         }
         velocities.push({
             position: s.touches[isH() ? 'currentX' : 'currentY'],
-            time: (new Date()).getTime()
+            time: (new window.Date()).getTime()
         });
     }
     // Update progress
@@ -1327,7 +1327,7 @@ s.onTouchEnd = function (e) {
                 }
                 // this implies that the user stopped moving a finger then released.
                 // There would be no events with distance zero, so the last event is stale.
-                if (time > 150 || (new Date().getTime() - lastMoveEvent.time) > 300) {
+                if (time > 150 || (new window.Date().getTime() - lastMoveEvent.time) > 300) {
                     s.velocity = 0;
                 }
             } else {
@@ -1544,7 +1544,7 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
         }
 
     }
-    
+
     return true;
 };
 
@@ -1668,7 +1668,7 @@ s.getTranslate = function (el, axis) {
     if (window.WebKitCSSMatrix) {
         // Some old versions of Webkit choke when 'none' is passed; pass
         // empty string instead in this case
-        transformMatrix = new WebKitCSSMatrix(curStyle.webkitTransform === 'none' ? '' : curStyle.webkitTransform);
+        transformMatrix = new window.WebKitCSSMatrix(curStyle.webkitTransform === 'none' ? '' : curStyle.webkitTransform);
     }
     else {
         transformMatrix = curStyle.MozTransform || curStyle.OTransform || curStyle.MsTransform || curStyle.msTransform  || curStyle.transform || curStyle.getPropertyValue('transform').replace('translate(', 'matrix(1, 0, 0, 1,');

--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -248,7 +248,7 @@ var Dom7 = (function () {
             for (var i = 0; i < this.length; i++) {
                 var evt;
                 try {
-                    evt = new CustomEvent(eventName, {detail: eventData, bubbles: true, cancelable: true});
+                    evt = new window.CustomEvent(eventName, {detail: eventData, bubbles: true, cancelable: true});
                 }
                 catch (e) {
                     evt = document.createEvent('Event');
@@ -363,7 +363,7 @@ var Dom7 = (function () {
             }
             return this;
         },
-        
+
         //Dom manipulation
         each: function (callback) {
             for (var i = 0; i < this.length; i++) {
@@ -414,7 +414,7 @@ var Dom7 = (function () {
                 }
                 return false;
             }
-            
+
         },
         index: function () {
             if (this[0]) {

--- a/src/js/mousewheel.js
+++ b/src/js/mousewheel.js
@@ -2,14 +2,14 @@
   Mousewheel Control
   ===========================*/
 s._wheelEvent = false;
-s._lastWheelScrollTime = (new Date()).getTime();
+s._lastWheelScrollTime = (new window.Date()).getTime();
 if (s.params.mousewheelControl) {
     if (document.onmousewheel !== undefined) {
         s._wheelEvent = 'mousewheel';
     }
     if (!s._wheelEvent) {
         try {
-            new WheelEvent('wheel');
+            new window.WheelEvent('wheel');
             s._wheelEvent = 'wheel';
         } catch (e) {}
     }
@@ -59,11 +59,11 @@ function handleMousewheel(e) {
     }
 
     if (!s.params.freeMode) {
-        if ((new Date()).getTime() - s._lastWheelScrollTime > 60) {
+        if ((new window.Date()).getTime() - s._lastWheelScrollTime > 60) {
             if (delta < 0) s.slideNext();
             else s.slidePrev();
         }
-        s._lastWheelScrollTime = (new Date()).getTime();
+        s._lastWheelScrollTime = (new window.Date()).getTime();
 
     }
     else {

--- a/src/js/swiper-intro.js
+++ b/src/js/swiper-intro.js
@@ -1,5 +1,5 @@
 /*===========================
 Swiper
 ===========================*/
-window.Swiper = function (container, params) {
+var Swiper = function (container, params) {
     if (!(this instanceof Swiper)) return new Swiper(container, params);

--- a/src/js/swiper-outro.js
+++ b/src/js/swiper-outro.js
@@ -1,4 +1,4 @@
-    
+
     // Return swiper instance
     return s;
 };

--- a/src/js/wrap-end.js
+++ b/src/js/wrap-end.js
@@ -1,1 +1,2 @@
+    window.Swiper = Swiper;
 })();


### PR DESCRIPTION
If I include this library with browserify and try to run my unit test, I get this error:

```
    Swiper.prototype = {
    ^
ReferenceError: Swiper is not defined
```

This is because most of the use cases of using the variable `Swiper` assume a browser.  I have slightly modified the code so that the initial creation uses `var Swiper = ...` instead of `window.Swiper = ...`.  At the end of the main file, I then do a `window.Swiper = Swiper;` to make sure it is available globally like it is now.  I also updated the amd script to use `window.Swiper` instead of just `Swiper` (which was just inferring the `window.` anyways).

I tested some of the examples (since there don't seem to be able unit tests) and everything worked fine.  If this could be merged and a new version pushed to npm that would be great (otherwise I will have to push my own version to npm to continue on with my project since I need my tests to pass).

Let me know if there is anything I need to change.