### PR TITLE
Add forcePreventDefault flag

### DIFF
--- a/src/components/core/defaults.js
+++ b/src/components/core/defaults.js
@@ -68,6 +68,7 @@ export default {
   threshold: 0,
   touchMoveStopPropagation: true,
   touchStartPreventDefault: true,
+  forcePreventDefault: false,
   touchReleaseOnEdges: false,
 
   // Unique Navigation Elements

--- a/src/components/core/events/onTouchStart.js
+++ b/src/components/core/events/onTouchStart.js
@@ -65,7 +65,9 @@ export default function (event) {
     ) {
       document.activeElement.blur();
     }
-    if (preventDefault && swiper.allowTouchMove && params.touchStartPreventDefault) {
+
+    const shouldPreventDefault = preventDefault && swiper.allowTouchMove && params.touchStartPreventDefault;
+    if (params.forcePreventDefault || shouldPreventDefault) {
       e.preventDefault();
     }
   }


### PR DESCRIPTION
There is a specific scenario where events in the slider will be blocked. I put a Stackblitz up to simulate the issue: https://stackblitz.com/edit/react-ts-iniqzm

- if I have a slide with an element inside
- the slide has a `noSwipingClass` set to `selected`, so when my element is select it will not slide
- in the container I have an event that happens `onMouseUp` that logs `hello` on the console
- if my element is not selected and I slide it will not trigger the `hello` event

I've been using an workaround by setting

```ts
this.swiper.touchEventsData.formElements = '*';
```

This way the current swiper code does this internally

```js
if ($(e.target).is(data.formElements)) preventDefault = false;
```

Which triggers the `event.preventDefault()` and allows my `hello` even to execute.

Instead of using this trick I would like to introduce a parameter `forcePreventDefault` so it someone else runs in a situation where they need to prevent default they can set this flag.

This PR introduces this new flag with the default value set to false, so it will not interfere in any existing behavior.