### PR TITLE
Fixed #3025

### DIFF
--- a/src/components/core/loop/loopCreate.js
+++ b/src/components/core/loop/loopCreate.js
@@ -22,7 +22,7 @@ export default function () {
 
   if (params.slidesPerView === 'auto' && !params.loopedSlides) params.loopedSlides = slides.length;
 
-  swiper.loopedSlides = parseInt(params.loopedSlides || params.slidesPerView, 10);
+  swiper.loopedSlides = Math.ceil(parseFloat(params.loopedSlides || params.slidesPerView, 10));
   swiper.loopedSlides += params.loopAdditionalSlides;
   if (swiper.loopedSlides > slides.length) {
     swiper.loopedSlides = slides.length;


### PR DESCRIPTION
Modified **loopCreate()** to set *loopedSlides* to a float rounded up to the nearest whole number.

original line in **loopCreate()**
```
swiper.loopedSlides = parseInt(params.loopedSlides || params.slidesPerView, 10);
```
new line
```
swiper.loopedSlides = Math.ceil(parseFloat(params.loopedSlides || params.slidesPerView, 10));
```
This modification allows *slidesPerView* to be a float value while also being able to swipe next through the loop.

Test: https://plnkr.co/edit/T6Upr5sMv2j7sM7MPCkw?p=preview