### PR TITLE
Only get direct children for loopedslides

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1866,7 +1866,8 @@ s.createLoop = function () {
     // Remove duplicated slides
     s.wrapper.children('.' + s.params.slideClass + '.' + s.params.slideDuplicateClass).remove();
 
-    var slides = s.wrapper.children('.' + s.params.slideClass);
+    // Only fetch direct children; we don't want to affect nested sliders!
+    var slides = s.wrapper.children('> .' + s.params.slideClass);
     s.loopedSlides = parseInt(s.params.loopedSlides || s.params.slidesPerView, 10);
     s.loopedSlides = s.loopedSlides + s.params.loopAdditionalSlides;
     if (s.loopedSlides > slides.length) {


### PR DESCRIPTION
We have a situation where we want to have a slider inside a 'looped' slider.
This gives the problem that the events on the nested slider is getting the containing sliders events.
The slider should only look at the direct children to determine what to loop on.