### PR TITLE
fix zoom on wrong slide - #3450 #2827

### DIFF
--- a/src/components/zoom/zoom.js
+++ b/src/components/zoom/zoom.js
@@ -269,7 +269,7 @@ const Zoom = {
     const { gesture, image } = zoom;
 
     if (!gesture.$slideEl) {
-      gesture.$slideEl = swiper.clickedSlide ? $(swiper.clickedSlide) : swiper.slides.eq(swiper.activeIndex);
+      gesture.$slideEl = swiper.slides.eq(swiper.activeIndex);
       gesture.$imageEl = gesture.$slideEl.find('img, svg, canvas');
       gesture.$imageWrapEl = gesture.$imageEl.parent(`.${params.containerClass}`);
     }
@@ -355,7 +355,7 @@ const Zoom = {
     const { gesture } = zoom;
 
     if (!gesture.$slideEl) {
-      gesture.$slideEl = swiper.clickedSlide ? $(swiper.clickedSlide) : swiper.slides.eq(swiper.activeIndex);
+      gesture.$slideEl = swiper.slides.eq(swiper.activeIndex);
       gesture.$imageEl = gesture.$slideEl.find('img, svg, canvas');
       gesture.$imageWrapEl = gesture.$imageEl.parent(`.${params.containerClass}`);
     }


### PR DESCRIPTION
The API is saying 
- `mySwiper.zoom.in(); | Zoom in image of the currently active slide`
- `mySwiper.zoom.out(); | Zoom out image of the currently active slide`
~ https://swiperjs.com/api/#zoom

The issues #3450 and #2827 describe how to reproduce a bug that does not zoom into the _currently active slide_.

This fix sets the correct slide instead of zooming into the previous slide.
