### PR TITLE
Fix touch swiping in UWP app on surface tablets

### DIFF
--- a/src/components/core/classes/addClasses.js
+++ b/src/components/core/classes/addClasses.js
@@ -33,7 +33,7 @@ export default function () {
     suffixes.push('ios');
   }
   // WP8 Touch Events Fix
-  if (Browser.isIE && (Support.pointerEvents || Support.prefixedPointerEvents)) {
+  if ((Browser.isIE || Browser.isEdge) && (Support.pointerEvents || Support.prefixedPointerEvents)) {
     suffixes.push(`wp8-${params.direction}`);
   }
 

--- a/src/utils/browser.js
+++ b/src/utils/browser.js
@@ -7,6 +7,7 @@ const Browser = (function Browser() {
   }
   return {
     isIE: !!window.navigator.userAgent.match(/Trident/g) || !!window.navigator.userAgent.match(/MSIE/g),
+    isEdge: !!window.navigator.userAgent.match(/Edge/g),
     isSafari: isSafari(),
     isUiWebView: /(iPhone|iPod|iPad).*AppleWebKit(?!.*Safari)/i.test(window.navigator.userAgent),
   };


### PR DESCRIPTION
I want to use **swiper** in a Universal Windows Platform App (UWP) on a surface tablet.
The swiper does not work with touch events on this device, because UWP Apps on Windows 10 are using the Edge Browser.

It seems like the Edge Browser needs the `WP8 Touch Events Fix` in ` /src/components/core/classes/addClasses.js` too.
I've added the `isEdge` property to not confuse anyone.
Because it's not the Internet Explorer, but it behaves like that.