### PR TITLE
Fix paginationClickable property in demo files to be boolean

### DIFF
--- a/demos/16-effect-fade.html
+++ b/demos/16-effect-fade.html
@@ -56,7 +56,7 @@
     <script>
     var swiper = new Swiper('.swiper-container', {
         pagination: '.swiper-pagination',
-        paginationClickable: '.swiper-pagination',
+        paginationClickable: true,
         nextButton: '.swiper-button-next',
         prevButton: '.swiper-button-prev',
         spaceBetween: 30,

--- a/demos/25-hash-navigation.html
+++ b/demos/25-hash-navigation.html
@@ -76,7 +76,7 @@
     <script>
     var swiper = new Swiper('.swiper-container', {
         pagination: '.swiper-pagination',
-        paginationClickable: '.swiper-pagination',
+        paginationClickable: true,
         nextButton: '.swiper-button-next',
         prevButton: '.swiper-button-prev',
         spaceBetween: 30,


### PR DESCRIPTION
Noticed while creating type definitions for Swiper 3.3.0 that in 16-effect-fade.html and 25-hash-navigation.html the paginationClickable property was being passed a selector. In the documentation and after examining Swiper's internal use of this property it is treated only as a boolean.

Typescript defitions for Swiper 3.3.0
https://github.com/WarriorRocker/DefinitelyTyped/blob/swiper/swiper/swiper.d.ts

Let me know what you think.