### PR TITLE
Add centeredSlidesBounds parameter. Prevents gaps at beginning and end…

### DIFF
--- a/src/components/core/update/updateSlides.js
+++ b/src/components/core/update/updateSlides.js
@@ -255,6 +255,20 @@ export default function () {
     } else slides.filter(slidesForMargin).css({ marginBottom: `${spaceBetween}px` });
   }
 
+  if (params.centeredSlides && params.centeredSlidesBounds) {
+    let allSlidesSize = 0;
+    slidesSizesGrid.forEach((slideSizeValue) => {
+      allSlidesSize += slideSizeValue + (params.spaceBetween ? params.spaceBetween : 0);
+    });
+    allSlidesSize -= params.spaceBetween;
+    const maxSnap = allSlidesSize - swiperSize;
+    snapGrid = snapGrid.map((snap) => {
+      if (snap < 0) return -offsetBefore;
+      if (snap > maxSnap) return maxSnap + offsetAfter;
+      return snap;
+    });
+  }
+
   if (params.centerInsufficientSlides) {
     let allSlidesSize = 0;
     slidesSizesGrid.forEach((slideSizeValue) => {


### PR DESCRIPTION
Adds `centeredSlidesBounds` parameter to prevent gaps at the beginning and end of the slider when `centeredSlide` is enabled.

It manipulates the `snapGrid` variable, but not the `slidesGrid` constant. Unknown any side effects associated with this, but it appears to function as expected in a number of situations.

Not intended to be used with `loop` or `pagination`.