### PR TITLE
Don't override Dom7 methods if already declared

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -80,7 +80,7 @@ const Methods = {
 };
 
 Object.keys(Methods).forEach((methodName) => {
-  $.fn[methodName] = Methods[methodName];
+  $.fn[methodName] = $.fn[methodName] || Methods[methodName];
 });
 
 export default $;


### PR DESCRIPTION
I'm using dom7 modular in a project together with swiper and patched some methods to be more jquery compatible (e.g. added second argument for toggleClass).

But now my methods gets randomly overidden (depending on webpacks processing order).
