### PR TITLE
Fixed handler unsubscription error on multiple create/destroy events …

### DIFF
--- a/src/utils/class.js
+++ b/src/utils/class.js
@@ -42,7 +42,7 @@ class SwiperClass {
     events.split(' ').forEach((event) => {
       if (typeof handler === 'undefined') {
         self.eventsListeners[event] = [];
-      } else {
+      } else if (self.eventsListeners[event] && self.eventsListeners[event].length) {
         self.eventsListeners[event].forEach((eventHandler, index) => {
           if (eventHandler === handler) {
             self.eventsListeners[event].splice(index, 1);


### PR DESCRIPTION
In case of empty listeners `self.eventsListeners[event]` this code brokes `self.eventsListeners[event].forEach()`