### PR TITLE
Fix incorrect calculation of the number of full columns.

### DIFF
--- a/src/components/core/update/updateSlides.js
+++ b/src/components/core/update/updateSlides.js
@@ -63,7 +63,7 @@ export default function () {
   let slideSize;
   const slidesPerColumn = params.slidesPerColumn;
   const slidesPerRow = slidesNumberEvenToRows / slidesPerColumn;
-  const numFullColumns = slidesPerRow - ((params.slidesPerColumn * slidesPerRow) - slidesLength);
+  const numFullColumns = Math.floor(slidesLength / params.slidesPerColumn);
   for (let i = 0; i < slidesLength; i += 1) {
     slideSize = 0;
     const slide = slides.eq(i);


### PR DESCRIPTION
In grid mode, the number of full columns is incorrectly calculated in updateSlides.js causing data-row-swiper to be incorrectly calculated and subsequently incorrect margins to be applied to the slides.

For example, a 8 x 3 grid (slidersPerView=3 and slidesPerColumn=8) yields 24 slides. If there are 17 slides in the collection then there are 2 full columns.

Existing logic calculated this as 3 - ((8 * 3) - 17) = -4. Clearly there cannot be -4 complete columns.

Correct logic should yield the integer component of (17 / 8) which is 2.
