### PR TITLE
fixed "swiper-slide-visible" className shows up when it shouldn't

### DIFF
--- a/demos/450-watchSlidesVisibility.html
+++ b/demos/450-watchSlidesVisibility.html
@@ -45,7 +45,7 @@
                 slider2</div>
             <div class="swiper-slide" style="background: #b7cc7d;">
                 slider3</div>
-            <div class="swiper-slide" style="background: #787a77;">
+            <div class="swiper-slide" style="background: #9eb75c;">
                 slider4</div>
             <div class="swiper-slide" style="background: #7da8cc;">
                 slider5</div>

--- a/demos/450-watchSlidesVisibility.html
+++ b/demos/450-watchSlidesVisibility.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>Swiper demo</title>
+    <!-- Link Swiper's CSS -->
+    <link rel="stylesheet" href="../dist/css/swiper.min.css">
+
+    <!-- Demo styles -->
+    <style>
+        html,
+        body {
+            position: relative;
+            height: 100%;
+        }
+
+        body {
+            background: #eee;
+            font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+            font-size: 14px;
+            color: #000;
+            margin: 0;
+            padding: 0;
+        }
+
+        .swiper-slide {
+            height: 300px;
+            background: #882525;
+            line-height: 300px;
+            text-align: center;
+        }
+    </style>
+</head>
+
+<body>
+    <!-- Swiper -->
+    <h3>Slider5 is visible when you slide to 2,3, or 4, and slider5 has "swiper-slide-visible" className</h3> <br>
+
+    <div class="swiper-container" id="swiper-container2" style="width:800px;">
+        <div class="swiper-wrapper">
+            <div class="swiper-slide active-slider">
+                slider1</div>
+            <div class="swiper-slide" style="background: #8acc7d;">
+                slider2</div>
+            <div class="swiper-slide" style="background: #b7cc7d;">
+                slider3</div>
+            <div class="swiper-slide" style="background: #787a77;">
+                slider4</div>
+            <div class="swiper-slide" style="background: #7da8cc;">
+                slider5</div>
+            <div class="swiper-slide" style="background: #9f7dcc;">
+                slider6</div>
+            <div class="swiper-slide" style="background: #96cc7d;">
+                slider7</div>
+            <div class="swiper-slide" style="background: #cc7dae;">
+                slider8</div>
+        </div>
+    </div>
+    <!-- Swiper JS -->
+    <script src="../dist/js/swiper.min.js"></script>
+    <!-- Initialize Swiper -->
+    <script>
+        var mySwiper2 = new Swiper('#swiper-container2', {
+            watchSlidesProgress: true,
+            watchSlidesVisibility: true,
+            slidesPerView: 3
+
+        })
+    </script>
+
+</body>
+
+</html>

--- a/src/components/core/update/updateSlidesProgress.js
+++ b/src/components/core/update/updateSlidesProgress.js
@@ -26,8 +26,8 @@ export default function (translate = (this && this.translate) || 0) {
     if (params.watchSlidesVisibility) {
       const slideBefore = -(offsetCenter - slide.swiperSlideOffset);
       const slideAfter = slideBefore + swiper.slidesSizesGrid[i];
-      const isVisible = (slideBefore >= 0 && slideBefore < swiper.size)
-                || (slideAfter > 0 && slideAfter <= swiper.size)
+      const isVisible = (slideBefore >= 0 && slideBefore < swiper.size - 1)
+                || (slideAfter > 1 && slideAfter <= swiper.size)
                 || (slideBefore <= 0 && slideAfter >= swiper.size);
       if (isVisible) {
         swiper.visibleSlides.push(slide);


### PR DESCRIPTION
Because in the “updateSlidesOffset” method,DOM offsetLeft and offsetTop do not compute decimals,So when slide offestLeft or offsetTop is decimal,  it will be issues. 
When you need to get the visibility parameters of slide, you will find that the invisible slide also has "swiper-slide-visible" className.
I set the error range between 1PX to control the visibility of the slider.
The example is in the demos files: "demos/450-watchSlidesVisibility.html"