### PR TITLE
Fixed #3126

### DIFF
--- a/src/components/core/events/onTouchEnd.js
+++ b/src/components/core/events/onTouchEnd.js
@@ -255,7 +255,8 @@ export default function (event) {
       swiper.slideTo(swiper.activeIndex);
       return;
     }
-    if (e.target.className !== 'swiper-button-next' && e.target.className !== 'swiper-button-prev') {
+    const isNavButtonTarget = swiper.navigation && (e.target === swiper.navigation.nextEl || e.target === swiper.navigation.prevEl);
+    if (!isNavButtonTarget) {
       if (swiper.swipeDirection === 'next') {
         swiper.slideTo(stopIndex + params.slidesPerGroup);
       }

--- a/src/components/core/events/onTouchEnd.js
+++ b/src/components/core/events/onTouchEnd.js
@@ -255,7 +255,7 @@ export default function (event) {
       swiper.slideTo(swiper.activeIndex);
       return;
     }
-    if(e.target.className !== 'swiper-button-next' && e.target.className !== 'swiper-button-prev') {
+    if (e.target.className !== 'swiper-button-next' && e.target.className !== 'swiper-button-prev') {
       if (swiper.swipeDirection === 'next') {
         swiper.slideTo(stopIndex + params.slidesPerGroup);
       }

--- a/src/components/core/events/onTouchEnd.js
+++ b/src/components/core/events/onTouchEnd.js
@@ -255,11 +255,13 @@ export default function (event) {
       swiper.slideTo(swiper.activeIndex);
       return;
     }
-    if (swiper.swipeDirection === 'next') {
-      swiper.slideTo(stopIndex + params.slidesPerGroup);
-    }
-    if (swiper.swipeDirection === 'prev') {
-      swiper.slideTo(stopIndex);
+    if(e.target.className != 'swiper-button-next' && e.target.className != 'swiper-button-prev') {
+      if (swiper.swipeDirection === 'next') {
+        swiper.slideTo(stopIndex + params.slidesPerGroup);
+      }
+      if (swiper.swipeDirection === 'prev') {
+        swiper.slideTo(stopIndex);
+      }
     }
   }
 }

--- a/src/components/core/events/onTouchEnd.js
+++ b/src/components/core/events/onTouchEnd.js
@@ -255,7 +255,7 @@ export default function (event) {
       swiper.slideTo(swiper.activeIndex);
       return;
     }
-    if(e.target.className != 'swiper-button-next' && e.target.className != 'swiper-button-prev') {
+    if(e.target.className !== 'swiper-button-next' && e.target.className !== 'swiper-button-prev') {
       if (swiper.swipeDirection === 'next') {
         swiper.slideTo(stopIndex + params.slidesPerGroup);
       }


### PR DESCRIPTION
Modified **onTouchEnd()** to check if the event target is either of the navigation buttons before short swiping

original block in **onTouchEnd()**
```
if (swiper.swipeDirection === 'next') {
    swiper.slideTo(stopIndex + params.slidesPerGroup);
}
if (swiper.swipeDirection === 'prev') {
    swiper.slideTo(stopIndex);
}
```
new block
```
if (e.target.className !== 'swiper-button-next' && e.target.className !== 'swiper-button-prev') {
      if (swiper.swipeDirection === 'next') {
        swiper.slideTo(stopIndex + params.slidesPerGroup);
      }
      if (swiper.swipeDirection === 'prev') {
        swiper.slideTo(stopIndex);
      }
}
```
This modification will prevent short swipes from firing when clicking on either of the navigation buttons

Test: https://plnkr.co/edit/1QlfdfMKiYKIDR2VLntQ?p=preview