### PR TITLE
Resolve #1625 Fix updating of previousIndex in slideTo function.

### DIFF
--- a/dist/js/swiper.js
+++ b/dist/js/swiper.js
@@ -1879,7 +1879,7 @@
         
             // Update Index
             if (typeof speed === 'undefined') speed = s.params.speed;
-            s.previousIndex = s.activeIndex || 0;
+            s.previousIndex = s.previousIndex || 0;
             s.activeIndex = slideIndex;
         
             if ((s.rtl && -translate === s.translate) || (!s.rtl && translate === s.translate)) {


### PR DESCRIPTION
The assignment made before causes previousIndex always being the same as activeIndex. Now it's initialized to 0 or keeps its value as it should instead of taking activeIndex value.