### PR TITLE
Add "browser" field to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.5.0",
   "description": "Most modern mobile touch slider and framework with hardware accelerated transitions",
   "main": "dist/js/swiper.js",
+  "browser": "dist/js/swiper.js",
   "jsnext:main": "dist/js/swiper.esm.bundle.js",
   "module": "dist/js/swiper.esm.bundle.js",
   "scripts": {


### PR DESCRIPTION
When bundling the Swiper module using Webpack, the bundled js will cause a Syntax error in IE 11.

The reason is that Webpack will use the "module" field (since the default value of `mainFields` defined in Webpack is `["browser", "module", "main"]` ) as the entry point of Swiper.

As the class syntax inside the "module" entry point was not transpiled and then was bundled into the target js files, which will cause the Syntax error in IE 11, because IE 11 doesn't support the class syntax.

The relevant issue is #2978 