### PR TITLE
Bug fix centered slides show/hide position

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -815,6 +815,7 @@ s.updateSlidesSize = function () {
 
         if (s.params.centeredSlides) {
             slidePosition = slidePosition + slideSize / 2 + prevSlideSize / 2 + spaceBetween;
+            if(prevSlideSize == 0 && i !== 0) slidePosition = slidePosition - s.size / 2 - spaceBetween;
             if (i === 0) slidePosition = slidePosition - s.size / 2 - spaceBetween;
             if (Math.abs(slidePosition) < 1 / 1000) slidePosition = 0;
             if ((index) % s.params.slidesPerGroup === 0) s.snapGrid.push(slidePosition);


### PR DESCRIPTION
If you want do show/hide with this usage swiper:
https://github.com/nolimits4web/Swiper/blob/master/demos/23-thumbs-gallery.html 

The position of centered slide is broken.

Demo:
http://www.giphy.com/gifs/26hirxQ7trqmlipQ4