### PR TITLE
Export defaults in Swiper object

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1,4 +1,4 @@
-var defaults = {
+var defaults = Swiper.defaults = {
     direction: 'horizontal',
     touchEventsTarget: 'container',
     initialSlide: 0,


### PR DESCRIPTION
This PR exports the defaults object as Swiper.defaults so others can use it. This is specially useful for wrappers like ember-cli-swiper that need to manage the parameters that the components can use.

See https://github.com/Suven/ember-cli-swiper/pull/32