### PR TITLE
Add label to formElements

### DIFF
--- a/src/components/core/core-class.js
+++ b/src/components/core/core-class.js
@@ -204,7 +204,7 @@ class Swiper extends SwiperClass {
         startTranslate: undefined,
         allowThresholdMove: undefined,
         // Form elements to match
-        formElements: 'input, select, option, textarea, button, video',
+        formElements: 'input, select, option, textarea, button, video, label',
         // Last click time
         lastClickTime: Utils.now(),
         clickTimeout: undefined,


### PR DESCRIPTION
Swiper.js currently prevents any mousedown/up events being fired within its container. _Except_ for form elements. However, it does not include `<label>` elements as being form elements.

Typically the label is also an element that can be interacted with within a form, like with checkboxes and radiobuttons. Especially if you create custom checkboxes and radiobuttons with only CSS, where you typically hide the actual checkbox/radiobutton `<input>` element via CSS and style the `<label>` (including its `:before` and `:after` pseudo elements) to represent the checkbox/radiobutton and its current visual state (using `input:checked ~ label`).

But in such a case this means the radiobutton or checkbox cannot actually be interacted with within a Swiper.js container, as the `<input>` element itself is hidden and any mousedown/up events on the  `<label>` are prevented by Swiper.js.

This PR simply adds `label` to the list of `formElements` for which there should be an exception.