### PR TITLE
Fixed #3029

### DIFF
--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -84,22 +84,22 @@ const Pagination = {
           for (let i = firstIndex; i <= lastIndex; i += 1) {
             bullets.eq(i).addClass(`${params.bulletActiveClass}-main`);
           }
-          if (bulletIndex >= bullets.length-params.dynamicMainBullets) {
-            for (let i = params.dynamicMainBullets; i >= 0; i--) {
-              bullets.eq(bullets.length - i).addClass(((params.bulletActiveClass) + "-main"));
+          if (bulletIndex >= bullets.length - params.dynamicMainBullets) {
+            for (let i = params.dynamicMainBullets; i >= 0; i -= 1) {
+              bullets.eq(bullets.length - i).addClass(`${params.bulletActiveClass}-main`);
             }
-            bullets.eq(bullets.length - (params.dynamicMainBullets+1)).addClass(((params.bulletActiveClass) + "-prev"));
+            bullets.eq(bullets.length - (params.dynamicMainBullets+1)).addClass(`${params.bulletActiveClass}-prev`);
           } else {
             $firstDisplayedBullet
               .prev()
-              .addClass(((params.bulletActiveClass) + "-prev"))
+              .addClass(`${params.bulletActiveClass}-prev`)
               .prev()
-              .addClass(((params.bulletActiveClass) + "-prev-prev"));
+              .addClass(`${params.bulletActiveClass}-prev-prev`);
             $lastDisplayedBullet
               .next()
-              .addClass(((params.bulletActiveClass) + "-next"))
+              .addClass(`${params.bulletActiveClass}-next`)
               .next()
-              .addClass(((params.bulletActiveClass) + "-next-next"));
+              .addClass(`${params.bulletActiveClass}-next-next`);
           }
         }
       }

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -76,6 +76,7 @@ const Pagination = {
         });
       } else {
         const $bullet = bullets.eq(current);
+        const bulletIndex = $bullet.index();
         $bullet.addClass(params.bulletActiveClass);
         if (params.dynamicBullets) {
           const $firstDisplayedBullet = bullets.eq(firstIndex);
@@ -83,16 +84,21 @@ const Pagination = {
           for (let i = firstIndex; i <= lastIndex; i += 1) {
             bullets.eq(i).addClass(`${params.bulletActiveClass}-main`);
           }
-          $firstDisplayedBullet
-            .prev()
-            .addClass(`${params.bulletActiveClass}-prev`)
-            .prev()
-            .addClass(`${params.bulletActiveClass}-prev-prev`);
-          $lastDisplayedBullet
-            .next()
-            .addClass(`${params.bulletActiveClass}-next`)
-            .next()
-            .addClass(`${params.bulletActiveClass}-next-next`);
+          if (bulletIndex === (bullets.length - 1)) {
+            bullets.eq(bulletIndex - 1).removeClass(((params.bulletActiveClass) + "-prev")).addClass(((params.bulletActiveClass) + "-main"));
+            bullets.eq(bulletIndex - 2).removeClass(((params.bulletActiveClass) + "-prev-prev")).addClass(((params.bulletActiveClass) + "-prev"));
+          } else {
+            $firstDisplayedBullet
+              .prev()
+              .addClass(((params.bulletActiveClass) + "-prev"))
+              .prev()
+              .addClass(((params.bulletActiveClass) + "-prev-prev"));
+            $lastDisplayedBullet
+              .next()
+              .addClass(((params.bulletActiveClass) + "-next"))
+              .next()
+              .addClass(((params.bulletActiveClass) + "-next-next"));
+          }
         }
       }
       if (params.dynamicBullets) {

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -84,9 +84,11 @@ const Pagination = {
           for (let i = firstIndex; i <= lastIndex; i += 1) {
             bullets.eq(i).addClass(`${params.bulletActiveClass}-main`);
           }
-          if (bulletIndex === (bullets.length - 1)) {
-            bullets.eq(bulletIndex - 1).removeClass(((params.bulletActiveClass) + "-prev")).addClass(((params.bulletActiveClass) + "-main"));
-            bullets.eq(bulletIndex - 2).removeClass(((params.bulletActiveClass) + "-prev-prev")).addClass(((params.bulletActiveClass) + "-prev"));
+          if (bulletIndex >= bullets.length-params.dynamicMainBullets) {
+            for (let i = params.dynamicMainBullets; i >= 0; i--) {
+              bullets.eq(bullets.length - i).addClass(((params.bulletActiveClass) + "-main"));
+            }
+            bullets.eq(bullets.length - (params.dynamicMainBullets+1)).addClass(((params.bulletActiveClass) + "-prev"));
           } else {
             $firstDisplayedBullet
               .prev()

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -84,11 +84,24 @@ const Pagination = {
           for (let i = firstIndex; i <= lastIndex; i += 1) {
             bullets.eq(i).addClass(`${params.bulletActiveClass}-main`);
           }
-          if (bulletIndex >= bullets.length - params.dynamicMainBullets) {
-            for (let i = params.dynamicMainBullets; i >= 0; i -= 1) {
-              bullets.eq(bullets.length - i).addClass(`${params.bulletActiveClass}-main`);
+          if (swiper.params.loop) {
+            if (bulletIndex >= bullets.length - params.dynamicMainBullets) {
+              for (let i = params.dynamicMainBullets; i >= 0; i -= 1) {
+                bullets.eq(bullets.length - i).addClass(`${params.bulletActiveClass}-main`);
+              }
+              bullets.eq(bullets.length - params.dynamicMainBullets - 1).addClass(`${params.bulletActiveClass}-prev`);
+            } else {
+              $firstDisplayedBullet
+                .prev()
+                .addClass(`${params.bulletActiveClass}-prev`)
+                .prev()
+                .addClass(`${params.bulletActiveClass}-prev-prev`);
+              $lastDisplayedBullet
+                .next()
+                .addClass(`${params.bulletActiveClass}-next`)
+                .next()
+                .addClass(`${params.bulletActiveClass}-next-next`);
             }
-            bullets.eq(bullets.length - (params.dynamicMainBullets + 1)).addClass(`${params.bulletActiveClass}-prev`);
           } else {
             $firstDisplayedBullet
               .prev()

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -88,7 +88,7 @@ const Pagination = {
             for (let i = params.dynamicMainBullets; i >= 0; i -= 1) {
               bullets.eq(bullets.length - i).addClass(`${params.bulletActiveClass}-main`);
             }
-            bullets.eq(bullets.length - (params.dynamicMainBullets+1)).addClass(`${params.bulletActiveClass}-prev`);
+            bullets.eq(bullets.length - (params.dynamicMainBullets + 1)).addClass(`${params.bulletActiveClass}-prev`);
           } else {
             $firstDisplayedBullet
               .prev()


### PR DESCRIPTION
This fixes the issue of pagination bullets at the end of a loop not having the ```-main``` class as per the ```dynamicMainBullets``` property [as described in the original issue](https://github.com/nolimits4web/swiper/issues/3029#issue-428709036).

Added a conditional in ```pagination.js``` to check if ```bulletIndex``` is at the end of the loop minus ```dynamicMainBullets```.

Test: https://plnkr.co/edit/JbSx3nijaSgs45qwXUr2?p=preview