### PR TITLE
Downgrade engine version for Yarn compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "http://www.idangero.us/swiper/",
   "engines": {
-    "node": ">= 6.7.0"
+    "node": ">= 4.7.0"
   },
   "devDependencies": {
     "gulp": "^3.9.1",


### PR DESCRIPTION
This fixes Yarn not installing Swiper on Node version < `6.7.0`. Yarn strictly checks for the engine version so it will refuse to install the package if the version is lower than specified on `package.json`. I've tested all the tasks on the build process and they work fine against Node `4.7.0`, so that's the version I specified. It could even run fine on an even lower version as well, but I haven't tested.

Resolves #1964.