### PR TITLE
Add support for reverse autoplay

### DIFF
--- a/src/components/autoplay/autoplay.js
+++ b/src/components/autoplay/autoplay.js
@@ -9,7 +9,21 @@ const Autoplay = {
       delay = $activeSlideEl.attr('data-swiper-autoplay') || swiper.params.autoplay.delay;
     }
     swiper.autoplay.timeout = Utils.nextTick(() => {
-      if (swiper.params.loop) {
+      if (swiper.params.autoplay.reverseDirection) {
+        if (swiper.params.loop) {
+          swiper.loopFix();
+          swiper.slidePrev(swiper.params.speed, true, true);
+          swiper.emit('autoplay');
+        } else if (!swiper.isBeginning) {
+          swiper.slidePrev(swiper.params.speed, true, true);
+          swiper.emit('autoplay');
+        } else if (!swiper.params.autoplay.stopOnLastSlide) {
+          swiper.slideTo(swiper.slides.length - 1, swiper.params.speed, true, true);
+          swiper.emit('autoplay');
+        } else {
+          swiper.autoplay.stop();
+        }
+      } else if (swiper.params.loop) {
         swiper.loopFix();
         swiper.slideNext(swiper.params.speed, true, true);
         swiper.emit('autoplay');
@@ -77,6 +91,7 @@ export default {
       delay: 3000,
       disableOnInteraction: true,
       stopOnLastSlide: false,
+      reverseDirection: false,
     },
   },
   create() {


### PR DESCRIPTION
Reverse direction of Swiper autoplay

## Description
This feature allows to play slides in reverse, simply setting the `reverseDirection` property to true and the slides will play in reverse.

## Motivation and Context
Other than this being a nice feature, it allows vertical top-to-bottom direction autoplay much like a news-feed effect.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.