### PR TITLE
Fixing IE9 issue.

### DIFF
--- a/demos/38-jquery-ie9-loop.html
+++ b/demos/38-jquery-ie9-loop.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Swiper demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
+
+    <!-- Link Swiper's CSS -->
+    <link rel="stylesheet" href="../dist/css/swiper.min.css">
+
+    <!-- Demo styles -->
+    <style>
+    html, body {
+        position: relative;
+        height: 100%;
+    }
+    body {
+        background: #eee;
+        font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        color:#000;
+        margin: 0;
+        padding: 0;
+    }
+    .swiper-container {
+        width: 100%;
+        height: 100%;
+    }
+    .swiper-slide {
+        text-align: center;
+        font-size: 18px;
+        background: #fff;
+
+        /* Center slide text vertically */
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: -webkit-flex;
+        display: flex;
+        -webkit-box-pack: center;
+        -ms-flex-pack: center;
+        -webkit-justify-content: center;
+        justify-content: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        -webkit-align-items: center;
+        align-items: center;
+    }
+    </style>
+</head>
+<body>
+    <!-- Swiper -->
+    <div class="swiper-container">
+        <div class="swiper-wrapper">
+            <div class="swiper-slide">Slide 1</div>
+            <div class="swiper-slide">Slide 2</div>
+            <div class="swiper-slide">Slide 3</div>
+            <div class="swiper-slide">Slide 4</div>
+            <div class="swiper-slide">Slide 5</div>
+            <div class="swiper-slide">Slide 6</div>
+            <div class="swiper-slide">Slide 7</div>
+            <div class="swiper-slide">Slide 8</div>
+            <div class="swiper-slide">Slide 9</div>
+            <div class="swiper-slide">Slide 10</div>
+        </div>
+        <!-- Add Pagination -->
+        <div class="swiper-pagination"></div>
+        <!-- Add Navigation -->
+        <div class="swiper-button-prev"></div>
+        <div class="swiper-button-next"></div>
+    </div>
+
+    <!-- jQuery -->
+    <script src="http://code.jquery.com/jquery-2.1.3.min.js"></script>
+    <!-- Swiper JS -->
+    <script src="../dist/js/swiper.jquery.min.js"></script>
+
+    <!-- Initialize Swiper -->
+    <script>
+    var swiper = new Swiper('.swiper-container', {
+        loop: true,
+        pagination: '.swiper-pagination',
+        paginationClickable: true,
+        nextButton: '.swiper-button-next',
+        prevButton: '.swiper-button-prev'
+    });
+    </script>
+</body>
+</html>

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1903,7 +1903,7 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
         s.setWrapperTranslate(translate);
         s.setWrapperTransition(speed);
         if (!s.animating) {
-            s.animating = true;
+            if (!s.browser.lteIE9) s.animating = true;
             s.wrapper.transitionEnd(function () {
                 if (!s) return;
                 s.onTransitionEnd(runCallbacks);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1894,7 +1894,7 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
     s.updateClasses();
     s.onTransitionStart(runCallbacks);
 
-    if (speed === 0) {
+    if (speed === 0 || s.browser.lteIE9) {
         s.setWrapperTranslate(translate);
         s.setWrapperTransition(0);
         s.onTransitionEnd(runCallbacks);
@@ -1903,7 +1903,7 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
         s.setWrapperTranslate(translate);
         s.setWrapperTransition(speed);
         if (!s.animating) {
-            if (!s.browser.lteIE9) s.animating = true;
+            s.animating = true;
             s.wrapper.transitionEnd(function () {
                 if (!s) return;
                 s.onTransitionEnd(runCallbacks);

--- a/src/js/swiper-proto.js
+++ b/src/js/swiper-proto.js
@@ -15,7 +15,15 @@ Swiper.prototype = {
     ====================================================*/
     browser: {
         ie: window.navigator.pointerEnabled || window.navigator.msPointerEnabled,
-        ieTouch: (window.navigator.msPointerEnabled && window.navigator.msMaxTouchPoints > 1) || (window.navigator.pointerEnabled && window.navigator.maxTouchPoints > 1)
+        ieTouch: (window.navigator.msPointerEnabled && window.navigator.msMaxTouchPoints > 1) || (window.navigator.pointerEnabled && window.navigator.maxTouchPoints > 1),
+        lteIE9: (function() {
+            // create temporary DIV
+            var div = document.createElement('div');
+            // add content to tmp DIV which is wrapped into the IE HTML conditional statement
+            div.innerHTML = '<!--[if lte IE 9]><i></i><![endif]-->';
+            // return true / false value based on what will browser render
+            return div.getElementsByTagName('i').length === 1;
+        })()
     },
     /*==================================================
     Devices


### PR DESCRIPTION
The following use-case was causing the regression error bug:
- Using 'dist/js/swiper.jquery.min.js' on IE9
- Setting 'loop' property on instantiation of Swiper to 'true'
- Using arrow as navigation (swiping was working fine)

If this use-case is happening (requirement on my project) 's.animating' within the 'core.js' will be re-assigned  to 'true' on each click on the arrow/s. Resulting in only one slide change (initial click).

Solution:
- added the lte (lower then or equal) IE9 conditional check in 'src/js/swiper-proto.js' > property 'browser' > property 'lteIE9' (detecting browser by feature instead of version or UA etc.)
- wrapping line 1907 in 'src/js/core.js' method 'slideTo' into the IF statement (if (!s.browser.lteIE9) s.animating = true;). Idea is not to do the re-assignment on 's.animating' if code is being executed on IE9 or lower version of IE.

Took me some time to get into your nice code and debug our archenemy aka IE...