### PR TITLE
fix Swiper doesn't back to the first slide when `translate === 0`.

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1628,10 +1628,7 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
     s.previousIndex = s.activeIndex || 0;
     s.activeIndex = slideIndex;
 
-    if (translate === s.translate) {
-        s.updateClasses();
-        return false;
-    }
+    if (translate === s.translate) s.updateClasses();
     s.updateClasses();
     s.onTransitionStart(runCallbacks);
     var translateX = isH() ? translate : 0, translateY = isH() ? 0 : translate;


### PR DESCRIPTION
I made a screen record for this issue I occured: https://youtu.be/6r_j_UyVc_w
