### PR TITLE
FIX scroll wheel unwanted frozen effect

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -34,8 +34,8 @@
     }
     .swiper-container {
         width: 100%;
-        height: 300px;
-        margin: 50px auto;
+        height: 100vh;
+        margin: 0 auto 200px;
     }
     .swiper-slide {
         background: #f1f1f1;
@@ -57,8 +57,10 @@
             scrollbar: {
               el: '.swiper-scrollbar',
             },
+            direction: "vertical",
             mousewheel: {
               enabled: true,
+              releaseOnEdges: true
             },
             keyboard: {
               enabled: true,

--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -160,7 +160,7 @@ const Mousewheel = {
       // Freemode or scrollContainer:
 
       // If we recently snapped after a momentum scroll, then ignore wheel events
-      // to give time for the declereration to finish. Stop ignoring after 500 msecs
+      // to give time for the deceleration to finish. Stop ignoring after 500 msecs
       // or if it's a new scroll (larger delta or inverse sign as last event before
       // an end-of-momentum snap).
       const newEvent = { time: Utils.now(), delta: Math.abs(delta), direction: Math.sign(delta) };


### PR DESCRIPTION
As I've already well explained in this two issues (nolimits4web/swiper#3325 and nolimits4web/swiper#3326) the user experience scrolling the slider was very bad due to the _momentum_ of the mouse/trackpad. This was particularly visible on Mac OS.

I've been fixing the behaviour by instructing the script to animate the slider when only if the scroll direction has changed or the scroll delta has increased. These two are sufficient to differentiate the scroll events triggered by a user and the ones triggered by the _momentum_.

You can try it on my fork using the playground.