### PR TITLE
dynamicBullets: fix for when user jumps to a more distant slide + fix for wrong offse…

### DIFF
--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -38,8 +38,7 @@ const Pagination = {
           swiper.pagination.dynamicBulletIndex += (current - swiper.previousIndex);
           if (swiper.pagination.dynamicBulletIndex > (params.dynamicMainBullets - 1)) {
             swiper.pagination.dynamicBulletIndex = params.dynamicMainBullets - 1;
-          }
-          else if (swiper.pagination.dynamicBulletIndex < 0) {
+          } else if (swiper.pagination.dynamicBulletIndex < 0) {
             swiper.pagination.dynamicBulletIndex = 0;
           }
         }

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -44,7 +44,7 @@ const Pagination = {
           }
         }
         firstIndex = current - swiper.pagination.dynamicBulletIndex;
-        lastIndex = firstIndex + Math.min(bullets.length, params.dynamicMainBullets) - 1;
+        lastIndex = firstIndex + (Math.min(bullets.length, params.dynamicMainBullets) - 1);
         midIndex = (lastIndex + firstIndex) / 2;
       }
       bullets.removeClass(`${params.bulletActiveClass} ${params.bulletActiveClass}-next ${params.bulletActiveClass}-next-next ${params.bulletActiveClass}-prev ${params.bulletActiveClass}-prev-prev ${params.bulletActiveClass}-main`);

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -35,14 +35,16 @@ const Pagination = {
         swiper.pagination.bulletSize = bullets.eq(0)[swiper.isHorizontal() ? 'outerWidth' : 'outerHeight'](true);
         $el.css(swiper.isHorizontal() ? 'width' : 'height', `${swiper.pagination.bulletSize * (params.dynamicMainBullets + 4)}px`);
         if (params.dynamicMainBullets > 1 && swiper.previousIndex !== undefined) {
-          if (current > swiper.previousIndex && swiper.pagination.dynamicBulletIndex < (params.dynamicMainBullets - 1)) {
-            swiper.pagination.dynamicBulletIndex += 1;
-          } else if (current < swiper.previousIndex && swiper.pagination.dynamicBulletIndex > 0) {
-            swiper.pagination.dynamicBulletIndex -= 1;
+          swiper.pagination.dynamicBulletIndex += (current - swiper.previousIndex);
+          if (swiper.pagination.dynamicBulletIndex > (params.dynamicMainBullets - 1)) {
+            swiper.pagination.dynamicBulletIndex = params.dynamicMainBullets - 1;
+          }
+          else if (swiper.pagination.dynamicBulletIndex < 0) {
+            swiper.pagination.dynamicBulletIndex = 0;
           }
         }
         firstIndex = current - swiper.pagination.dynamicBulletIndex;
-        lastIndex = firstIndex + (params.dynamicMainBullets - 1);
+        lastIndex = firstIndex + Math.min(bullets.length, params.dynamicMainBullets) - 1;
         midIndex = (lastIndex + firstIndex) / 2;
       }
       bullets.removeClass(`${params.bulletActiveClass} ${params.bulletActiveClass}-next ${params.bulletActiveClass}-next-next ${params.bulletActiveClass}-prev ${params.bulletActiveClass}-prev-prev ${params.bulletActiveClass}-main`);


### PR DESCRIPTION
…t when there are less bullets than the dynamicMainBullets

there is a bug when user moves to a slide that isn't next to the current slide,
because the active bullets will move only one step instead of the true distance between the slides

also if there are less bullets than the number configured for the dynamicMainBullets, the calculation of the offset will be wrong because it will be as if there are more bullets and so the bullets will look skewed