### PR TITLE
Fix scrolling issue in Firefox when freeMode enabled.

### DIFF
--- a/src/js/mousewheel.js
+++ b/src/js/mousewheel.js
@@ -77,7 +77,9 @@ function handleMousewheel(e) {
     }
     else {
         //Freemode or scrollContainer:
-
+        if(Math.abs(delta) < 50){
+          delta > 0 ? (delta = delta + 120) : (delta = delta - 120);
+        }
         var position = s.getWrapperTranslate() + delta * s.params.mousewheelSensitivity;
 
         if (position > 0) position = 0;


### PR DESCRIPTION
Fix limited scrolling in Firefox versions when freeMode is enabled.
https://github.com/nolimits4web/Swiper/issues/1434
