### PR TITLE
Fixes previousIndex assignment

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1856,7 +1856,7 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
 
     // Update Index
     if (typeof speed === 'undefined') speed = s.params.speed;
-    s.previousIndex = s.activeIndex || 0;
+    s.previousIndex = s.previousIndex || 0;
     s.activeIndex = slideIndex;
 
     if ((s.rtl && -translate === s.translate) || (!s.rtl && translate === s.translate)) {


### PR DESCRIPTION
The assignment made before causes previousIndex always being the same as activeIndex. Now it's initialized to 0 or keeps its value as it should instead of taking activeIndex value.

Related to #1625
