### PR TITLE
Coverflow stretch percentage for responsiveness

### DIFF
--- a/src/components/effect-coverflow/effect-coverflow.js
+++ b/src/components/effect-coverflow/effect-coverflow.js
@@ -26,8 +26,13 @@ const Coverflow = {
       // var rotateZ = 0
       let translateZ = -translate * Math.abs(offsetMultiplier);
 
-      let translateY = isHorizontal ? 0 : params.stretch * (offsetMultiplier);
-      let translateX = isHorizontal ? params.stretch * (offsetMultiplier) : 0;
+      let stretch = params.stretch;
+      // Allow percentage to make a relative stretch for responsive sliders
+      if (typeof stretch === 'string' && stretch.indexOf('%') !== -1) {
+        stretch = ((parseFloat(params.stretch) / 100) * slideSize);
+      }
+      let translateY = isHorizontal ? 0 : stretch * (offsetMultiplier);
+      let translateX = isHorizontal ? stretch * (offsetMultiplier) : 0;
 
       // Fix for ultra small values
       if (Math.abs(translateX) < 0.001) translateX = 0;


### PR DESCRIPTION
For the coverflow effect, one can use `stretch` to define how many pixels the prev/next sliders go behind the front one. So if slider is 1000px, you can put `900` and only 10% is shown. However if this slider is responsive (width: 70% or something) and becomes 800px, 500px, etc. width, then the `900` is obviously wrong.

With this tiny PR, one can put `'10%'` instead, so stretch will be relative based on the actual width. I hope this can be approved as it's probably useful in plenty of today's responsive sites. Thanks!