### PR TITLE
Remove swiper.virtual.update() from beforeInit callback

### DIFF
--- a/src/components/virtual/virtual.js
+++ b/src/components/virtual/virtual.js
@@ -170,8 +170,6 @@ export default {
       };
       Utils.extend(swiper.params, overwriteParams);
       Utils.extend(swiper.originalParams, overwriteParams);
-
-      swiper.virtual.update();
     },
     setTranslate() {
       const swiper = this;


### PR DESCRIPTION
This is a fix for: https://github.com/nolimits4web/swiper/issues/2755

Before, on `beforeInit` event, `swiper.virtual.update()` being executed when value for `swiper.activeIndex` was not set. That led to Swiper rendering `0`&`1` slides, even if the `initialSlide` was set to something else.

`virtual.update()` is not nessesary in the `beforeInit` callback, since its being called in the `setTranslate` callback and by that time `swiper.activeIndex` was initialised with the right  `initialSlide` value.

