### PR TITLE
Add enableTouchControl() and disableTouchControl()

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1964,6 +1964,15 @@ s.slideReset = function (runCallbacks, speed, internal) {
     return s.slideTo(s.activeIndex, speed, runCallbacks);
 };
 
+s.disableTouchControl = function () {
+    s.params.onlyExternal = true;
+    return true;
+};
+s.enableTouchControl = function () {
+    s.params.onlyExternal = false;
+    return true;
+};
+
 /*=========================
   Translate/transition helpers
   ===========================*/


### PR DESCRIPTION
Implements the feature request described in #1673. Simply a couple of wrappers for toggling s.params.onlyExternal after the Swiper has been instantiated.