### PR TITLE
Fix `freeModeSticky` resizing behavior to ensure it stays sticky after a resize

### DIFF
--- a/src/components/core/events/onResize.js
+++ b/src/components/core/events/onResize.js
@@ -20,23 +20,13 @@ export default function () {
   swiper.updateSize();
   swiper.updateSlides();
 
-  if (params.freeMode) {
-    const newTranslate = Math.min(Math.max(swiper.translate, swiper.maxTranslate()), swiper.minTranslate());
-    swiper.setTranslate(newTranslate);
-    swiper.updateActiveIndex();
-    swiper.updateSlidesClasses();
-
-    if (params.autoHeight) {
-      swiper.updateAutoHeight();
-    }
+  swiper.updateSlidesClasses();
+  if ((params.slidesPerView === 'auto' || params.slidesPerView > 1) && swiper.isEnd && !swiper.params.centeredSlides) {
+    swiper.slideTo(swiper.slides.length - 1, 0, false, true);
   } else {
-    swiper.updateSlidesClasses();
-    if ((params.slidesPerView === 'auto' || params.slidesPerView > 1) && swiper.isEnd && !swiper.params.centeredSlides) {
-      swiper.slideTo(swiper.slides.length - 1, 0, false, true);
-    } else {
-      swiper.slideTo(swiper.activeIndex, 0, false, true);
-    }
+    swiper.slideTo(swiper.activeIndex, 0, false, true);
   }
+
   if (swiper.autoplay && swiper.autoplay.running && swiper.autoplay.paused) {
     swiper.autoplay.run();
   }


### PR DESCRIPTION
This PR fixes #2708 by handling resizing in the same way regardless of whether `freeModeSticky` is active or not.  See https://github.com/nolimits4web/swiper/issues/2708#issuecomment-518935544 for an explanation of the problem and a description of the thinking behind this PR. 

You can use the same site from #3301 to verify that this PR is working: 
`git clone https://github.com/justingrant/swiper-repro.git && npm i && npm start`

To verify the PR is working, simply resize the browser. If the fix works, after resizing the slide should stick to the edges. (Without this fix, the slide will not be stuck to the edge after resizing.)
