### PR TITLE
Swiper Module Bug

### DIFF
--- a/src/components/core/update/updateProgress.js
+++ b/src/components/core/update/updateProgress.js
@@ -1,6 +1,6 @@
 import Utils from '../../../utils/utils';
 
-export default function (translate = this.translate || 0) {
+export default function (translate = this && this.translate || 0) {
   const swiper = this;
   const params = swiper.params;
 

--- a/src/components/core/update/updateSlidesProgress.js
+++ b/src/components/core/update/updateSlidesProgress.js
@@ -1,4 +1,4 @@
-export default function (translate = this.translate || 0) {
+export default function (translate = this && this.translate || 0) {
   const swiper = this;
   const params = swiper.params;
 


### PR DESCRIPTION
Fixed issue where when swiper was imported as a module it would throw errors because 'this' was undefined.