### PR TITLE
enable a11y by default

### DIFF
--- a/src/components/a11y/a11y.js
+++ b/src/components/a11y/a11y.js
@@ -153,7 +153,7 @@ export default {
   name: 'a11y',
   params: {
     a11y: {
-      enabled: false,
+      enabled: true,
       notificationClass: 'swiper-notification',
       prevSlideMessage: 'Previous slide',
       nextSlideMessage: 'Next slide',


### PR DESCRIPTION
a11y should be enabled by default like in most frameworks, it should be optout.