### PR TITLE
SlideSize to include paddings for border-box elements in IE (fixes #2897)

### DIFF
--- a/src/components/core/events/onResize.js
+++ b/src/components/core/events/onResize.js
@@ -29,7 +29,6 @@ export default function () {
     if (params.autoHeight) {
       swiper.updateAutoHeight();
     }
-
   } else {
     swiper.updateSlidesClasses();
     if ((params.slidesPerView === 'auto' || params.slidesPerView > 1) && swiper.isEnd && !swiper.params.centeredSlides) {

--- a/src/components/core/update/updateSlides.js
+++ b/src/components/core/update/updateSlides.js
@@ -1,6 +1,7 @@
 import { window } from 'ssr-window';
 import Utils from '../../../utils/utils';
 import Support from '../../../utils/support';
+import Browser from '../../../utils/browser';
 
 export default function () {
   const swiper = this;
@@ -128,7 +129,7 @@ export default function () {
           const marginLeft = parseFloat(slideStyles.getPropertyValue('margin-left'));
           const marginRight = parseFloat(slideStyles.getPropertyValue('margin-right'));
           const boxSizing = slideStyles.getPropertyValue('box-sizing');
-          if (boxSizing && boxSizing === 'border-box') {
+          if (boxSizing && boxSizing === 'border-box' && !Browser.isIE) {
             slideSize = width + marginLeft + marginRight;
           } else {
             slideSize = width + paddingLeft + paddingRight + marginLeft + marginRight;
@@ -140,7 +141,7 @@ export default function () {
           const marginTop = parseFloat(slideStyles.getPropertyValue('margin-top'));
           const marginBottom = parseFloat(slideStyles.getPropertyValue('margin-bottom'));
           const boxSizing = slideStyles.getPropertyValue('box-sizing');
-          if (boxSizing && boxSizing === 'border-box') {
+          if (boxSizing && boxSizing === 'border-box' && !Browser.isIE) {
             slideSize = height + marginTop + marginBottom;
           } else {
             slideSize = height + paddingTop + paddingBottom + marginTop + marginBottom;


### PR DESCRIPTION
In IE the width returned from `getPropertyValue('width')` on elements with a `box-sizing: border-box` styling doesn't include paddings as in other browsers.

This is an issue that arrises in IE when using `slidesPerView: 'auto'` and having paddings on each slide together with a `box-sizing: border-box;` styling on the slides.

Here's an example: https://s.codepen.io/DKvistgaard/debug/BXyZyx/XBrGRZbEvGGM

Also see the issue #2897 for more info.