### PR TITLE
normally calculate break points;

### DIFF
--- a/src/components/core/breakpoints/getBreakpoint.js
+++ b/src/components/core/breakpoints/getBreakpoint.js
@@ -11,7 +11,7 @@ export default function (breakpoints) {
   points.sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
   for (let i = 0; i < points.length; i += 1) {
     const point = points[i];
-    if (point >= window.innerWidth && !breakpoint) {
+    if (point <= window.innerWidth) {
       breakpoint = point;
     }
   }


### PR DESCRIPTION
If during the development of the project the principle mobile first is used, it is not possible to normally calculate break points. 
I suggest calculating points to do the opposite for convenience.

For example:
```
breakpoints: {
            // when window width is >= 320px
            320: {
                slidesPerView: 2
            },
            // when window width is >= 768px
            768: {
                slidesPerView: 3
            },
            // when window width is >= 1170px
            1170: {
                slidesPerView: 4
            }
        }
```