### PR TITLE
Snap to nearest snap point in slide reset

### DIFF
--- a/src/components/core/slide/slideReset.js
+++ b/src/components/core/slide/slideReset.js
@@ -1,5 +1,19 @@
 /* eslint no-unused-vars: "off" */
 export default function (speed = this.params.speed, runCallbacks = true, internal) {
   const swiper = this;
-  return swiper.slideTo(swiper.activeIndex, speed, runCallbacks, internal);
+  let index = swiper.activeIndex;
+  const snapIndex = Math.floor(index / swiper.params.slidesPerGroup);
+
+  if (snapIndex < swiper.snapGrid.length - 1) {
+    const translate = swiper.rtl ? swiper.translate : -swiper.translate;
+
+    const currentSnap = swiper.snapGrid[snapIndex];
+    const nextSnap = swiper.snapGrid[snapIndex + 1];
+
+    if ((translate - currentSnap) > (nextSnap - currentSnap) / 2) {
+      index += swiper.params.slidesPerGroup;
+    }
+  }
+
+  return swiper.slideTo(index, speed, runCallbacks, internal);
 }


### PR DESCRIPTION
Currently the swiper will "reset" to the current snap point, even if the next snap point is actually closer. This pull request checks if the current or next snap point is closer to the current translation, and afterwards snaps to the one that is closer.

Fix #2485 
