### PR TITLE
Implement ratio breakpoints

### DIFF
--- a/demos/381-ratio-breakpoints.html
+++ b/demos/381-ratio-breakpoints.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Swiper demo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
+
+  <!-- Link Swiper's CSS -->
+  <link rel="stylesheet" href="../package/css/swiper.min.css">
+
+  <!-- Demo styles -->
+  <style>
+    html, body {
+      position: relative;
+      height: 100%;
+    }
+    body {
+      background: #eee;
+      font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+      font-size: 14px;
+      color:#000;
+      margin: 0;
+      padding: 0;
+    }
+    .swiper-container {
+      width: 100%;
+      height: 100%;
+    }
+    .swiper-slide {
+      text-align: center;
+      font-size: 18px;
+      background: #fff;
+
+      /* Center slide text vertically */
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: -webkit-flex;
+      display: flex;
+      -webkit-box-pack: center;
+      -ms-flex-pack: center;
+      -webkit-justify-content: center;
+      justify-content: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      -webkit-align-items: center;
+      align-items: center;
+    }
+  </style>
+</head>
+<body>
+  <!-- Swiper -->
+  <div class="swiper-container">
+    <div class="swiper-wrapper">
+      <div class="swiper-slide">Slide 1</div>
+      <div class="swiper-slide">Slide 2</div>
+      <div class="swiper-slide">Slide 3</div>
+      <div class="swiper-slide">Slide 4</div>
+      <div class="swiper-slide">Slide 5</div>
+      <div class="swiper-slide">Slide 6</div>
+      <div class="swiper-slide">Slide 7</div>
+      <div class="swiper-slide">Slide 8</div>
+      <div class="swiper-slide">Slide 9</div>
+      <div class="swiper-slide">Slide 10</div>
+    </div>
+    <!-- Add Pagination -->
+    <div class="swiper-pagination"></div>
+  </div>
+
+  <!-- Swiper JS -->
+  <script src="../package/js/swiper.min.js"></script>
+
+  <!-- Initialize Swiper -->
+  <script>
+    var swiper = new Swiper('.swiper-container', {
+      slidesPerView: 1,
+      spaceBetween: 10,
+      // init: false,
+      pagination: {
+        el: '.swiper-pagination',
+        clickable: true,
+      },
+      breakpoints: {
+        '@0.00': {
+          slidesPerView: 1,
+          spaceBetween: 10,
+        },
+        '@0.75': {
+          slidesPerView: 2,
+          spaceBetween: 20,
+        },
+        '@1.00': {
+          slidesPerView: 3,
+          spaceBetween: 40,
+        },
+        '@1.50': {
+          slidesPerView: 4,
+          spaceBetween: 50,
+        },
+      }
+    });
+  </script>
+</body>
+</html>

--- a/src/components/core/breakpoints/getBreakpoint.js
+++ b/src/components/core/breakpoints/getBreakpoint.js
@@ -4,14 +4,20 @@ export default function (breakpoints) {
   // Get breakpoint for window width
   if (!breakpoints) return undefined;
   let breakpoint = false;
-  const points = [];
-  Object.keys(breakpoints).forEach((point) => {
-    points.push(point);
+
+  const points = Object.keys(breakpoints).map((point) => {
+    if (typeof point === 'string' && point.startsWith('@')) {
+      const minRatio = parseFloat(point.substr(1));
+      const value = window.innerHeight * minRatio;
+      return { value, point };
+    }
+    return point;
   });
-  points.sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
+
+  points.sort((a, b) => parseInt(a.value, 10) - parseInt(b.value, 10));
   for (let i = 0; i < points.length; i += 1) {
-    const point = points[i];
-    if (point <= window.innerWidth) {
+    const { point, value } = points[i];
+    if (value <= window.innerWidth) {
       breakpoint = point;
     }
   }

--- a/src/components/core/breakpoints/getBreakpoint.js
+++ b/src/components/core/breakpoints/getBreakpoint.js
@@ -11,7 +11,7 @@ export default function (breakpoints) {
       const value = window.innerHeight * minRatio;
       return { value, point };
     }
-    return point;
+    return { value: point, point };
   });
 
   points.sort((a, b) => parseInt(a.value, 10) - parseInt(b.value, 10));


### PR DESCRIPTION
**Problem / Current Limitation:**
Currently, the `breakpoints` param only supports absolute unit values, e.g. the width of the window in pixels. For some applications, e.g. on mobile devices, this turns out to be a limitation, preventing an easy way to implement certain logic like portrait / landscape switches.

**Use Cases:**
- Implementing a breakpoint switch between portrait and landscape by using `@1.00` (width/height ratio above 1.00 / square).
- More granular control of slide layout, by tuning the ratio values to guarantee a certain width / height ratio of visible slides.

**Example:**
Located in [`demos/381-ratio-breakpoints.html`](https://github.com/MagLoft/swiper/blob/963f622d329568bc28fb639a6858178f3c6b8cf6/demos/381-ratio-breakpoints.html#L82)

**The parameter works in the following way:**
1. The `breakpoints` array parameter allows keys in string notation `'@X.XX': { ... }`, where `X.XX` represents the minimum aspect ratio (`width / height`) to trigger the breakpoint.
2. Provides compatibility and mixing with integer keys (current behaviour).