### PR TITLE
Change aria-disabled attribute to disabled

### DIFF
--- a/src/components/a11y/a11y.js
+++ b/src/components/a11y/a11y.js
@@ -15,11 +15,11 @@ const a11y = {
     return $el;
   },
   disableEl($el) {
-    $el.attr('aria-disabled', true);
+    $el.attr('disabled', true);
     return $el;
   },
   enableEl($el) {
-    $el.attr('aria-disabled', false);
+    $el.attr('disabled', false);
     return $el;
   },
   onEnterKey(e) {


### PR DESCRIPTION
Disabled elements are being accessible via keyboard, in order to fix this I'm changing the aria-disabled attribute to disabled.

<img width="871" alt="Screen Shot 2020-04-24 at 11 37 59" src="https://user-images.githubusercontent.com/54283594/80236085-413fd800-8620-11ea-9e54-6fdf3d0ef340.png">
