### PR TITLE
fix: only cancel cancelable touchmove events

### DIFF
--- a/src/components/core/events/onTouchMove.js
+++ b/src/components/core/events/onTouchMove.js
@@ -102,10 +102,10 @@ export default function (event) {
     return;
   }
   swiper.allowClick = false;
-  if (!params.cssMode) {
+  if (!params.cssMode && e.cancelable) {
     e.preventDefault();
   }
-  if (params.touchMoveStopPropagation && !params.nested) {
+  if (params.touchMoveStopPropagation && !params.nested && e.cancelable) {
     e.stopPropagation();
   }
 

--- a/src/components/core/events/onTouchMove.js
+++ b/src/components/core/events/onTouchMove.js
@@ -105,7 +105,7 @@ export default function (event) {
   if (!params.cssMode && e.cancelable) {
     e.preventDefault();
   }
-  if (params.touchMoveStopPropagation && !params.nested && e.cancelable) {
+  if (params.touchMoveStopPropagation && !params.nested) {
     e.stopPropagation();
   }
 


### PR DESCRIPTION
We are receiving a reasonable amount of ReportingObserver errors on our swiper component. The error is:
```
ReportingObserver [intervention]: Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted
```

To be honest I am not sure how to test this as I havent been able to trigger this issue myself, but I used this SO as reference and the error it self also exactly explains what the issue is: https://stackoverflow.com/questions/26478267/touch-move-getting-stuck-ignored-attempt-to-cancel-a-touchmove