### PR TITLE
Swiper4 - Use changedTouches instead of targetTouches inside of onTouchMove

### DIFF
--- a/src/components/core/events/index.js
+++ b/src/components/core/events/index.js
@@ -8,6 +8,9 @@ import onTouchEnd from './onTouchEnd';
 import onResize from './onResize';
 import onClick from './onClick';
 
+let dummyEventAttached = false;
+function dummyEventListener() {}
+
 function attachEvents() {
   const swiper = this;
   const {
@@ -37,6 +40,11 @@ function attachEvents() {
         target.addEventListener(touchEvents.start, swiper.onTouchStart, passiveListener);
         target.addEventListener(touchEvents.move, swiper.onTouchMove, Support.passiveListener ? { passive: false, capture } : capture);
         target.addEventListener(touchEvents.end, swiper.onTouchEnd, passiveListener);
+        
+        if (!dummyEventAttached) {
+          document.addEventListener('touchstart', dummyEventListener);
+          dummyEventAttached = true;
+        }
       }
       if ((params.simulateTouch && !Device.ios && !Device.android) || (params.simulateTouch && !Support.touch && Device.ios)) {
         target.addEventListener('mousedown', swiper.onTouchStart, false);

--- a/src/components/core/events/index.js
+++ b/src/components/core/events/index.js
@@ -40,7 +40,7 @@ function attachEvents() {
         target.addEventListener(touchEvents.start, swiper.onTouchStart, passiveListener);
         target.addEventListener(touchEvents.move, swiper.onTouchMove, Support.passiveListener ? { passive: false, capture } : capture);
         target.addEventListener(touchEvents.end, swiper.onTouchEnd, passiveListener);
-        
+
         if (!dummyEventAttached) {
           document.addEventListener('touchstart', dummyEventListener);
           dummyEventAttached = true;

--- a/src/components/core/events/onTouchMove.js
+++ b/src/components/core/events/onTouchMove.js
@@ -15,8 +15,9 @@ export default function (event) {
     return;
   }
   if (data.isTouchEvent && e.type === 'mousemove') return;
-  const pageX = e.type === 'touchmove' ? e.changedTouches[0].pageX : e.pageX;
-  const pageY = e.type === 'touchmove' ? e.changedTouches[0].pageY : e.pageY;
+  const targetTouch = e.type === 'touchmove' && e.targetTouches[0] && (e.targetTouches[0] || e.changedTouches[0]);
+  const pageX = e.type === 'touchmove' ? targetTouch.pageX : e.pageX;
+  const pageY = e.type === 'touchmove' ? targetTouch.pageY : e.pageY;
   if (e.preventedByNestedSwiper) {
     touches.startX = pageX;
     touches.startY = pageY;

--- a/src/components/core/events/onTouchMove.js
+++ b/src/components/core/events/onTouchMove.js
@@ -15,8 +15,8 @@ export default function (event) {
     return;
   }
   if (data.isTouchEvent && e.type === 'mousemove') return;
-  const pageX = e.type === 'touchmove' ? e.targetTouches[0].pageX : e.pageX;
-  const pageY = e.type === 'touchmove' ? e.targetTouches[0].pageY : e.pageY;
+  const pageX = e.type === 'touchmove' ? e.changedTouches[0].pageX : e.pageX;
+  const pageY = e.type === 'touchmove' ? e.changedTouches[0].pageY : e.pageY;
   if (e.preventedByNestedSwiper) {
     touches.startX = pageX;
     touches.startY = pageY;


### PR DESCRIPTION
_Copied from PR https://github.com/nolimits4web/swiper/pull/3259 for 4rd version_
Fixes #2956

MDN currently describes targetTouches as not supported but this isn't the case, at least in iOS 13.

Most of the time referencing targetTouches is ok however sometimes it doesn't contain any Touch objects inside the touchmove event. This happens when the drag was initiated outside of the Swiper container.