### PR TITLE
Hot fix for touchStart prevent default issue

### DIFF
--- a/src/components/core/events/onTouchStart.js
+++ b/src/components/core/events/onTouchStart.js
@@ -65,7 +65,7 @@ export default function (event) {
     ) {
       document.activeElement.blur();
     }
-    if (preventDefault && swiper.allowTouchMove && swiper.touchStartPreventDefault) {
+    if (preventDefault && swiper.allowTouchMove && params.touchStartPreventDefault) {
       e.preventDefault();
     }
   }


### PR DESCRIPTION
Hot fix #2794 

I saw `swiper.allowTouchMove` and I thought that `swiper` has inside all params but you extends swiper instance and add `allowTouchMove` property on another file 😖.

I fix it with the correct `params` object