### PR TITLE
Bugfix: flexbox support check

### DIFF
--- a/src/components/core/update/updateSlides.js
+++ b/src/components/core/update/updateSlides.js
@@ -141,7 +141,7 @@ export default function () {
     rtl && wrongRTL && (params.effect === 'slide' || params.effect === 'coverflow')) {
     $wrapperEl.css({ width: `${swiper.virtualSize + params.spaceBetween}px` });
   }
-  if (!swiper.support.flexbox || params.setWrapperSize) {
+  if (!Support.flexbox || params.setWrapperSize) {
     if (swiper.isHorizontal()) $wrapperEl.css({ width: `${swiper.virtualSize + params.spaceBetween}px` });
     else $wrapperEl.css({ height: `${swiper.virtualSize + params.spaceBetween}px` });
   }

--- a/src/components/core/update/updateSlides.js
+++ b/src/components/core/update/updateSlides.js
@@ -1,4 +1,5 @@
 import Utils from '../../../utils/utils';
+import Support from '../../../utils/support';
 
 export default function () {
   const swiper = this;


### PR DESCRIPTION
Since "support" is no longer a property of the Swiper core class, a check for "support.flexbox" throws an error for an invalid object access.