### PR TITLE
Prevent adding extra blank items

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -2349,11 +2349,13 @@ s.createLoop = function () {
 
     if (s.params.fitSlideGroupWithBlank) {
         var blankSlidesNum = s.params.slidesPerGroup - slides.length % s.params.slidesPerGroup;
-        for (var i = 0; i < blankSlidesNum; i++) {
-            var blankNode = $(document.createElement('div')).addClass(s.params.slideClass + ' ' + s.params.blankClass);
-            s.wrapper.append(blankNode);
+        if (blankSlidesNum !== s.params.slidesPerGroup) {
+            for (var i = 0; i < blankSlidesNum; i++) {
+                var blankNode = $(document.createElement('div')).addClass(s.params.slideClass + ' ' + s.params.blankClass);
+                s.wrapper.append(blankNode);
+            }
+            slides = s.wrapper.children();
         }
-        slides = s.wrapper.children();
     }
 
     if(s.params.slidesPerView === 'auto' && !s.params.loopedSlides) s.params.loopedSlides = slides.length;


### PR DESCRIPTION
It is related to https://github.com/nolimits4web/Swiper/pull/2150
Sorry, I forgot to update the situation that if slides.length can be divided by slidesPerGroup.
In this case, there will be one more blank group in the end.
