### PR TITLE
Add blank slides to fit slides per group

### DIFF
--- a/demos/40-infinite-loop-with-multiple-slides.html
+++ b/demos/40-infinite-loop-with-multiple-slides.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Swiper demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
+
+    <!-- Link Swiper's CSS -->
+    <link rel="stylesheet" href="../dist/css/swiper.min.css">
+
+    <!-- Demo styles -->
+    <style>
+    html, body {
+        position: relative;
+        height: 100%;
+    }
+    body {
+        background: #eee;
+        font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        color:#000;
+        margin: 0;
+        padding: 0;
+    }
+    .swiper-container {
+        width: 100%;
+        height: 100%;
+    }
+    .swiper-slide {
+        text-align: center;
+        font-size: 18px;
+        background: #fff;
+        
+        /* Center slide text vertically */
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: -webkit-flex;
+        display: flex;
+        -webkit-box-pack: center;
+        -ms-flex-pack: center;
+        -webkit-justify-content: center;
+        justify-content: center;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        -webkit-align-items: center;
+        align-items: center;
+    }
+    </style>
+</head>
+<body>
+    <!-- Swiper -->
+    <div class="swiper-container">
+        <div class="swiper-wrapper">
+            <div class="swiper-slide">Slide 1</div>
+            <div class="swiper-slide">Slide 2</div>
+            <div class="swiper-slide">Slide 3</div>
+            <div class="swiper-slide">Slide 4</div>
+            <div class="swiper-slide">Slide 5</div>
+            <div class="swiper-slide">Slide 6</div>
+            <div class="swiper-slide">Slide 7</div>
+            <div class="swiper-slide">Slide 8</div>
+            <div class="swiper-slide">Slide 9</div>
+            <div class="swiper-slide">Slide 10</div>
+        </div>
+        <!-- Add Pagination -->
+        <div class="swiper-pagination"></div>
+        <!-- Add Arrows -->
+        <div class="swiper-button-next"></div>
+        <div class="swiper-button-prev"></div>
+    </div>
+
+    <!-- Swiper JS -->
+    <script src="../dist/js/swiper.min.js"></script>
+
+    <!-- Initialize Swiper -->
+    <script>
+    var swiper = new Swiper('.swiper-container', {
+        pagination: '.swiper-pagination',
+        slidesPerView: 3,
+        paginationClickable: true,
+        spaceBetween: 30,
+        nextButton: '.swiper-button-next',
+        prevButton: '.swiper-button-prev',
+        slidesPerGroup: 3,
+        loop: true,
+        fitSlideGroupWithBlank: true
+    });
+    </script>
+</body>
+</html>

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -112,6 +112,8 @@ var defaults = {
     paginationFractionRender: null,
     paginationCustomRender: null,
     paginationType: 'bullets', // 'bullets' or 'progress' or 'fraction' or 'custom'
+    fitSlideGroupWithBlank: false,
+    blankClass: 'swiper-invisible-blank-slide',
     // Resistance
     resistance: true,
     resistanceRatio: 0.85,
@@ -2340,6 +2342,15 @@ s.createLoop = function () {
     s.wrapper.children('.' + s.params.slideClass + '.' + s.params.slideDuplicateClass).remove();
 
     var slides = s.wrapper.children('.' + s.params.slideClass);
+
+    if (s.params.fitSlideGroupWithBlank) {
+        var blankSlidesNum = s.params.slidesPerGroup - slides.length % s.params.slidesPerGroup;
+        for (var i = 0; i < blankSlidesNum; i++) {
+            var blankNode = $(document.createElement('div')).addClass(s.params.slideClass + ' ' + s.params.blankClass);
+            s.wrapper.append(blankNode);
+        }
+        slides = s.wrapper.children();
+    }
 
     if(s.params.slidesPerView === 'auto' && !s.params.loopedSlides) s.params.loopedSlides = slides.length;
 

--- a/src/less/core.less
+++ b/src/less/core.less
@@ -69,6 +69,9 @@
     height: 100%;
     position: relative;
 }
+.swiper-invisible-blank-slide {
+    visibility: hidden;
+}
 /* Auto Height */
 .swiper-container-autoheight, .swiper-container-autoheight .swiper-slide {
     height: auto;


### PR DESCRIPTION
I encounter the same problem as #1800 
When using infinite loop with slidesPerGroup, some slides will repeat if the number of slides doesn't fit the group.

For example, 
If there are 10 slides with following settings:
```js
slidesPerView: 4,
slidesPerGroup: 4,
loop: true,
```
it becomes:
page 1: 1, 2, 3, 4
page 2: 5, 6, 7, 8
page 3: 9, 10, 1, 2
page 1: 1, 2, 3, 4

1 and 2 are repeated in page 3.
Thus, this PR adds the feature to fit the last page with blank slide(s) when the new parameter `fitSlideGroupWithBlank` is set to true.
Then page 3 will become: 9, 10, (empty), (empty)



