### PR TITLE
Swapping main with module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "swiper",
   "version": "4.5.0",
   "description": "Most modern mobile touch slider and framework with hardware accelerated transitions",
-  "main": "dist/js/swiper.js",
+  "main": "dist/js/swiper.esm.bundle.js",
   "jsnext:main": "dist/js/swiper.esm.bundle.js",
-  "module": "dist/js/swiper.esm.bundle.js",
+  "module": "dist/js/swiper.js",
   "scripts": {
     "build:dev": "cross-env NODE_ENV=development gulp build",
     "build:prod": "cross-env NODE_ENV=production gulp build",


### PR DESCRIPTION
Right now [as per Webpack's documentation](https://webpack.js.org/configuration/resolve/), the `module` version is the one that's going to be resolved when it's required. However, `module` as it stands today, is not transpiled and has ES6 notation. Since mostly everyone excludes `/node_modules/` from their transpilation, it does not work and there are little workarounds around it. This is especially nasty for libraries that depend on Swiper such as React/Vue/Angular/nameYourFramework wrappers.

Either ESM gets transpiled (so no `class` nor `const` notation but imports are good to stay) or this which is the quickest win.

Fixes #3199 #3073
Also https://github.com/kidjp85/react-id-swiper/issues/332 and https://github.com/kidjp85/react-id-swiper/issues/317