### PR TITLE
Add an event on hash change

### DIFF
--- a/src/components/hash-navigation/hash-navigation.js
+++ b/src/components/hash-navigation/hash-navigation.js
@@ -5,6 +5,7 @@ import Utils from '../../utils/utils';
 const HashNavigation = {
   onHashCange() {
     const swiper = this;
+    swiper.emit('hashChange');
     const newHash = document.location.hash.replace('#', '');
     const activeSlideHash = swiper.slides.eq(swiper.activeIndex).attr('data-hash');
     if (newHash !== activeSlideHash) {

--- a/src/components/hash-navigation/hash-navigation.js
+++ b/src/components/hash-navigation/hash-navigation.js
@@ -19,10 +19,12 @@ const HashNavigation = {
     if (!swiper.hashNavigation.initialized || !swiper.params.hashNavigation.enabled) return;
     if (swiper.params.hashNavigation.replaceState && window.history && window.history.replaceState) {
       window.history.replaceState(null, null, (`#${swiper.slides.eq(swiper.activeIndex).attr('data-hash')}` || ''));
+      swiper.emit('hashSet');
     } else {
       const slide = swiper.slides.eq(swiper.activeIndex);
       const hash = slide.attr('data-hash') || slide.attr('data-history');
       document.location.hash = hash || '';
+      swiper.emit('hashSet');
     }
   },
   init() {


### PR DESCRIPTION
When using nested swipers you can check if you have hash navigated to a slide of the nested swiper with the slideChange event and position the main swiper on the slide where the nested swiper is located. However if the nested swiper slide that is being hash navigated is the active slide, the SlideChange event does not happen, hence the need for the HashChange event in this particular case.
