### PR TITLE
Touch start prevent default option

### DIFF
--- a/src/components/core/defaults.js
+++ b/src/components/core/defaults.js
@@ -65,6 +65,7 @@ export default {
   allowTouchMove: true,
   threshold: 0,
   touchMoveStopPropagation: true,
+  touchStartPreventDefault: true,
   touchReleaseOnEdges: false,
 
   // Unique Navigation Elements

--- a/src/components/core/events/onTouchStart.js
+++ b/src/components/core/events/onTouchStart.js
@@ -64,7 +64,7 @@ export default function (event) {
     ) {
       document.activeElement.blur();
     }
-    if (preventDefault && swiper.allowTouchMove) {
+    if (preventDefault && swiper.allowTouchMove && swiper.touchStartPreventDefault) {
       e.preventDefault();
     }
   }


### PR DESCRIPTION
I have a window mousemove event to save x and y mouse coords.
I try to add the event with the capture option but on mousedown Swiper fire the prevent default.
I added this option `touchStartPreventDefault` to prevent this behavior, and manualy prevent default mousedown event only to an image inside the swiper-slide (for example).
Before this i try to change `touchEventsTarget` with for example `wrapper` but it doesn't work.

Example here:
https://codepen.io/exodusanto/pen/OovKEq?editors=0010

If you move the mouse the coords info change but if you start drag swiper the event mousemove freeze until you stop the drag.