### PR TITLE
Fix swiper.onClick don't occur in Chrome on Old Android OS

### DIFF
--- a/src/components/core/events/onTouchMove.js
+++ b/src/components/core/events/onTouchMove.js
@@ -71,6 +71,7 @@ export default function (event) {
 
   const diffX = touches.currentX - touches.startX;
   const diffY = touches.currentY - touches.startY;
+  if (swiper.params.threshold && Math.sqrt(Math.pow(diffX, 2) + Math.pow(diffY, 2)) < swiper.params.threshold) return;
 
   if (typeof data.isScrolling === 'undefined') {
     let touchAngle;
@@ -87,7 +88,7 @@ export default function (event) {
   if (data.isScrolling) {
     swiper.emit('touchMoveOpposite', e);
   }
-  if (typeof startMoving === 'undefined') {
+  if (typeof data.startMoving === 'undefined') {
     if (touches.currentX !== touches.startX || touches.currentY !== touches.startY) {
       data.startMoving = true;
     }

--- a/src/components/core/events/onTouchMove.js
+++ b/src/components/core/events/onTouchMove.js
@@ -71,7 +71,7 @@ export default function (event) {
 
   const diffX = touches.currentX - touches.startX;
   const diffY = touches.currentY - touches.startY;
-  if (swiper.params.threshold && Math.sqrt(Math.pow(diffX, 2) + Math.pow(diffY, 2)) < swiper.params.threshold) return;
+  if (swiper.params.threshold && Math.sqrt((diffX ** 2) + (diffY ** 2)) < swiper.params.threshold) return;
 
   if (typeof data.isScrolling === 'undefined') {
     let touchAngle;


### PR DESCRIPTION
This PR fix swiper.onClick don't occur in Chrome on Old Android OS (Android Lollipop - Marshmallow)

This bug exists even in the latest Chrome, if Android OS is old.
The reason of this bug is, swiper.onTouchMove events are fired even subtle touch move in Old Android's Chrome

So, swiper.onTouchMove event forces to change swiper.allowTouch property to "false" every time, hence occurring of swiper.onClick is canceled in swiper.onTouchEnd.
To avoid this, I add the code
`
  if (swiper.params.threshold && Math.sqrt(Math.pow(diffX, 2) + Math.pow(diffY, 2)) < swiper.params.threshold) return;
`
in swiper.onTouchMove.
By this, if finger moving distance is less than params.threshold, swiper.allowTouch not change to false.
So, swiper.onClick event works.

If user don't set params.threshold value, this error still exists.
I have no idea to fix it.