### PR TITLE
Lazyload on resize

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -807,6 +807,9 @@ s.updateSlidesProgress = function (translate) {
                 (slideBefore <= 0 && slideAfter >= s.size);
             if (isVisible) {
                 s.slides.eq(i).addClass(s.params.slideVisibleClass);
+                if (s.lazy && s.params.lazyLoading){
+                    s.lazy.loadImageInSlide(i);
+                }
             }
         }
         slide.progress = s.rtl ? -slideProgress : slideProgress;


### PR DESCRIPTION
Allows to lazyload not loaded images when  the number of visible slide changes by resize