### PR TITLE
fixed breakpoint with loop getting wrong realIndex when on init

### DIFF
--- a/src/components/core/breakpoints/setBreakpoint.js
+++ b/src/components/core/breakpoints/setBreakpoint.js
@@ -2,7 +2,9 @@ import Utils from '../../../utils/utils';
 
 export default function () {
   const swiper = this;
-  const { activeIndex, loopedSlides = 0, params } = swiper;
+  const {
+    activeIndex, initialized, loopedSlides = 0, params,
+  } = swiper;
   const breakpoints = params.breakpoints;
   if (!breakpoints || (breakpoints && Object.keys(breakpoints).length === 0)) return;
   // Set breakpoint for window width and update parameters
@@ -21,7 +23,7 @@ export default function () {
 
     swiper.currentBreakpoint = breakpoint;
 
-    if (needsReLoop) {
+    if (needsReLoop && initialized) {
       swiper.loopDestroy();
       swiper.loopCreate();
       swiper.updateSlides();


### PR DESCRIPTION
fix #2566

Fixed using breakpoint with loop will get wrong realIndex on init. Using `swiper.initialized` to prevent `slideTo` when init swiper.