### PR TITLE
Fixed #3005

### DIFF
--- a/src/components/core/check-overflow/index.js
+++ b/src/components/core/check-overflow/index.js
@@ -1,9 +1,16 @@
 
 function checkOverflow() {
   const swiper = this;
+  const params = swiper.params;
   const wasLocked = swiper.isLocked;
+  let lastSlidePosition = (params.slidesOffsetBefore + (params.spaceBetween * (swiper.slides.length - 1)) + ((swiper.slides[0]).offsetWidth) * swiper.slides.length)
 
-  swiper.isLocked = swiper.snapGrid.length === 1;
+  if ((typeof params.slidesOffsetBefore !== 'undefined' && params.slidesOffsetBefore !== 0) || (typeof params.slidesOffsetAfter !== 'undefined' && params.slidesOffsetAfter !== 0)) {
+    swiper.isLocked = lastSlidePosition <= swiper.size;
+  } else {
+    swiper.isLocked = swiper.snapGrid.length === 1;
+  }
+
   swiper.allowSlideNext = !swiper.isLocked;
   swiper.allowSlidePrev = !swiper.isLocked;
 

--- a/src/components/core/check-overflow/index.js
+++ b/src/components/core/check-overflow/index.js
@@ -3,9 +3,9 @@ function checkOverflow() {
   const swiper = this;
   const params = swiper.params;
   const wasLocked = swiper.isLocked;
-  const lastSlidePosition = (params.slidesOffsetBefore + (params.spaceBetween * (swiper.slides.length - 1)) + ((swiper.slides[0]).offsetWidth) * swiper.slides.length);
+  const lastSlidePosition = swiper.slides.length > 0 ? (params.slidesOffsetBefore + (params.spaceBetween * (swiper.slides.length - 1)) + ((swiper.slides[0]).offsetWidth) * swiper.slides.length) : undefined;
 
-  if ((typeof params.slidesOffsetBefore !== 'undefined' && params.slidesOffsetBefore !== 0) || (typeof params.slidesOffsetAfter !== 'undefined' && params.slidesOffsetAfter !== 0)) {
+  if (((typeof params.slidesOffsetBefore !== 'undefined' && params.slidesOffsetBefore !== 0) || (typeof params.slidesOffsetAfter !== 'undefined' && params.slidesOffsetAfter !== 0)) && lastSlidePosition !== 'undefined') {
     swiper.isLocked = lastSlidePosition <= swiper.size;
   } else {
     swiper.isLocked = swiper.snapGrid.length === 1;

--- a/src/components/core/check-overflow/index.js
+++ b/src/components/core/check-overflow/index.js
@@ -3,9 +3,9 @@ function checkOverflow() {
   const swiper = this;
   const params = swiper.params;
   const wasLocked = swiper.isLocked;
-  const lastSlidePosition = swiper.slides.length > 0 ? (params.slidesOffsetBefore + (params.spaceBetween * (swiper.slides.length - 1)) + ((swiper.slides[0]).offsetWidth) * swiper.slides.length) : undefined;
+  const lastSlidePosition = swiper.slides.length > 0 && (params.slidesOffsetBefore + (params.spaceBetween * (swiper.slides.length - 1)) + ((swiper.slides[0]).offsetWidth) * swiper.slides.length);
 
-  if (((typeof params.slidesOffsetBefore !== 'undefined' && params.slidesOffsetBefore !== 0) || (typeof params.slidesOffsetAfter !== 'undefined' && params.slidesOffsetAfter !== 0)) && lastSlidePosition !== 'undefined') {
+  if (params.slidesOffsetBefore && params.slidesOffsetAfter && lastSlidePosition) {
     swiper.isLocked = lastSlidePosition <= swiper.size;
   } else {
     swiper.isLocked = swiper.snapGrid.length === 1;

--- a/src/components/core/check-overflow/index.js
+++ b/src/components/core/check-overflow/index.js
@@ -3,7 +3,7 @@ function checkOverflow() {
   const swiper = this;
   const params = swiper.params;
   const wasLocked = swiper.isLocked;
-  let lastSlidePosition = (params.slidesOffsetBefore + (params.spaceBetween * (swiper.slides.length - 1)) + ((swiper.slides[0]).offsetWidth) * swiper.slides.length)
+  const lastSlidePosition = (params.slidesOffsetBefore + (params.spaceBetween * (swiper.slides.length - 1)) + ((swiper.slides[0]).offsetWidth) * swiper.slides.length);
 
   if ((typeof params.slidesOffsetBefore !== 'undefined' && params.slidesOffsetBefore !== 0) || (typeof params.slidesOffsetAfter !== 'undefined' && params.slidesOffsetAfter !== 0)) {
     swiper.isLocked = lastSlidePosition <= swiper.size;


### PR DESCRIPTION
Modified checkOverflow() to account for ```slidesOffsetBefore``` and ```slidesOffsetAfter```. This fixes a [bug](https://github.com/nolimits4web/swiper/issues/3005) where ```watchOverflow: true``` wouldn't work with ```slidesOffsetBefore``` and ```slidesOffsetAfter``` set to a non-zero value.

Test: https://plnkr.co/edit/o6gQxkfqcVjYEF3rPskx?p=preview