### PR TITLE
Sets keyboardControl param in disable and enableKeyboardControl

### DIFF
--- a/src/js/keyboard.js
+++ b/src/js/keyboard.js
@@ -67,8 +67,10 @@ function handleKeyboard(e) {
     }
 }
 s.disableKeyboardControl = function () {
+    s.params.keyboardControl = false;
     $(document).off('keydown', handleKeyboard);
 };
 s.enableKeyboardControl = function () {
+    s.params.keyboardControl = true;
     $(document).on('keydown', handleKeyboard);
 };


### PR DESCRIPTION
Hi

I want to set the keyboardControl param in enableKeyboardControl to true, and respectively false in disableKeyboardControl.

I want this functionality because I don't want to call enableKeyboardControl more than once if it is enabled. But as it is now, params.keyboardControl won't change in these functions, so it will always return true if it was enabled on init. So I have no way to check the state as I understand.

It would be nice if we could use this existing property, and not have to add another property reflecting this state.

What do you think of the idea?