### PR TITLE
[fix] use echo instead of node -e

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -6,7 +6,7 @@
   "jsnext:main": "js/swiper.esm.bundle.js",
   "module": "js/swiper.esm.bundle.js",
   "scripts": {
-    "postinstall": "node -e \"console.log('\\u001b[35m\\u001b[1mLove Swiper? Support Vladimir\\'s work by donating or pledging on patreon:\\u001b[22m\\u001b[39m\\n > \\u001b[32mhttps://patreon.com/vladimirkharlampidi\\u001b[0m\\n')\""
+    "postinstall": "echo \"\u001b[35m\u001b[1mLove Swiper? Support Vladimir's work by donating or pledging on patreon:\u001b[22m\u001b[39m\n > \u001b[32mhttps://patreon.com/vladimirkharlampidi\u001b[0m\n\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It will fix install issues with yarn berry (v2)

Currently install is broken on yarn berry due to an error with node -e.

```
# This file contains the result of Yarn building a package (swiper@npm:5.2.0)
# Script name: postinstall

[eval]:1
console.log('u001b[35mu001b[1mLove Swiper? Support Vladimir's work by donating or pledging on patreon:u001b[22mu001b[39mn > u001b[32mhttps://patreon.com/vladimirkharlampidiu001b[0mn')
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

SyntaxError: missing ) after argument list
    at new Script (vm.js:86:7)
    at createScript (vm.js:268:10)
    at Object.runInThisContext (vm.js:316:10)
    at Object.<anonymous> ([eval]-wrapper:9:26)
    at Module._compile (internal/modules/cjs/loader.js:945:30)
    at evalScript (internal/process/execution.js:80:25)
    at internal/main/eval_string.js:23:3
```

Use echo instead of node is a better choice because you are not dependant of node eval implementation. It also fix the issue.

Result : 
<img width="684" alt="image" src="https://user-images.githubusercontent.com/6277284/69876125-1181e380-12bf-11ea-8bf8-d66c2246632c.png">
