### PR TITLE
Use clickable class instead of modifier with postfix

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -412,7 +412,7 @@ if (s.params.pagination) {
     }
 
     if (s.params.paginationType === 'bullets' && s.params.paginationClickable) {
-        s.paginationContainer.addClass(s.params.paginationModifierClass + 'clickable');
+        s.paginationContainer.addClass(s.params.paginationClickableClass);
     }
     else {
         s.params.paginationClickable = false;


### PR DESCRIPTION
A specific constant exists for the `pagination-clickable` class, but isn't currently used. Now it does! 