### PR TITLE
#2730: Ensure observerUpdate event is only dispatched once on a MutationEvent

### DIFF
--- a/src/components/core/events/onTouchStart.js
+++ b/src/components/core/events/onTouchStart.js
@@ -1,6 +1,5 @@
 import { window, document } from 'ssr-window';
 import $ from '../../../utils/dom';
-import Device from '../../../utils/device';
 import Utils from '../../../utils/utils';
 
 export default function (event) {

--- a/src/modules/observer/observer.js
+++ b/src/modules/observer/observer.js
@@ -9,9 +9,18 @@ const Observer = {
 
     const ObserverFunc = Observer.func;
     const observer = new ObserverFunc((mutations) => {
-      mutations.forEach((mutation) => {
-        swiper.emit('observerUpdate', mutation);
-      });
+      // The observerUpdate event should only be triggered
+      // once despite the number of mutations.  Additional
+      // triggers are redundant and are very costly
+      const observerUpdate = function observerUpdate() {
+        swiper.emit('observerUpdate', mutations[0]);
+      };
+
+      if (window.requestAnimationFrame) {
+        window.requestAnimationFrame(observerUpdate);
+      } else {
+        window.setTimeout(observerUpdate, 0);
+      }
     });
 
     observer.observe(target, {


### PR DESCRIPTION
I found that the `observerUpdate` event is being dispatched for every mutation in a MutationEvent.

This causes serious performance issues depending on the number of mutations that are present in the MutationEvent.  I saw that all the methods that react to the `observerUpdate` will safely accommodate this change.  Calling `observerUpdate` multiple times will have the same end result as dispatching it once within a callstack.

And to make things run just a little smoother, I decided to add the ability to run this within an animation frame to help keep the ui from locking up.