### PR TITLE
fix: support pointerEvents

### DIFF
--- a/src/utils/support.js
+++ b/src/utils/support.js
@@ -7,7 +7,7 @@ const Support = (function Support() {
       return !!((window.navigator.maxTouchPoints > 0) || ('ontouchstart' in window) || (window.DocumentTouch && document instanceof window.DocumentTouch));
     }()),
 
-    pointerEvents: !!(window.navigator.pointerEnabled || window.PointerEvent || ('maxTouchPoints' in window.navigator)),
+    pointerEvents: !!(window.navigator.pointerEnabled || window.PointerEvent || ('maxTouchPoints' in window.navigator && window.navigator.maxTouchPoints > 0)),
     prefixedPointerEvents: !!window.navigator.msPointerEnabled,
 
     transition: (function checkTransition() {


### PR DESCRIPTION
pointerEvents: navigator.maxTouchPoints should > 0 , when pointerEnabled and PointerEvent no exitsts.
It's cause none simulate touch in chrome 49
```js
// src/components/core/events/index.js#L30
if (!Support.touch && (Support.pointerEvents || Support.prefixedPointerEvents)) {
  // actual go here
  target.addEventListener(touchEvents.start, swiper.onTouchStart, false);
  document.addEventListener(touchEvents.move, swiper.onTouchMove, capture);
  document.addEventListener(touchEvents.end, swiper.onTouchEnd, false);
} else {
  // should go here
  if (Support.touch) {
    const passiveListener = touchEvents.start === 'touchstart' && Support.passiveListener && params.passiveListeners ? { passive: true, capture: false } : false;
    target.addEventListener(touchEvents.start, swiper.onTouchStart, passiveListener);
    target.addEventListener(touchEvents.move, swiper.onTouchMove, Support.passiveListener ? { passive: false, capture } : capture);
    target.addEventListener(touchEvents.end, swiper.onTouchEnd, passiveListener);
  }
  if ((params.simulateTouch && !Device.ios && !Device.android) || (params.simulateTouch && !Support.touch && Device.ios)) {
    target.addEventListener('mousedown', swiper.onTouchStart, false);
    document.addEventListener('mousemove', swiper.onTouchMove, capture);
    document.addEventListener('mouseup', swiper.onTouchEnd, false);
  }
}
```
