### PR TITLE
Implement `slidesPerGroupSkip` parameter

### DIFF
--- a/demos/211-slides-per-group-skip.html
+++ b/demos/211-slides-per-group-skip.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Swiper demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
+
+  <!-- Link Swiper's CSS -->
+  <link rel="stylesheet" href="../package/css/swiper.min.css">
+
+  <!-- Demo styles -->
+  <style>
+    body, html {
+        padding: 0;
+        margin: 0;
+        position: relative;
+        height: 100%;
+    }
+    .swiper-container {
+      width: 100%;
+      height: 100%;
+    }
+    .swiper-slide {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+    }
+    .swiper-slide img {
+        display: block;
+        width: 100%;
+    }
+    @media only screen and (min-width: 769px) {
+        .swiper-slide:first-child { transition: transform 100ms; }
+        .swiper-slide:first-child img { transition: box-shadow 500ms; }
+        .swiper-slide.swiper-slide-active:first-child { transform: translateX(50%); z-index: 2; }
+        .swiper-slide.swiper-slide-active:first-child img { box-shadow: 0px 32px 80px rgba(0,0,0,0.35); }
+        .swiper-slide:nth-child(2) { transition: transform 100ms; }
+        .swiper-slide.swiper-slide-next:nth-child(2) { transform: translateX(55%); z-index: 1; } 
+        .swiper-container[dir=rtl] .swiper-slide.swiper-slide-active:first-child { transform: translateX(-50%); }
+        .swiper-container[dir=rtl] .swiper-slide.swiper-slide-next:nth-child(2) { transform: translateX(-55%); } 
+    }
+  </style>
+</head>
+<body>
+  <!-- Swiper -->
+  <div class="swiper-container">
+    <div class="swiper-wrapper">
+      <div class="swiper-slide"><img src="//cdn.magloft.com/github/swiper/images/page-001.jpg"></div>
+      <div class="swiper-slide"><img src="//cdn.magloft.com/github/swiper/images/page-002.jpg"></div>
+      <div class="swiper-slide"><img src="//cdn.magloft.com/github/swiper/images/page-003.jpg"></div>
+      <div class="swiper-slide"><img src="//cdn.magloft.com/github/swiper/images/page-004.jpg"></div>
+      <div class="swiper-slide"><img src="//cdn.magloft.com/github/swiper/images/page-005.jpg"></div>
+      <div class="swiper-slide"><img src="//cdn.magloft.com/github/swiper/images/page-006.jpg"></div>
+      <div class="swiper-slide"><img src="//cdn.magloft.com/github/swiper/images/page-007.jpg"></div>
+      <div class="swiper-slide"><img src="//cdn.magloft.com/github/swiper/images/page-008.jpg"></div>
+      <div class="swiper-slide"><img src="//cdn.magloft.com/github/swiper/images/page-009.jpg"></div>
+    </div>
+    <div class="swiper-scrollbar"></div>
+    <div class="swiper-button-next"></div>
+    <div class="swiper-button-prev"></div>
+    <div class="swiper-pagination"></div>
+  </div>
+
+  <!-- Swiper JS -->
+  <script src="../package/js/swiper.min.js"></script>
+
+  <!-- Initialize Swiper -->
+  <script>
+    var swiper = new Swiper('.swiper-container', {
+      slidesPerView: 1,
+      centeredSlides: false,
+      slidesPerGroupSkip: 1,
+      grabCursor: true,
+      keyboard: { enabled: true },
+      breakpoints: { 769: { slidesPerView: 2, slidesPerGroup: 2 } },
+      scrollbar: { el: '.swiper-scrollbar' },
+      navigation: { nextEl: '.swiper-button-next', prevEl: '.swiper-button-prev' },
+      pagination: { el: '.swiper-pagination', clickable: true }
+    });
+  </script>
+</body>
+</html>

--- a/src/components/core/breakpoints/setBreakpoint.js
+++ b/src/components/core/breakpoints/setBreakpoint.js
@@ -14,7 +14,7 @@ export default function () {
   if (breakpoint && swiper.currentBreakpoint !== breakpoint) {
     const breakpointOnlyParams = breakpoint in breakpoints ? breakpoints[breakpoint] : undefined;
     if (breakpointOnlyParams) {
-      ['slidesPerView', 'spaceBetween', 'slidesPerGroup', 'slidesPerColumn'].forEach((param) => {
+      ['slidesPerView', 'spaceBetween', 'slidesPerGroup', 'slidesPerGroupSkip', 'slidesPerColumn'].forEach((param) => {
         const paramValue = breakpointOnlyParams[param];
         if (typeof paramValue === 'undefined') return;
         if (param === 'slidesPerView' && (paramValue === 'AUTO' || paramValue === 'auto')) {

--- a/src/components/core/defaults.js
+++ b/src/components/core/defaults.js
@@ -44,6 +44,7 @@ export default {
   slidesPerColumn: 1,
   slidesPerColumnFill: 'column',
   slidesPerGroup: 1,
+  slidesPerGroupSkip: 0,
   centeredSlides: false,
   centeredSlidesBounds: false,
   slidesOffsetBefore: 0, // in px

--- a/src/components/core/events/onTouchEnd.js
+++ b/src/components/core/events/onTouchEnd.js
@@ -238,11 +238,12 @@ export default function (event) {
   // Find current slide
   let stopIndex = 0;
   let groupSize = swiper.slidesSizesGrid[0];
-  for (let i = 0; i < slidesGrid.length; i += params.slidesPerGroup) {
-    if (typeof slidesGrid[i + params.slidesPerGroup] !== 'undefined') {
-      if (currentPos >= slidesGrid[i] && currentPos < slidesGrid[i + params.slidesPerGroup]) {
+  for (let i = 0; i < slidesGrid.length; i += (i < params.slidesPerGroupSkip ? 1 : params.slidesPerGroup)) {
+    const increment = (i < params.slidesPerGroupSkip - 1 ? 1 : params.slidesPerGroup);
+    if (typeof slidesGrid[i + increment] !== 'undefined') {
+      if (currentPos >= slidesGrid[i] && currentPos < slidesGrid[i + increment]) {
         stopIndex = i;
-        groupSize = slidesGrid[i + params.slidesPerGroup] - slidesGrid[i];
+        groupSize = slidesGrid[i + increment] - slidesGrid[i];
       }
     } else if (currentPos >= slidesGrid[i]) {
       stopIndex = i;
@@ -252,6 +253,7 @@ export default function (event) {
 
   // Find current slide size
   const ratio = (currentPos - slidesGrid[stopIndex]) / groupSize;
+  const increment = (stopIndex < params.slidesPerGroupSkip - 1 ? 1 : params.slidesPerGroup);
 
   if (timeDiff > params.longSwipesMs) {
     // Long touches
@@ -260,11 +262,11 @@ export default function (event) {
       return;
     }
     if (swiper.swipeDirection === 'next') {
-      if (ratio >= params.longSwipesRatio) swiper.slideTo(stopIndex + params.slidesPerGroup);
+      if (ratio >= params.longSwipesRatio) swiper.slideTo(stopIndex + increment);
       else swiper.slideTo(stopIndex);
     }
     if (swiper.swipeDirection === 'prev') {
-      if (ratio > (1 - params.longSwipesRatio)) swiper.slideTo(stopIndex + params.slidesPerGroup);
+      if (ratio > (1 - params.longSwipesRatio)) swiper.slideTo(stopIndex + increment);
       else swiper.slideTo(stopIndex);
     }
   } else {
@@ -276,13 +278,13 @@ export default function (event) {
     const isNavButtonTarget = swiper.navigation && (e.target === swiper.navigation.nextEl || e.target === swiper.navigation.prevEl);
     if (!isNavButtonTarget) {
       if (swiper.swipeDirection === 'next') {
-        swiper.slideTo(stopIndex + params.slidesPerGroup);
+        swiper.slideTo(stopIndex + increment);
       }
       if (swiper.swipeDirection === 'prev') {
         swiper.slideTo(stopIndex);
       }
     } else if (e.target === swiper.navigation.nextEl) {
-      swiper.slideTo(stopIndex + params.slidesPerGroup);
+      swiper.slideTo(stopIndex + increment);
     } else {
       swiper.slideTo(stopIndex);
     }

--- a/src/components/core/slide/slideNext.js
+++ b/src/components/core/slide/slideNext.js
@@ -2,12 +2,13 @@
 export default function (speed = this.params.speed, runCallbacks = true, internal) {
   const swiper = this;
   const { params, animating } = swiper;
+  const increment = swiper.activeIndex < params.slidesPerGroupSkip ? 1 : params.slidesPerGroup;
   if (params.loop) {
     if (animating) return false;
     swiper.loopFix();
     // eslint-disable-next-line
     swiper._clientLeft = swiper.$wrapperEl[0].clientLeft;
-    return swiper.slideTo(swiper.activeIndex + params.slidesPerGroup, speed, runCallbacks, internal);
+    return swiper.slideTo(swiper.activeIndex + increment, speed, runCallbacks, internal);
   }
-  return swiper.slideTo(swiper.activeIndex + params.slidesPerGroup, speed, runCallbacks, internal);
+  return swiper.slideTo(swiper.activeIndex + increment, speed, runCallbacks, internal);
 }

--- a/src/components/core/slide/slideTo.js
+++ b/src/components/core/slide/slideTo.js
@@ -10,8 +10,9 @@ export default function (index = 0, speed = this.params.speed, runCallbacks = tr
     return false;
   }
 
-  let snapIndex = Math.floor(slideIndex / params.slidesPerGroup);
-  if (snapIndex >= snapGrid.length) snapIndex = snapGrid.length - 1;
+  const skip = Math.min(swiper.params.slidesPerGroupSkip, slideIndex);
+  let snapIndex = skip + Math.floor((slideIndex - skip) / swiper.params.slidesPerGroup);
+  if (snapIndex >= slidesGrid.length) snapIndex = slidesGrid.length - 1;
 
   if ((activeIndex || params.initialSlide || 0) === (previousIndex || 0) && runCallbacks) {
     swiper.emit('beforeSlideChangeStart');

--- a/src/components/core/slide/slideToClosest.js
+++ b/src/components/core/slide/slideToClosest.js
@@ -2,7 +2,8 @@
 export default function (speed = this.params.speed, runCallbacks = true, internal, threshold = 0.5) {
   const swiper = this;
   let index = swiper.activeIndex;
-  const snapIndex = Math.floor(index / swiper.params.slidesPerGroup);
+  const skip = Math.min(swiper.params.slidesPerGroupSkip, index);
+  const snapIndex = skip + Math.floor((index - skip) / swiper.params.slidesPerGroup);
 
   const translate = swiper.rtlTranslate ? swiper.translate : -swiper.translate;
 
@@ -24,7 +25,7 @@ export default function (speed = this.params.speed, runCallbacks = true, interna
     }
   }
   index = Math.max(index, 0);
-  index = Math.min(index, swiper.snapGrid.length - 1);
+  index = Math.min(index, swiper.slidesGrid.length - 1);
 
   return swiper.slideTo(index, speed, runCallbacks, internal);
 }

--- a/src/components/core/update/updateActiveIndex.js
+++ b/src/components/core/update/updateActiveIndex.js
@@ -28,7 +28,8 @@ export default function (newActiveIndex) {
   if (snapGrid.indexOf(translate) >= 0) {
     snapIndex = snapGrid.indexOf(translate);
   } else {
-    snapIndex = Math.floor(activeIndex / params.slidesPerGroup);
+    const skip = Math.min(params.slidesPerGroupSkip, activeIndex);
+    snapIndex = skip + Math.floor((activeIndex - skip) / params.slidesPerGroup);
   }
   if (snapIndex >= snapGrid.length) snapIndex = snapGrid.length - 1;
   if (activeIndex === previousIndex) {

--- a/src/components/core/update/updateSlides.js
+++ b/src/components/core/update/updateSlides.js
@@ -195,7 +195,7 @@ export default function () {
       slidesGrid.push(slidePosition);
     } else {
       if (params.roundLengths) slidePosition = Math.floor(slidePosition);
-      if ((index) % params.slidesPerGroup === 0) snapGrid.push(slidePosition);
+      if ((index - Math.min(swiper.params.slidesPerGroupSkip, index)) % swiper.params.slidesPerGroup === 0) snapGrid.push(slidePosition);
       slidesGrid.push(slidePosition);
       slidePosition = slidePosition + slideSize + spaceBetween;
     }


### PR DESCRIPTION
**Problem / Current Limitation:**
The current `slidesPerGroup` implementation strictly enforces groups to be of constant size. Previously, a `slidesPerGroup = 'auto'` option has been requested, but implementation seems complex and cumbersome.

**Use Cases:**
- One of the use-cases for a more dynamic `slidesPerGroup` setting was the ability to treat a cover slide differently, to replicate a flipbook / magazine. see #1422
- For such use-case, the new property `slidesPerGroupSkip` allows users to configure the amount of slides to treat as single groups, before starting to swich into grouped mode.

**Example:**
http://cdn.magloft.com/github/swiper/index.html

**The parameter works in the following way:**
1. If `slidesPerGroupSkip` equals `0` (default), no slides are excluded from grouping, and the resulting behaviour is the same as without this change.
2. If `slidesPerGroupSkip` is equal or greater than `1` the first X slides are treated as single groups, whereas all following slides are grouped by the `slidesPerGroup` value.

**Additional Notes:**
- As both parameters`slidesPerGroup` and `slidesPerGroupSkip` support the `breakpoints` configuration, this can also be used to create a responsive reader that switches between `dual-spread` and `single-spread` based on available browser width.