### PR TITLE
fix prevButton will jump 2 slide

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -2144,9 +2144,9 @@ s.slidePrev = function (runCallbacks, speed, internal) {
         if (s.animating) return false;
         s.fixLoop();
         var clientLeft = s.container[0].clientLeft;
-        return s.slideTo(s.activeIndex - 1, speed, runCallbacks, internal);
+        return s.slideTo(s.snapIndex - 1, speed, runCallbacks, internal);
     }
-    else return s.slideTo(s.activeIndex - 1, speed, runCallbacks, internal);
+    else return s.slideTo(s.snapIndex - 1, speed, runCallbacks, internal);
 };
 s._slidePrev = function (speed) {
     return s.slidePrev(true, speed, true);


### PR DESCRIPTION
#2003 
this PR is to solve the problem when you set a `slidesPerView: 'auto'` and press previous button on the last slide, it moves back 2 slides instead of 1. 