### PR TITLE
Faster & smoother mousewheel inertial scrolling

### DIFF
--- a/src/components/core/slide/slideToClosest.js
+++ b/src/components/core/slide/slideToClosest.js
@@ -1,19 +1,30 @@
 /* eslint no-unused-vars: "off" */
-export default function (speed = this.params.speed, runCallbacks = true, internal) {
+export default function (speed = this.params.speed, runCallbacks = true, internal, threshold = 0.5) {
   const swiper = this;
   let index = swiper.activeIndex;
   const snapIndex = Math.floor(index / swiper.params.slidesPerGroup);
 
-  if (snapIndex < swiper.snapGrid.length - 1) {
-    const translate = swiper.rtlTranslate ? swiper.translate : -swiper.translate;
+  const translate = swiper.rtlTranslate ? swiper.translate : -swiper.translate;
 
+  if (translate >= swiper.snapGrid[snapIndex]) {
+    // The current translate is on or after the current snap index, so the choice
+    // is between the current index and the one after it.
     const currentSnap = swiper.snapGrid[snapIndex];
     const nextSnap = swiper.snapGrid[snapIndex + 1];
-
-    if ((translate - currentSnap) > (nextSnap - currentSnap) / 2) {
-      index = swiper.params.slidesPerGroup;
+    if ((translate - currentSnap) > (nextSnap - currentSnap) * threshold) {
+      index += swiper.params.slidesPerGroup;
+    }
+  } else {
+    // The current translate is before the current snap index, so the choice
+    // is between the current index and the one before it.
+    const prevSnap = swiper.snapGrid[snapIndex - 1];
+    const currentSnap = swiper.snapGrid[snapIndex];
+    if ((translate - prevSnap) <= (currentSnap - prevSnap) * threshold) {
+      index -= swiper.params.slidesPerGroup;
     }
   }
+  index = Math.max(index, 0);
+  index = Math.min(index, swiper.snapGrid.length - 1);
 
   return swiper.slideTo(index, speed, runCallbacks, internal);
 }


### PR DESCRIPTION
This PR fixes #3154 by enabling smoother and faster inertial scrolling when `freeModeSticky` is on. Changes include:
* Fixes the problem where you're "locked out" of wheel scrolling for a few hundred msecs after the end of a momentum wheel scroll. With this PR you can repeatedly scroll with wheel or two-finger trackpad gestures without any lags or pauses.
* Avoids the delay between the last `wheel` event and snapping to the closest edge. With this PR, the snap happens during the deceleration phase of the momentum scroll instead of waiting 500ms after the last `wheel` event is received, so the snap happens 600ms+ sooner than current behavior.
* Biases snapping in the direction of the scroll, instead of slowing down and then reversing a long distance.  If the projected end of the scroll is >20% of the current slide, then the scroll will continue to the edge of that slide without reversing.

The result isn't perfectly smooth inertial scrolling UX like we get with inertial scrolling for touch events. Even with this PR, there's still a noticeable velocity difference between the decelerating momentum scroll (slow velocity) and the snap (faster velocity). But the velocity difference is much smaller than current behavior, the snap is 600ms+ faster, and (IMHO) the overall UX is smoother than the current behavior.

Here's how it works:

A) Detect the final stages of a decelerating inertial scroll by analyzing the last 15 wheel events within a 500ms rolling window. When a new wheel event comes in, apply the following tests to the rolling window:
  1. do all events have decreasing or same ΔX? (If the delta is going up, then it's not a deceleration. Note: here and below, I'm saying ΔX but replace with ΔY for vertical slides.)
  2. did all events arrive in the last 500 msecs? (only respond to quick, automated decelerations not slow events caused by user actually moving the mousewheel/trackpad.)
  3. does the earliest event have an abs(ΔX) that's at least 1px larger than the most recent event? (otherwise it's not a deceleration!)
  4. does the latest event have a ΔX that's smaller than 6 pixels? (wait until it's almost at the end of a scroll when deltas are small)

B) If 1-4 above are all "yes" then we're near the end of a momentum scroll deceleration. Do the following:
  * i. clear the rolling window
  * ii. programmatically scroll to the next/prev snap point, depending on the scroll direction. Because there's remaining momentum in the scroll (remaining wheel events that we're going to ignore), and because it's more natural UX for scrolling to continue in the same direction as opposed to reversing, we'll bias the snap in the direction of the ongoing scroll.  Therefore, if it's already scrolled more than 20% of the current slide width in the current scroll direction, keep going to the end of that slide.  Otherwise reverse.
  * iii. ignore wheel events for 300 msecs after the last `wheel` event , UNLESS...
    * ...a new `wheel` event arrives with a larger or reverse-sign ΔX than the most recent event received during deceleration, which indicates that the user has started another scroll.  In this case, clear the "ignore wheel events" timeout and start storing events in a new rolling window.

C) However, if 1-4 above aren't satisfied, then wait to snap until 500ms after the last `wheel` event.  In other words, fall through to the existing behavior before this PR. This will handle cases where users are manually scrolling with the wheel (not momentum). This also ensures that if there's a problem (e.g. overloaded CPU) that prevents the algorithm from triggering, the behavior will match the current behavior before this PR.

Here's a test repo you can use to compare this PR to previous behavior: 
`git clone https://github.com/justingrant/swiper-repro.git && npm i && npm start`
