### PR TITLE
Handle mouseenter and mouseleave events

### DIFF
--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -99,19 +99,17 @@ const Mousewheel = {
   },
   handleMouseEnter() {
     const swiper = this;
-    swiper.mouseEntered = true
+    swiper.mouseEntered = true;
   },
   handleMouseLeave() {
     const swiper = this;
-    swiper.mouseEntered = false
+    swiper.mouseEntered = false;
   },
   handle(event) {
     let e = event;
     const swiper = this;
 
-    if(!swiper.mouseEntered) {
-      return;
-    }
+    if (!swiper.mouseEntered) return true;
 
     const params = swiper.params.mousewheel;
     if (e.originalEvent) e = e.originalEvent; // jquery fix

--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -192,7 +192,7 @@ const Mousewheel = {
       target = $(swiper.params.mousewheel.eventsTarged);
     }
     target.on('mouseenter', swiper.mousewheel.handleMouseEnter);
-    target.on('mouseenter', swiper.mousewheel.handleMouseLeave);
+    target.on('mouseleave', swiper.mousewheel.handleMouseLeave);
     target.on(Mousewheel.event, swiper.mousewheel.handle);
     swiper.mousewheel.enabled = true;
     return true;
@@ -232,7 +232,7 @@ export default {
         disable: Mousewheel.disable.bind(swiper),
         handle: Mousewheel.handle.bind(swiper),
         handleMouseEnter: Mousewheel.handleMouseEnter.bind(swiper),
-        handlemouseLeave: Mousewheel.handlemouseLeave.bind(swiper),
+        handleMouseLeave: Mousewheel.handleMouseLeave.bind(swiper),
         lastScrollTime: Utils.now(),
       },
     });

--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -109,7 +109,7 @@ const Mousewheel = {
     let e = event;
     const swiper = this;
 
-    if (!swiper.mouseEntered) return true;
+    if (!swiper.mouseEntered && !params.releaseOnEdges) return true;
 
     const params = swiper.params.mousewheel;
     if (e.originalEvent) e = e.originalEvent; // jquery fix

--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -97,9 +97,22 @@ const Mousewheel = {
       pixelY: pY,
     };
   },
+  handleMouseEnter() {
+    const swiper = this;
+    swiper.mouseEntered = true
+  },
+  handleMouseLeave() {
+    const swiper = this;
+    swiper.mouseEntered = false
+  },
   handle(event) {
     let e = event;
     const swiper = this;
+
+    if(!swiper.mouseEntered) {
+      return;
+    }
+
     const params = swiper.params.mousewheel;
     if (e.originalEvent) e = e.originalEvent; // jquery fix
     let delta = 0;
@@ -180,6 +193,8 @@ const Mousewheel = {
     if (swiper.params.mousewheel.eventsTarged !== 'container') {
       target = $(swiper.params.mousewheel.eventsTarged);
     }
+    target.on("mouseenter", swiper.mousewheel.handleMouseEnter);
+    target.on("mouseenter", swiper.mousewheel.handleMouseLeave);
     target.on(Mousewheel.event, swiper.mousewheel.handle);
     swiper.mousewheel.enabled = true;
     return true;
@@ -218,6 +233,8 @@ export default {
         enable: Mousewheel.enable.bind(swiper),
         disable: Mousewheel.disable.bind(swiper),
         handle: Mousewheel.handle.bind(swiper),
+        handleMouseEnter: Mousewheel.handleMouseEnter.bind(swiper),
+        handlemouseLeave: Mousewheel.handlemouseLeave.bind(swiper),
         lastScrollTime: Utils.now(),
       },
     });

--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -108,10 +108,10 @@ const Mousewheel = {
   handle(event) {
     let e = event;
     const swiper = this;
+    const params = swiper.params.mousewheel;
 
     if (!swiper.mouseEntered && !params.releaseOnEdges) return true;
 
-    const params = swiper.params.mousewheel;
     if (e.originalEvent) e = e.originalEvent; // jquery fix
     let delta = 0;
     const rtlFactor = swiper.rtl ? -1 : 1;

--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -191,8 +191,8 @@ const Mousewheel = {
     if (swiper.params.mousewheel.eventsTarged !== 'container') {
       target = $(swiper.params.mousewheel.eventsTarged);
     }
-    target.on("mouseenter", swiper.mousewheel.handleMouseEnter);
-    target.on("mouseenter", swiper.mousewheel.handleMouseLeave);
+    target.on('mouseenter', swiper.mousewheel.handleMouseEnter);
+    target.on('mouseenter', swiper.mousewheel.handleMouseLeave);
     target.on(Mousewheel.event, swiper.mousewheel.handle);
     swiper.mousewheel.enabled = true;
     return true;


### PR DESCRIPTION
Fix Issue #2513 I raised earlier today. 

Added mouseenter and mouseleave handlers to set a flag which conditionally lets the mousewheel handler complete. If the scroll/ mousewheel event is triggered while the mouse is on an element that is not a Swiper element, the event will not propagate.