### PR TITLE
Remove obsolete prefixed event names

### DIFF
--- a/src/components/core/events/onTouchMove.js
+++ b/src/components/core/events/onTouchMove.js
@@ -98,7 +98,7 @@ export default function (event) {
     data.startTranslate = swiper.getTranslate();
     swiper.setTransition(0);
     if (swiper.animating) {
-      swiper.$wrapperEl.trigger('webkitTransitionEnd transitionend oTransitionEnd MSTransitionEnd msTransitionEnd');
+      swiper.$wrapperEl.trigger('webkitTransitionEnd transitionend');
     }
     data.allowMomentumBounce = false;
     // Grab Cursor

--- a/src/components/effect-fade/effect-fade.js
+++ b/src/components/effect-fade/effect-fade.js
@@ -35,7 +35,7 @@ const Fade = {
         if (!swiper) return;
         eventTriggered = true;
         swiper.animating = false;
-        const triggerEvents = ['webkitTransitionEnd', 'transitionend', 'oTransitionEnd', 'MSTransitionEnd', 'msTransitionEnd'];
+        const triggerEvents = ['webkitTransitionEnd', 'transitionend'];
         for (let i = 0; i < triggerEvents.length; i += 1) {
           $wrapperEl.trigger(triggerEvents[i]);
         }

--- a/src/components/effect-flip/effect-flip.js
+++ b/src/components/effect-flip/effect-flip.js
@@ -63,7 +63,7 @@ const Flip = {
         if (!$(this).hasClass(swiper.params.slideActiveClass)) return;
         eventTriggered = true;
         swiper.animating = false;
-        const triggerEvents = ['webkitTransitionEnd', 'transitionend', 'oTransitionEnd', 'MSTransitionEnd', 'msTransitionEnd'];
+        const triggerEvents = ['webkitTransitionEnd', 'transitionend'];
         for (let i = 0; i < triggerEvents.length; i += 1) {
           $wrapperEl.trigger(triggerEvents[i]);
         }


### PR DESCRIPTION
This PR removes obsolete transitionend prefixed events as discussed at https://github.com/framework7io/Framework7/issues/1288 and at https://github.com/framework7io/Framework7/pull/1849
