### PR TITLE
Swiper shouldn't declare margins on top and bottom aswell

### DIFF
--- a/src/components/core/core.less
+++ b/src/components/core/core.less
@@ -1,5 +1,6 @@
 .swiper-container {
-  margin: 0 auto;
+  margin-left: auto;
+  margin-right: auto;
   position: relative;
   overflow: hidden;
   list-style: none;

--- a/src/components/core/core.scss
+++ b/src/components/core/core.scss
@@ -1,5 +1,6 @@
 .swiper-container {
-  margin: 0 auto;
+  margin-left: auto;
+  margin-right: auto;
   position: relative;
   overflow: hidden;
   list-style: none;


### PR DESCRIPTION
your sourcecode does this, which effectively overwrites my usage of margin-classes:
```css
.swiper-container {
  margin: 0 auto;
}
```

```html
<div class="some-gallery swiper-container   margin1">
    <div class="swiper-wrapper">
        ...
```

And I'd argue it's not swipers job to declare margin before or after it;
I like to avoid extra wrappers wherever possible. :)