### PR TITLE
Better cleanup when instance is deleted

### DIFF
--- a/src/js/init.js
+++ b/src/js/init.js
@@ -149,7 +149,13 @@ s.destroy = function (deleteInstance, cleanupStyles) {
     // Destroy callback
     s.emit('onDestroy');
     // Delete instance
-    if (deleteInstance !== false) s = null;
+    if (deleteInstance !== false){
+        s.container[0].swiper = null;
+        s.container.data('swiper', null);
+        s.container = null;
+        s.wrapper = null;
+        s = null;
+    }
 };
 
 s.init();


### PR DESCRIPTION
Clean up jQuery data and object reference attached to the DOM element, remove reference to container and wrapper.