### PR TITLE
Use Math.pow() instead of ** operator

### DIFF
--- a/src/components/core/events/onTouchMove.js
+++ b/src/components/core/events/onTouchMove.js
@@ -72,7 +72,7 @@ export default function (event) {
 
   const diffX = touches.currentX - touches.startX;
   const diffY = touches.currentY - touches.startY;
-  if (swiper.params.threshold && Math.sqrt((diffX ** 2) + (diffY ** 2)) < swiper.params.threshold) return;
+  if (swiper.params.threshold && Math.sqrt(Math.pow(diffX, 2) + Math.pow(diffY, 2)) < swiper.params.threshold) return;
 
   if (typeof data.isScrolling === 'undefined') {
     let touchAngle;

--- a/src/components/zoom/zoom.js
+++ b/src/components/zoom/zoom.js
@@ -11,7 +11,7 @@ const Zoom = {
     const y1 = e.targetTouches[0].pageY;
     const x2 = e.targetTouches[1].pageX;
     const y2 = e.targetTouches[1].pageY;
-    const distance = Math.sqrt(((x2 - x1) ** 2) + ((y2 - y1) ** 2));
+    const distance = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
     return distance;
   },
   // Events


### PR DESCRIPTION
I'm getting `Unexpected token *` exceptions from the production server (Sentry) from Chrome 49 which is the latest possible version of Chrome on Win XP.

The reason is `**` operator which was introduced in ECMAScript 2016 (ES7). 

I can't see reasons not to use `Math.pow()`, it's even a bit more readable IMO because of fewer brackets.

PS. thank you for the outstanding swiper, IMO it's the best from zillions of slider plugins on GitHub.