### PR TITLE
RTL scrollbar drag fix #2183

### DIFF
--- a/src/js/scrollbar.js
+++ b/src/js/scrollbar.js
@@ -19,6 +19,9 @@ s.scrollbar = {
         else if (position > positionMax) {
             position = positionMax;
         }
+        if (s.rtl) {
+            position = positionMax - position;
+        }
         position = -position / sb.moveDivider;
         s.updateProgress(position);
         s.setWrapperTranslate(position, true);


### PR DESCRIPTION
RTL scrollbar drag wrong position fix.
One line fix. If direction is rtl then set inverse position for scrollbar drag.
https://github.com/nolimits4web/Swiper/issues/2183