### PR TITLE
[feature] thumbs options - add option to control multiple slide activation

### DIFF
--- a/src/components/thumbs/thumbs.js
+++ b/src/components/thumbs/thumbs.js
@@ -110,7 +110,7 @@ const Thumbs = {
       thumbsToActivate = swiper.params.slidesPerView;
     }
 
-    if (!swiper.params.thumbs.allowMultipleActiveSlides) {
+    if (!swiper.params.thumbs.multipleActiveThumbs) {
       thumbsToActivate = 1;
     }
 
@@ -132,7 +132,7 @@ export default {
   name: 'thumbs',
   params: {
     thumbs: {
-      allowMultipleActiveSlides: true,
+      multipleActiveThumbs: true,
       swiper: null,
       slideThumbActiveClass: 'swiper-slide-thumb-active',
       thumbsContainerClass: 'swiper-container-thumbs',

--- a/src/components/thumbs/thumbs.js
+++ b/src/components/thumbs/thumbs.js
@@ -110,6 +110,12 @@ const Thumbs = {
       thumbsToActivate = swiper.params.slidesPerView;
     }
 
+    if (!swiper.params.thumbs.allowMultipleActiveSlides) {
+      thumbsToActivate = 1;
+    }
+
+    thumbsToActivate = Math.floor(thumbsToActivate);
+
     thumbsSwiper.slides.removeClass(thumbActiveClass);
     if (thumbsSwiper.params.loop || (thumbsSwiper.params.virtual && thumbsSwiper.params.virtual.enabled)) {
       for (let i = 0; i < thumbsToActivate; i += 1) {
@@ -126,6 +132,7 @@ export default {
   name: 'thumbs',
   params: {
     thumbs: {
+      allowMultipleActiveSlides: true,
       swiper: null,
       slideThumbActiveClass: 'swiper-slide-thumb-active',
       thumbsContainerClass: 'swiper-container-thumbs',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22181589/67963575-1fc8db00-fbff-11e9-9287-784ee457670e.png)

In this image we use slidesPerView of 1.5 for the main images, the connected thumbnail slider uses this value to activate multiple thumbnails. In our usecase we only want the first (real) slide to get activated. CSS workarounds would be ugly or impossible.  

That's why I suggest to add an option for it. I've set the default value to the current behaviour. Additionally i rounded down the thumbsToActivate value in case someone is using it (as we did) with a fractional value (a small logic fix).
