### PR TITLE
Fixed #3084

### DIFF
--- a/src/utils/class.js
+++ b/src/utils/class.js
@@ -30,11 +30,11 @@ class SwiperClass {
     const self = this;
     if (typeof handler !== 'function') return self;
     function onceHandler(...args) {
-      handler.apply(self, args);
       self.off(events, onceHandler);
       if (onceHandler.f7proxy) {
         delete onceHandler.f7proxy;
       }
+      handler.apply(self, args);
     }
     onceHandler.f7proxy = handler;
     return self.on(events, onceHandler, priority);


### PR DESCRIPTION
Modified class.js ```once``` event listener. Moved ```handler.apply(self, args)``` to run after ```if (onceHandler.f7proxy)```. This should fix a bug where this event runs more than once. See [issue 3084](https://github.com/nolimits4web/swiper/issues/3084).