### PR TITLE
Fix issue with wrong row/column if not full groups

### DIFF
--- a/src/components/core/update/updateSlides.js
+++ b/src/components/core/update/updateSlides.js
@@ -82,8 +82,11 @@ export default function () {
       if (params.slidesPerColumnFill === 'row' && params.slidesPerGroup > 1) {
         const groupIndex = Math.floor(i / (params.slidesPerGroup * params.slidesPerColumn));
         const slideIndexInGroup = i - params.slidesPerColumn * params.slidesPerGroup * groupIndex;
-        row = Math.floor(slideIndexInGroup / params.slidesPerGroup);
-        column = (slideIndexInGroup - row * params.slidesPerGroup) + groupIndex * params.slidesPerGroup;
+        const columnsInGroup = groupIndex === 0 ?
+          params.slidesPerGroup :
+          Math.min(Math.ceil((slidesLength - groupIndex * slidesPerColumn * params.slidesPerGroup) / slidesPerColumn), params.slidesPerGroup);
+        row = Math.floor(slideIndexInGroup / columnsInGroup);
+        column = (slideIndexInGroup - row * columnsInGroup) + groupIndex * params.slidesPerGroup;
 
         newSlideOrderIndex = column + ((row * slidesNumberEvenToRows) / slidesPerColumn);
         slide

--- a/src/components/core/update/updateSlides.js
+++ b/src/components/core/update/updateSlides.js
@@ -82,9 +82,9 @@ export default function () {
       if (params.slidesPerColumnFill === 'row' && params.slidesPerGroup > 1) {
         const groupIndex = Math.floor(i / (params.slidesPerGroup * params.slidesPerColumn));
         const slideIndexInGroup = i - params.slidesPerColumn * params.slidesPerGroup * groupIndex;
-        const columnsInGroup = groupIndex === 0 ?
-          params.slidesPerGroup :
-          Math.min(Math.ceil((slidesLength - groupIndex * slidesPerColumn * params.slidesPerGroup) / slidesPerColumn), params.slidesPerGroup);
+        const columnsInGroup = groupIndex === 0
+          ? params.slidesPerGroup
+          : Math.min(Math.ceil((slidesLength - groupIndex * slidesPerColumn * params.slidesPerGroup) / slidesPerColumn), params.slidesPerGroup);
         row = Math.floor(slideIndexInGroup / columnsInGroup);
         column = (slideIndexInGroup - row * columnsInGroup) + groupIndex * params.slidesPerGroup;
 


### PR DESCRIPTION
Fix to issue #3222. Slides could get misplaced with wrong order and margin if `slidesPerColumnFill = row` and `slidesPerGroup > 1` and `slidesPerColumn > 1` and the last group was not filled up with slides.