### PR TITLE
Add possibility to change all class names

### DIFF
--- a/src/js/a11y.js
+++ b/src/js/a11y.js
@@ -49,7 +49,7 @@ s.a11y = {
         }
     },
 
-    liveRegion: $('<span class="swiper-notification" aria-live="assertive" aria-atomic="true"></span>'),
+    liveRegion: $('<span class="' + s.params.notificationClass + '" aria-live="assertive" aria-atomic="true"></span>'),
 
     notify: function (message) {
         var notification = s.a11y.liveRegion;

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -138,6 +138,7 @@ var defaults = {
     noSwiping: true,
     noSwipingClass: 'swiper-no-swiping',
     // NS
+    containerModifierClass: 'swiper-container-', // NEW
     slideClass: 'swiper-slide',
     slideActiveClass: 'swiper-slide-active',
     slideVisibleClass: 'swiper-slide-visible',
@@ -152,7 +153,15 @@ var defaults = {
     paginationTotalClass: 'swiper-pagination-total',
     paginationHiddenClass: 'swiper-pagination-hidden',
     paginationProgressbarClass: 'swiper-pagination-progressbar',
+    paginationClickableClass: 'swiper-pagination-clickable', // NEW
+    paginationModifierClass: 'swiper-pagination-', // NEW
     lazyLoadingClass: 'swiper-lazy',
+    lazyStatusLoadingClass: 'swiper-lazy-loading',
+    lazyStatusLoadedClass: 'swiper-lazy-loaded',
+    lazyPreloaderClass: 'swiper-lazy-preloader',
+    notificationClass: 'swiper-notification',
+    preloaderClass: 'preloader',
+
     // Observer
     observer: false,
     observeParents: false,
@@ -312,17 +321,17 @@ if (s.container.length > 1) {
 s.container[0].swiper = s;
 s.container.data('swiper', s);
 
-s.classNames.push('swiper-container-' + s.params.direction);
+s.classNames.push(s.params.containerModifierClass + s.params.direction);
 
 if (s.params.freeMode) {
-    s.classNames.push('swiper-container-free-mode');
+    s.classNames.push(s.params.containerModifierClass + 'free-mode');
 }
 if (!s.support.flexbox) {
-    s.classNames.push('swiper-container-no-flexbox');
+    s.classNames.push(s.params.containerModifierClass + 'no-flexbox');
     s.params.slidesPerColumn = 1;
 }
 if (s.params.autoHeight) {
-    s.classNames.push('swiper-container-autoheight');
+    s.classNames.push(s.params.containerModifierClass + 'autoheight');
 }
 // Enable slides progress when required
 if (s.params.parallax || s.params.watchSlidesVisibility) {
@@ -332,14 +341,14 @@ if (s.params.parallax || s.params.watchSlidesVisibility) {
 if (['cube', 'coverflow', 'flip'].indexOf(s.params.effect) >= 0) {
     if (s.support.transforms3d) {
         s.params.watchSlidesProgress = true;
-        s.classNames.push('swiper-container-3d');
+        s.classNames.push(s.params.containerModifierClass + '3d');
     }
     else {
         s.params.effect = 'slide';
     }
 }
 if (s.params.effect !== 'slide') {
-    s.classNames.push('swiper-container-' + s.params.effect);
+    s.classNames.push(s.params.containerModifierClass + s.params.effect);
 }
 if (s.params.effect === 'cube') {
     s.params.resistanceRatio = 0;
@@ -379,12 +388,12 @@ if (s.params.pagination) {
     }
 
     if (s.params.paginationType === 'bullets' && s.params.paginationClickable) {
-        s.paginationContainer.addClass('swiper-pagination-clickable');
+        s.paginationContainer.addClass(s.params.paginationModifierClass + 'clickable');
     }
     else {
         s.params.paginationClickable = false;
     }
-    s.paginationContainer.addClass('swiper-pagination-' + s.params.paginationType);
+    s.paginationContainer.addClass(s.params.paginationModifierClass + s.params.paginationType);
 }
 // Next/Prev Buttons
 if (s.params.nextButton || s.params.prevButton) {
@@ -411,7 +420,7 @@ s.isHorizontal = function () {
 // RTL
 s.rtl = s.isHorizontal() && (s.container[0].dir.toLowerCase() === 'rtl' || s.container.css('direction') === 'rtl');
 if (s.rtl) {
-    s.classNames.push('swiper-container-rtl');
+    s.classNames.push(s.params.containerModifierClass + 'rtl');
 }
 
 // Wrong RTL support
@@ -421,12 +430,12 @@ if (s.rtl) {
 
 // Columns
 if (s.params.slidesPerColumn > 1) {
-    s.classNames.push('swiper-container-multirow');
+    s.classNames.push(s.params.containerModifierClass + 'multirow');
 }
 
 // Check for Android
 if (s.device.android) {
-    s.classNames.push('swiper-container-android');
+    s.classNames.push(s.params.containerModifierClass + 'android');
 }
 
 // Add classes
@@ -1325,7 +1334,7 @@ s.updateClickedSlide = function (e) {
             if (s.params.centeredSlides) {
                 if ((slideToIndex < s.loopedSlides - s.params.slidesPerView/2) || (slideToIndex > s.slides.length - s.loopedSlides + s.params.slidesPerView/2)) {
                     s.fixLoop();
-                    slideToIndex = s.wrapper.children('.' + s.params.slideClass + '[data-swiper-slide-index="' + realIndex + '"]:not(.swiper-slide-duplicate)').eq(0).index();
+                    slideToIndex = s.wrapper.children('.' + s.params.slideClass + '[data-swiper-slide-index="' + realIndex + '"]:not(.' + s.params.slideDuplicateClass + ')').eq(0).index();
                     setTimeout(function () {
                         s.slideTo(slideToIndex);
                     }, 0);
@@ -1337,7 +1346,7 @@ s.updateClickedSlide = function (e) {
             else {
                 if (slideToIndex > s.slides.length - s.params.slidesPerView) {
                     s.fixLoop();
-                    slideToIndex = s.wrapper.children('.' + s.params.slideClass + '[data-swiper-slide-index="' + realIndex + '"]:not(.swiper-slide-duplicate)').eq(0).index();
+                    slideToIndex = s.wrapper.children('.' + s.params.slideClass + '[data-swiper-slide-index="' + realIndex + '"]:not(.' + s.params.slideDuplicateClass + ')').eq(0).index();
                     setTimeout(function () {
                         s.slideTo(slideToIndex);
                     }, 0);

--- a/src/js/keyboard.js
+++ b/src/js/keyboard.js
@@ -20,7 +20,7 @@ function handleKeyboard(e) {
     if (kc === 37 || kc === 39 || kc === 38 || kc === 40) {
         var inView = false;
         //Check that swiper should be inside of visible area of window
-        if (s.container.parents('.swiper-slide').length > 0 && s.container.parents('.swiper-slide-active').length === 0) {
+        if (s.container.parents('.' + s.params.slideClass).length > 0 && s.container.parents('.' + s.params.slideActiveClass).length === 0) {
             return;
         }
         var windowScroll = {

--- a/src/js/lazy-load.js
+++ b/src/js/lazy-load.js
@@ -9,15 +9,15 @@ s.lazy = {
         if (s.slides.length === 0) return;
 
         var slide = s.slides.eq(index);
-        var img = slide.find('.' + s.params.lazyLoadingClass + ':not(.swiper-lazy-loaded):not(.swiper-lazy-loading)');
-        if (slide.hasClass(s.params.lazyLoadingClass) && !slide.hasClass('swiper-lazy-loaded') && !slide.hasClass('swiper-lazy-loading')) {
+        var img = slide.find('.' + s.params.lazyLoadingClass + ':not(.' + s.params.lazyStatusLoadedClass + '):not(.' + s.params.lazyStatusLoadingClass + ')');
+        if (slide.hasClass(s.params.lazyLoadingClass) && !slide.hasClass(s.params.lazyStatusLoadedClass) && !slide.hasClass(s.params.lazyStatusLoadingClass)) {
             img = img.add(slide[0]);
         }
         if (img.length === 0) return;
 
         img.each(function () {
             var _img = $(this);
-            _img.addClass('swiper-lazy-loading');
+            _img.addClass(s.params.lazyStatusLoadingClass);
             var background = _img.attr('data-background');
             var src = _img.attr('data-src'),
                 srcset = _img.attr('data-srcset');
@@ -38,8 +38,8 @@ s.lazy = {
 
                 }
 
-                _img.addClass('swiper-lazy-loaded').removeClass('swiper-lazy-loading');
-                slide.find('.swiper-lazy-preloader, .preloader').remove();
+                _img.addClass(s.params.lazyStatusLoadedClass).removeClass(s.params.lazyStatusLoadingClass);
+                slide.find('.' + s.params.lazyPreloaderClass + ', .' + s.params.preloaderClass).remove();
                 if (s.params.loop && loadInDuplicate) {
                     var slideOriginalIndex = slide.attr('data-swiper-slide-index');
                     if (slide.hasClass(s.params.slideDuplicateClass)) {


### PR DESCRIPTION
Currently, it's not possible to change all class names in the settings. I also fixed some hardcoded class names (e.g. `slideClass` or `slideDuplicateClass`, see `src/js/keyboard.js`) that could already be changed in the settings.