### PR TITLE
Fix : activeIndex not changed when more than one slidePerView at the end of the swiper

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1978,10 +1978,11 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
     s.updateProgress(translate);
 
     // Normalize slideIndex
+    var normalizeSlideIndex = 0;
     if(s.params.normalizeSlideIndex){
         for (var i = 0; i < s.slidesGrid.length; i++) {
             if (- Math.floor(translate * 100) >= Math.floor(s.slidesGrid[i] * 100)) {
-                slideIndex = i;
+                normalizeSlideIndex = i;
             }
         }
     }
@@ -1991,7 +1992,7 @@ s.slideTo = function (slideIndex, speed, runCallbacks, internal) {
         return false;
     }
     if (!s.params.allowSwipeToPrev && translate > s.translate && translate > s.maxTranslate()) {
-        if ((s.activeIndex || 0) !== slideIndex ) return false;
+        if ((s.activeIndex || 0) !== normalizeSlideIndex ) return false;
     }
 
     // Update Index


### PR DESCRIPTION
When you have more than one slidePerView in the swiper and when you are at the end of it, if you click on one of the last visible slides, you don't need to slide to see them. However, it is good to change the activeIndex (to have the activeClass for example) on the clicked slide.

The initial slideIndex were changed when we check if we need to slide to see the clicked slide, therefore, the activeIndex were always the first visible slide. 