### PR TITLE
TASK: Fix dom7/src/methods import statement

### DIFF
--- a/dist/js/swiper.modular.js
+++ b/dist/js/swiper.modular.js
@@ -11,7 +11,7 @@
  */
 
 import $ from 'dom7/src/$';
-import Methods from 'dom7/src/methods';
+import * as Methods from 'dom7/src/methods';
 
 let w;
 if (typeof window === 'undefined') {

--- a/dist/js/swiper.module.js
+++ b/dist/js/swiper.module.js
@@ -11,7 +11,7 @@
  */
 
 import $ from 'dom7/src/$';
-import Methods from 'dom7/src/methods';
+import * as Methods from 'dom7/src/methods';
 
 let w;
 if (typeof window === 'undefined') {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,5 +1,5 @@
 import $ from 'dom7/src/$';
-import Methods from 'dom7/src/methods';
+import * as Methods from 'dom7/src/methods';
 
 // Methods
 $.use(Methods);


### PR DESCRIPTION
With the different export statement from dom7, the import statement from `dom7/src/methods` need to adjust.