### PR TITLE
Fix duration when freeModeSticky is active

### DIFF
--- a/src/components/core/events/onTouchEnd.js
+++ b/src/components/core/events/onTouchEnd.js
@@ -164,6 +164,24 @@ export default function (event) {
         } else {
           momentumDuration = Math.abs((newPosition - swiper.translate) / swiper.velocity);
         }
+        if (params.freeModeSticky) {
+          // If freeModeSticky is active and the user ends a swipe with a slow-velocity
+          // event, then durations can be 20+ seconds to slide one (or zero!) slides.
+          // It's easy to see this when simulating touch with mouse events. To fix this,
+          // limit single-slide swipes to the default slide duration. This also has the
+          // nice side effect of matching slide speed if the user stopped moving before
+          // lifting finger or mouse vs. moving slowly before lifting the finger/mouse.
+          // For faster swipes, also apply limits (albeit higher ones).
+          const moveDistance = Math.abs((rtl ? -newPosition : newPosition) - swiper.translate);
+          const currentSlideSize = swiper.slidesSizesGrid[swiper.activeIndex];
+          if (moveDistance < currentSlideSize) {
+            momentumDuration = params.speed;
+          } else if (moveDistance < 2 * currentSlideSize) {
+            momentumDuration = params.speed * 1.5;
+          } else {
+            momentumDuration = params.speed * 2.5;
+          }
+        }
       } else if (params.freeModeSticky) {
         swiper.slideToClosest();
         return;


### PR DESCRIPTION
This PR fixes #3301 by limiting the maximum swipe duration when `freeModeSticky` is active, as follows: 
* If the `moveDistance` is less than the current slide size, then the duration is limited to the default swipe speed (`params.speed`)
* If the `moveDistance` is 1x to 2x the current slide size, then the max duration is limited to 1.5x the default swipe speed
* Otherwise the max duration is limited to 2.5x the default swipe speed. 

The underlying problem is caused because the duration was previously calculated without taking into account the extra distance required to snap to the nearest slide when `freeModeSticky` is active.

You can use the same site from #3301 to verify that this PR is working: 
`git clone https://github.com/justingrant/swiper-repro.git && npm i && npm start`

To verify the PR is working, use the same repro steps from #3301.  You should see the desired behavior from #3301.
