### PR TITLE
Fix noSwipingClass ignore

### DIFF
--- a/src/components/core/events/onTouchStart.js
+++ b/src/components/core/events/onTouchStart.js
@@ -11,7 +11,7 @@ export default function (event) {
   if (e.originalEvent) e = e.originalEvent;
   data.isTouchEvent = e.type === 'touchstart';
   if (!data.isTouchEvent && 'which' in e && e.which === 3) return;
-  if (params.noSwiping && $(e).closest(`.${params.noSwipingClass}`)[0]) {
+  if (params.noSwiping && $(e.target).closest(`.${params.noSwipingClass}`)[0]) {
     swiper.allowClick = true;
     return;
   }


### PR DESCRIPTION
На работал поиск ближайжего родителя с класом  `noSwipingClass`  из-за того, что в `Dom7()` предавался евент в качестве агрумента 


![image](https://user-images.githubusercontent.com/4661784/32268666-153aa0a2-bf01-11e7-94a7-cb122ad92af4.png)

