### PR TITLE
Make possible of work shift + mouse wheel (horizontal scroll)

### DIFF
--- a/src/components/core/events/onResize.js
+++ b/src/components/core/events/onResize.js
@@ -29,7 +29,6 @@ export default function () {
     if (params.autoHeight) {
       swiper.updateAutoHeight();
     }
-
   } else {
     swiper.updateSlidesClasses();
     if ((params.slidesPerView === 'auto' || params.slidesPerView > 1) && swiper.isEnd && !swiper.params.centeredSlides) {

--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -72,6 +72,11 @@ const Mousewheel = {
       pX = e.deltaX;
     }
 
+    if (e.shiftKey && !pX) { // if user scrolls with shift he wants horizontal scroll
+      pX = pY;
+      pY = 0;
+    }
+
     if ((pX || pY) && e.deltaMode) {
       if (e.deltaMode === 1) { // delta in LINE units
         pX *= LINE_HEIGHT;


### PR DESCRIPTION
When create swiper with horizontal scroll only (forceToAxis)
```
mousewheel: {
  forceToAxis: true,
  invert: true,
},
```
it doesn't scroll if try to scroll with `Shift + Scroll` combination

Checked in all browsers (except safari) + mobile + win touchpad, works fine