### PR TITLE
Fixing autoHeight if slidesPerView is more than 1

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -622,12 +622,30 @@ s.maxTranslate = function () {
   Slider/slides sizes
   ===========================*/
 s.updateAutoHeight = function () {
-    // Update Height
-    var slide = s.slides.eq(s.activeIndex)[0];
-    if (typeof slide !== 'undefined') {
-        var newHeight = slide.offsetHeight;
-        if (newHeight) s.wrapper.css('height', newHeight + 'px');
+    var activeSlides = [];
+    var newHeight = 0;
+
+    // Find slides currently in view
+    if(s.params.slidesPerView !== 'auto' && s.params.slidesPerView > 1) {
+        for (i = 0; i < Math.ceil(s.params.slidesPerView); i++) {
+            var index = s.activeIndex + i;
+            if(index > s.slides.length) break;
+            activeSlides.push(s.slides.eq(index)[0]);
+        }
+    } else {
+        activeSlides.push(s.slides.eq(s.activeIndex)[0]);
     }
+
+    // Find new height from heighest slide in view
+    for (i = 0; i < activeSlides.length; i++) {
+        if (typeof activeSlides[i] !== 'undefined') {
+            var height = activeSlides[i].offsetHeight;
+            newHeight = height > newHeight ? height : newHeight;
+        }
+    }
+
+    // Update Height
+    if (newHeight) s.wrapper.css('height', newHeight + 'px');
 };
 s.updateContainerSize = function () {
     var width, height;


### PR DESCRIPTION
Currently Swiper only measures the height of the active slide when setting container height. This fix also looks at other slides in view, and uses the tallest slide's height.

**NOTE:** This fix doesn't take into account sliders with `slidesPerView: 'auto'`, it only ignores it. A more elaborate fix is needed to support that.