### PR TITLE
Remove redundant method call

### DIFF
--- a/src/components/core/slide/slideNext.js
+++ b/src/components/core/slide/slideNext.js
@@ -7,7 +7,6 @@ export default function (speed = this.params.speed, runCallbacks = true, interna
     swiper.loopFix();
     // eslint-disable-next-line
     swiper._clientLeft = swiper.$wrapperEl[0].clientLeft;
-    return swiper.slideTo(swiper.activeIndex + params.slidesPerGroup, speed, runCallbacks, internal);
   }
   return swiper.slideTo(swiper.activeIndex + params.slidesPerGroup, speed, runCallbacks, internal);
 }


### PR DESCRIPTION
Same method call runs after `if` block.
