### PR TITLE
fix: should judge existence of `navigation` in a11y module

### DIFF
--- a/src/components/a11y/a11y.js
+++ b/src/components/a11y/a11y.js
@@ -61,7 +61,7 @@ const a11y = {
   updateNavigation() {
     const swiper = this;
 
-    if (swiper.params.loop) return;
+    if (swiper.params.loop || !swiper.navigation) return;
     const { $nextEl, $prevEl } = swiper.navigation;
 
     if ($prevEl && $prevEl.length > 0) {


### PR DESCRIPTION
I found this bug when I was investigating a problem, that user specified `init()` callback not be fired when we have only one initial slide.

My trace route is: `init() > swiper.preloadImages() > swiper.update() > swiper.updateProgress() > swiper.emit('reachEnd toEdge') > a11y::on::toEdge() > swiper.a11y.updateNavigation()`.

Since we haven't met this problem ever before, I think it may be a recent change to cause it easier?