### PR TITLE
Fix focus ring rendering glitch due to inherited page line-height.

### DIFF
--- a/src/components/navigation/navigation.less
+++ b/src/components/navigation/navigation.less
@@ -28,6 +28,7 @@
     letter-spacing: 0;
     text-transform: none;
     font-variant: initial;
+    line-height: 1;
   }
 }
 .swiper-button-prev,

--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -28,6 +28,7 @@
     letter-spacing: 0;
     text-transform: none;
     font-variant: initial;
+    line-height: 1;
   }
 }
 .swiper-button-prev,


### PR DESCRIPTION
**Before**:
![Screenshot 2020-04-21 at 11 37 43](https://user-images.githubusercontent.com/56371/79851684-f0cd3e00-83c5-11ea-96a8-d751053c99b5.png)

**After**:
![Screenshot 2020-04-21 at 11 52 55](https://user-images.githubusercontent.com/56371/79852263-b7e19900-83c6-11ea-91e3-da6af553665f.png)

Looks like the focus ring has a rendering glitch due to inherited page `line-height`, that is likely > 1.0. Set the pseudo-element `line-height` to a neutral value of 1.0 fixes it. 
Tested with latest Safari, Chrome and Firefox. 
 