### PR TITLE
Fix loop behavior (Issue #2647)

### DIFF
--- a/src/components/core/loop/loopFix.js
+++ b/src/components/core/loop/loopFix.js
@@ -19,7 +19,7 @@ export default function () {
     if (slideChanged && diff !== 0) {
       swiper.setTranslate((rtl ? -swiper.translate : swiper.translate) - diff);
     }
-  } else if ((params.slidesPerView === 'auto' && activeIndex >= loopedSlides * 2) || (activeIndex > slides.length - (params.slidesPerView * 2))) {
+  } else if ((params.slidesPerView === 'auto' && activeIndex >= loopedSlides * 2) || (activeIndex >= slides.length - loopedSlides)) {
     // Fix For Positive Oversliding
     newIndex = -slides.length + activeIndex + loopedSlides;
     newIndex += loopedSlides;


### PR DESCRIPTION
Fixed loop behavior, which reported in issue #2647.

In 10 slides and 2.5 slidesPerView case,

* Left arrow button stops between Slide 9 and Slide 8 => Fixed
* 2 swipes are need to move from Slide 9 to Slide 8 => Fixed
* Slide 8 is often not shown in left of Slide 9 => Fixed

Test is at https://jsfiddle.net/kochizufan/su1ka5ov/