### PR TITLE
Adds "[prefix]-initialized" Class to the Container Element.

### DIFF
--- a/src/components/core/classes/addClasses.js
+++ b/src/components/core/classes/addClasses.js
@@ -9,6 +9,7 @@ export default function () {
   } = swiper;
   const suffixes = [];
 
+  suffixes.push('initialized');
   suffixes.push(params.direction);
 
   if (params.freeMode) {


### PR DESCRIPTION
This could allow users to use CSS to hide/show elements in the HTML which only have relevance when the Slider is initialized.

For example, I might use CSS to hide the Pagination and Nav Buttons if the Slider is not Initialized.

    .swiper-container .swiper-pagination ,
    .swiper-container .swiper-button-prev ,
    .swiper-container .swiper-button-next {
      display: none;
    }
    .swiper-container-initialized .swiper-pagination ,
    .swiper-container-initialized .swiper-container .swiper-button-prev ,
    .swiper-container-initialized .swiper-container .swiper-button-next {
      display: initial;
    }
