### PR TITLE
fix bug with placeholder editing in IE

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1197,7 +1197,7 @@ s.onTouchStart = function (e) {
         var preventDefault = true;
         if ($(e.target).is(formElements)) preventDefault = false;
         if (document.activeElement && $(document.activeElement).is(formElements)) {
-            document.activeElement.blur();
+            if (!s.browser.ie) document.activeElement.blur();
         }
         if (preventDefault) {
             e.preventDefault();


### PR DESCRIPTION
Reproduced https://jsfiddle.net/gxo4nydd/4/ on IE 10,11 on Windows 7
Just click on input several times rapidly until you see cursor and placeholder at the same time. Now you can edit the placeholder. Input value stays empty. 

PS What use of blurring :inputs?
![placeholder](https://cloud.githubusercontent.com/assets/1208824/10763444/03170b1e-7cdb-11e5-9405-93d5c405b297.png)
