### PR TITLE
Fixes an error on swiper.destroy() when scrollbar is enabled

### DIFF
--- a/src/js/scrollbar.js
+++ b/src/js/scrollbar.js
@@ -82,9 +82,9 @@ s.scrollbar = {
     disableDraggable: function () {
         var sb = s.scrollbar;
         var target = s.support.touch ? sb.track : document;
-        $(sb.track).off(s.draggableEvents.start, sb.dragStart);
-        $(target).off(s.draggableEvents.move, sb.dragMove);
-        $(target).off(s.draggableEvents.end, sb.dragEnd);
+        $(sb.track).off(sb.draggableEvents.start, sb.dragStart);
+        $(target).off(sb.draggableEvents.move, sb.dragMove);
+        $(target).off(sb.draggableEvents.end, sb.dragEnd);
     },
     set: function () {
         if (!s.params.scrollbar) return;


### PR DESCRIPTION
This fixes a typo in the disableDraggable function which causes swiper.destroy() to error out when the scrollbar is enabled.
