### PR TITLE
Add SCSS interpolation for --swiper-theme-color variable when not building from source

### DIFF
--- a/package/components/core/core.scss
+++ b/package/components/core/core.scss
@@ -1,5 +1,5 @@
 :root {
-  --swiper-theme-color: $themeColor;
+  --swiper-theme-color: #{$themeColor};
 }
 .swiper-container {
   margin-left: auto;


### PR DESCRIPTION
Add SCSS interpolation for `--swiper-theme-color` variable when not building from source.

See #3327 