### PR TITLE
Set default loopedSlides to avoid NaN

### DIFF
--- a/src/components/core/breakpoints/setBreakpoint.js
+++ b/src/components/core/breakpoints/setBreakpoint.js
@@ -21,7 +21,7 @@ function getBreakpoint(breakpoints) {
 
 export default function () {
   const swiper = this;
-  const { activeIndex, loopedSlides, params } = swiper;
+  const { activeIndex, loopedSlides = 0, params } = swiper;
   const breakpoints = params.breakpoints;
   if (!breakpoints || (breakpoints && Object.keys(breakpoints).length === 0)) return;
   // Set breakpoint for window width and update parameters


### PR DESCRIPTION
Sets a default loopedSlides count to avoid NaN. The problem resulted in `swiper.slideTo(NaN, 0, false)`. It only occurred when using using both loop and breakpoints, and initialising on a viewport within a breakpoint.

Also Fixes #2243

