### PR TITLE
fix wrong choose for module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Most modern mobile touch slider and framework with hardware accelerated transitions",
   "main": "dist/js/swiper.js",
   "jsnext:main": "dist/js/swiper.esm.bundle.js",
-  "module": "dist/js/swiper.esm.bundle.js",
+  "module": "dist/js/swiper.esm.js",
   "scripts": {
     "build:dev": "cross-env NODE_ENV=development gulp build",
     "build:prod": "cross-env NODE_ENV=production gulp build",


### PR DESCRIPTION
webpack default options for `resolve.mainFields` is module.In everyday habits we ignore `node_modules` in babel plugins.so if we ues es6 it will have some mistakes in the browser which is lower version
