### PR TITLE
FIX typo and update dates in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,34 @@
 # Change Log
 
-## [Swiper 5.4.0](https://github.com/nolimits4web/swiper/compare/v5.3.8...v5.4.0) - Released on May 15, 2020
+## [Swiper 5.4.0](https://github.com/nolimits4web/swiper/compare/v5.3.8...v5.4.0) - Released on May 15th, 2020
   * Hash Navigation
     * Added `hashChange` and `hashSet` events (#3557)
   * Lazy
     * Added support for `<picture>` lazy loading (#3560)
   * Mousewheel
-    * Potentially improved vertical scrolling issues on Windows/Linux
-  * Updated `ssr-window` and `dom7` dependencies to lates versions
+    * Potentially improved vertical scrolling issues on Windows/Linux OS
+  * Updated `ssr-window` and `dom7` dependencies to latest versions
   * Minor fixes
 
-## [Swiper 5.3.8](https://github.com/nolimits4web/swiper/compare/v5.3.7...v5.3.8) - Released on April 24, 2020
+## [Swiper 5.3.8](https://github.com/nolimits4web/swiper/compare/v5.3.7...v5.3.8) - Released on April 24th, 2020
   * Core
     * Fix iOS bug with double bounce on free mode momentum bounce
   * A11y
     * Fixed focus ring on navigation buttons (#3544)
     * Fixed RegExp issue in `paginationBulletMessage` (#3540, #3541)
   * Thumbs
-    * Added `thumbs.autoScrollOffset` parameter that allows to set on what thumbs active slide from edge it should automaticall move scroll thumbs
+    * Added `thumbs.autoScrollOffset` parameter that allows to set on what thumbs active slide from edge. 
+It should automaticall move scroll thumbs
   * Minor fixes
 
-## [Swiper 5.3.7](https://github.com/nolimits4web/swiper/compare/v5.3.6...v5.3.7) - Released on April 10, 2020
+## [Swiper 5.3.7](https://github.com/nolimits4web/swiper/compare/v5.3.6...v5.3.7) - Released on April 10th, 2020
   * Core
     * Fixed `cssMode` behavior in RTL layout
   * Zoom
     * Fixed issue with not working double-tap to toggle with virtual slides
   * Minor fixes
 
-## [Swiper 5.3.6](https://github.com/nolimits4web/swiper/compare/v5.3.1...v5.3.6) - Released on February 29, 2020
+## [Swiper 5.3.6](https://github.com/nolimits4web/swiper/compare/v5.3.1...v5.3.6) - Released on February 29th, 2020
   * Core
     * Fixed wrong auto height calculation with `centeredSlides` enabled
   * Lazy
@@ -40,12 +41,12 @@
     * `stretch` parameter now can be set in `%` (#3468)
   * Minor fixes
 
-## [Swiper 5.3.1](https://github.com/nolimits4web/swiper/compare/v5.3.0...v5.3.1) - Released on February 8, 2020
+## [Swiper 5.3.1](https://github.com/nolimits4web/swiper/compare/v5.3.0...v5.3.1) - Released on February 8th, 2020
   * Core
     * Fixed issue when slider could stuck after last slide (#3414)
     * Added `label` to list of form events to keep clicks on it (#3407)
 
-## [Swiper 5.3.0](https://github.com/nolimits4web/swiper/compare/v5.2.1...v5.3.0) - Released on January 11, 2020
+## [Swiper 5.3.0](https://github.com/nolimits4web/swiper/compare/v5.2.1...v5.3.0) - Released on January 11th, 2020
   * Core
     * New `slidesPerGroupSkip` behavior (#3361)
     * New ratio-based breakpoints (#3389)
@@ -54,7 +55,7 @@
     * Fixed issue when it can fail on load (#3383)
   * Minor fixes
 
-## [Swiper 5.2.1](https://github.com/nolimits4web/swiper/compare/v5.2.0...v5.2.1) - Released on November 16, 2019
+## [Swiper 5.2.1](https://github.com/nolimits4web/swiper/compare/v5.2.0...v5.2.1) - Released on November 16th, 2019
   * Core
     * New loop events `beforeLoopFix` and `loopFix`
     * New parameter `updateOnWindowResize` (by default `true`) that will update/recalc swiper on window resize/orientationchange
@@ -67,7 +68,7 @@
     * New `multipleActiveThumbs` (by default `true`) option to control whether multiple thumbnail slides may get activated or not.
   * Minor fixes
 
-## [Swiper 5.2.0](https://github.com/nolimits4web/swiper/compare/v5.1.0...v5.2.0) - Released on October 26, 2019
+## [Swiper 5.2.0](https://github.com/nolimits4web/swiper/compare/v5.1.0...v5.2.0) - Released on October 26th, 2019
   * Core
     * New `centeredSlidesBounds` parameter that when enabled will keep first and last slides at bounds
     * Fixed issue when `freeMode` could break position on resize (#2708, #3303)
@@ -81,7 +82,7 @@
     * Added minified version of browser.esm.bundle
   * Minor fixes
 
-## [Swiper 5.1.0](https://github.com/nolimits4web/swiper/compare/v5.0.4...v5.1.0) - Released on October 16, 2019
+## [Swiper 5.1.0](https://github.com/nolimits4web/swiper/compare/v5.0.4...v5.1.0) - Released on October 16th, 2019
   * Core
     * Fixed issues with touch on iOS 13
     * New `translateTo` method #3268
@@ -91,7 +92,7 @@
     * Fixed issue with pinch to zoom on Android
   * Minor fixes
 
-## [Swiper 5.0.4](https://github.com/nolimits4web/swiper/compare/v5.0.3...v5.0.4) - Released on September 30, 2019
+## [Swiper 5.0.4](https://github.com/nolimits4web/swiper/compare/v5.0.3...v5.0.4) - Released on September 30th, 2019
   * Core
     * Now on short swipes over navigation buttons, it will treat it like nav button click (#3237 by @robpop)
     * Fixed issue when passing float `slidesPerView` could break loop mode (#3225 by @robpop)
@@ -101,7 +102,7 @@
     * Fixed issue when it was `paused` after returning from hidden tab
   * Minor fixes
 
-## [Swiper 5.0.3](https://github.com/nolimits4web/swiper/compare/v5.0.2...v5.0.3) - Released on September 19, 2019
+## [Swiper 5.0.3](https://github.com/nolimits4web/swiper/compare/v5.0.2...v5.0.3) - Released on September 19th, 2019
   * Core
     * `touchEventsTarget` defaults back to `container`
     * Added handling of `touchcancel` event #3219
@@ -109,11 +110,11 @@
     * Fixed issue with slides missplacing when prepending slides in virutal mode
     * Fixed issue when zoomed image still swiped to another slide on mobiles
 
-## [Swiper 5.0.1](https://github.com/nolimits4web/swiper/compare/v5.0.0...v5.0.1) - Released on September 17, 2019
+## [Swiper 5.0.1](https://github.com/nolimits4web/swiper/compare/v5.0.0...v5.0.1) - Released on September 17th, 2019
   * Core
     * Fixed typo in code
 
-## [Swiper 5.0.0](https://github.com/nolimits4web/swiper/compare/v4.5.1...v5.0.0) - Released on September 17, 2019
+## [Swiper 5.0.0](https://github.com/nolimits4web/swiper/compare/v4.5.1...v5.0.0) - Released on September 17th, 2019
   * Core
     * All new CSS Scroll Snap mode (can be enabled with `cssMode: true`). It doesn't support all of Swiper's features, but potentially should bring a much better performance in simple configurations
     * Fully removed Internet Explorer support
@@ -138,7 +139,7 @@
     * With `--swiper-navigation-size` (defaults to `44px`) it is now possible to change size of the navigation buttons (and icons)
   * Minor fixes and improvements
 
-## [Swiper 4.5.1](https://github.com/nolimits4web/swiper/compare/v4.5.0...v4.5.1) - Released on September 13, 2019
+## [Swiper 4.5.1](https://github.com/nolimits4web/swiper/compare/v4.5.0...v4.5.1) - Released on September 13th, 2019
   * Core
     * Fixed issue when callbacks fires on init even if it disabled (#2807)
     * Fixed issue when "swiper-slide-visible" class name in some situations shows up when it shouldn't
@@ -153,7 +154,7 @@
     * Fixed issue when parallax opacity didn't work (#3147)
   * Minor fixes and improvements
 
-## [Swiper 4.5.0](https://github.com/nolimits4web/swiper/compare/v4.4.5...v4.5.0) - Released on February 22, 2019
+## [Swiper 4.5.0](https://github.com/nolimits4web/swiper/compare/v4.4.5...v4.5.0) - Released on February 22nd, 2019
   * Core
     * New `swiper.changeDirection()` method to change direction from horizontal to vertical (and back) dynamically
     * `direction` parameter can be used in breakpoints
@@ -172,11 +173,11 @@
     * Source styles are now available in SCSS in addition to LESS
   * Minor fixes and improvements
 
-## [Swiper 4.4.6](https://github.com/nolimits4web/swiper/compare/v4.4.5...v4.4.6) - Released on December 19, 2018
+## [Swiper 4.4.6](https://github.com/nolimits4web/swiper/compare/v4.4.5...v4.4.6) - Released on December 19th, 2018
   * Core
     * Fixed issue with wrong slide size calculation in some cases
 
-## [Swiper 4.4.5](https://github.com/nolimits4web/swiper/compare/v4.4.2...v4.4.5) - Released on December 14, 2018
+## [Swiper 4.4.5](https://github.com/nolimits4web/swiper/compare/v4.4.2...v4.4.5) - Released on December 14th, 2018
   * Core
     * New `observeSlideChildren` parameter to enable auto update on slide children update
     * Fixed issue when slide padding was not considered when calculating sizes
@@ -186,17 +187,17 @@
     * Now it emits `zoomChange` event with `scale`, `imageEl` and `slideEl` arguments
   * Minor fixes
 
-## [Swiper 4.4.2](https://github.com/nolimits4web/swiper/compare/v4.4.1...v4.4.2) - Released on November 1, 2018
+## [Swiper 4.4.2](https://github.com/nolimits4web/swiper/compare/v4.4.1...v4.4.2) - Released on November 1st, 2018
   * New `touchStartForcePreventDefault` parameter to force touch start event prevent default
   * Breakpoints fix when breakpoint keys are strings
   * Fixed issue when draggable scrollbar may not work on desktop Safari
   * Fixed issue with wrong sort of Virtual Slides
   * Minor fixes
 
-## [Swiper 4.4.1](https://github.com/nolimits4web/swiper/compare/v4.4.0...v4.4.1) - Released on September 14, 2018
+## [Swiper 4.4.1](https://github.com/nolimits4web/swiper/compare/v4.4.0...v4.4.1) - Released on September 14th, 2018
   * Fixed issue with preventing touchstart event
 
-## [Swiper 4.4.0](https://github.com/nolimits4web/swiper/compare/v4.3.5...v4.4.0) - Released on September 14, 2018
+## [Swiper 4.4.0](https://github.com/nolimits4web/swiper/compare/v4.3.5...v4.4.0) - Released on September 14th, 2018
   * Core
     * New `centerInsufficientSlides` parameter to center slides if the amount of slides less than `slidesPerView`
     * New `breakpointsInverse` parameter (boolean), if enabled then it will count breakpoints in reversed direction, e.g. will override parameters if window width is more than specified breakpoint
@@ -206,7 +207,7 @@
     * All new "Thumbs" module/component designed to control slider thumbnails, in more logical and correct way than with Controller module.
   * Lots of minor fixes
 
-## [Swiper 4.3.5](https://github.com/nolimits4web/swiper/compare/v4.3.3...v4.3.5) - Released on July 31, 2018
+## [Swiper 4.3.5](https://github.com/nolimits4web/swiper/compare/v4.3.3...v4.3.5) - Released on July 31th, 2018
   * Core
     * `iOSEdgeSwipeThreshold` parameter renamed to just `edgeSwipeThreshold`. Old `iOSEdgeSwipeThreshold` name is still supported
     * Improved observer performance if there are many mutations at a time. Thanks to @rayvincent-bsd
@@ -216,13 +217,13 @@
     * Fixed issue when it was using active event listeners instead of passive. Thanks to @nyon
   * Minor fixes
 
-## [Swiper 4.3.3](https://github.com/nolimits4web/swiper/compare/v4.3.2...v4.3.3) - Released on June 5, 2018
+## [Swiper 4.3.3](https://github.com/nolimits4web/swiper/compare/v4.3.2...v4.3.3) - Released on June 5th, 2018
   * Core
     * Fixed issue when slidePrev goes to wrong slide #2650
     * Fixed issue when roundLength was not considered for grids calculation #2656
     * Fixed typo in API #2659
 
-## [Swiper 4.3.2](https://github.com/nolimits4web/swiper/compare/v4.3.0...v4.3.2) - Released on June 1, 2018
+## [Swiper 4.3.2](https://github.com/nolimits4web/swiper/compare/v4.3.0...v4.3.2) - Released on June 1st, 2018
   * Core
     * Added `addSlide(index, slide)` method to add slide at required position. Thanks to @kochizufan
     * Fixed issue with loop #2647. Thanks to @kochizufan
@@ -231,7 +232,7 @@
     * New `formatFractionTotal(number)` parameter to format total number in Fraction pagination
   * Minor fixes
 
-## [Swiper 4.3.0](https://github.com/nolimits4web/swiper/compare/v4.2.6...v4.3.0) - Released on May 27, 2018
+## [Swiper 4.3.0](https://github.com/nolimits4web/swiper/compare/v4.2.6...v4.3.0) - Released on May 27th, 2018
   * Core
     * Fixed issue when `swipeBack` sometimes slides to wrong slide
     * Fixed issue when window resizing can break Coverflow effect layout
@@ -240,10 +241,10 @@
     * Fixed issue with remove event listeners when they was not added
   * Minor fixes
 
-## [Swiper 4.2.6](https://github.com/nolimits4web/swiper/compare/v4.2.5...v4.2.6) - Released on May 1, 2018
+## [Swiper 4.2.6](https://github.com/nolimits4web/swiper/compare/v4.2.5...v4.2.6) - Released on May 1st, 2018
   * `console.log` cleanup
 
-## [Swiper 4.2.5](https://github.com/nolimits4web/swiper/compare/v4.2.2...v4.2.5) - Released on April 29, 2018
+## [Swiper 4.2.5](https://github.com/nolimits4web/swiper/compare/v4.2.2...v4.2.5) - Released on April 29th, 2018
   * Core
     * Prevent apply grab cursor when swiper is locked
     * Fixed breakpoint with loop getting wrong realIndex when on init
@@ -254,7 +255,7 @@
     *Imporved internal events proxies logic for better memory management
   * Minor fixes
 
-## [Swiper 4.2.2](https://github.com/nolimits4web/swiper/compare/v4.2.0...v4.2.2) - Released on April 1, 2018
+## [Swiper 4.2.2](https://github.com/nolimits4web/swiper/compare/v4.2.0...v4.2.2) - Released on April 1st, 2018
   * Core
     * Respect and update breakpoints when calling Swiper's `.update()` method
   * Pagination
@@ -263,7 +264,7 @@
     * Fixed issue in `loop` + `freeMode` for loop not being set correctly
   * Minor fixes
 
-## [Swiper 4.2.0](https://github.com/nolimits4web/swiper/compare/v4.1.6...v4.2.0) - Released on March 16, 2018
+## [Swiper 4.2.0](https://github.com/nolimits4web/swiper/compare/v4.1.6...v4.2.0) - Released on March 16th, 2018
   * Core
     * `swiper.updateAutoHeight(speed)` now supports `speed` parameter to resize swiper wrapper with duration
     * Fixed issues in free mode with `freeModeSticky` not being able to snap to closest snap point
@@ -276,10 +277,10 @@
     * Fixed issue when lazy loading not always triggered on window resize
   * Minor fixes
 
-## [Swiper 4.1.6](https://github.com/nolimits4web/swiper/compare/v4.1.5...v4.1.6) - Released on February 11, 2018
+## [Swiper 4.1.6](https://github.com/nolimits4web/swiper/compare/v4.1.5...v4.1.6) - Released on February 11th, 2018
   * Fixed onTouchMoveOpposite event on touch devices
 
-## [Swiper 4.1.5](https://github.com/nolimits4web/swiper/compare/v4.1.0...v4.1.5) - Released on February 10, 2018
+## [Swiper 4.1.5](https://github.com/nolimits4web/swiper/compare/v4.1.0...v4.1.5) - Released on February 10th, 2018
   * Improved touch events support on desktop Windows devices with touch screen
   * Improved "loop fix" when slider is in the free mode
   * New `noSwipingSelector` parameter that can be used instead of `noSwipingClass`
@@ -296,7 +297,7 @@
     * Now supports Virtual Slides
   * Minor fixes
 
-## [Swiper 4.1.0](https://github.com/nolimits4web/swiper/compare/v4.0.7...v4.1.0) - Released on January 13, 2018
+## [Swiper 4.1.0](https://github.com/nolimits4web/swiper/compare/v4.0.7...v4.1.0) - Released on January 13th, 2018
   * Improved IE 10 support. But it is recommended to use [__proto__ polyfill](https://www.npmjs.com/package/proto-polyfill)
   * Improved touch support for Edge
   * New `watchOverflow` (disabled by default). When enabled Swiper will be disabled and hide navigation buttons on case there are not enough slides for sliding
@@ -306,20 +307,20 @@
   * Keyboard
     * New `onlyInViewport` parameter (enabled by default). When enabled it will control sliders that are currently in viewport
 
-## [Swiper 4.0.7](https://github.com/nolimits4web/swiper/compare/v4.0.6...v4.0.7) - Released on November 28, 2017
+## [Swiper 4.0.7](https://github.com/nolimits4web/swiper/compare/v4.0.6...v4.0.7) - Released on November 28th, 2017
   * Fixed issue with not working correctly `touchReleaseOnEdges` on iOS
   * Fixed issue with not working allowSlideNext/Prev change on Breakpoints
   * Fixed wrong scrollbar dragging when using custom `dragSize`
   * Minor fixes
 
-## [Swiper 4.0.6](https://github.com/nolimits4web/swiper/compare/v4.0.5...v4.0.6) - Released on November 13, 2017
+## [Swiper 4.0.6](https://github.com/nolimits4web/swiper/compare/v4.0.5...v4.0.6) - Released on November 13th, 2017
   * Fixed Coverflow effect issue using with breakpoints
   * `iOSEdgeSwipeDetection` will also be in consideration with right-edge swipe
   * Fixed `freeModeSticky` behavior in RTL mode
   * Swiper now emits `breakpoint` event on breakpoint change
   * Minor fixes
 
-## [Swiper 4.0.5](https://github.com/nolimits4web/swiper/compare/v4.0.3...v4.0.5) - Released on November 7, 2017
+## [Swiper 4.0.5](https://github.com/nolimits4web/swiper/compare/v4.0.3...v4.0.5) - Released on November 7th, 2017
   * Fixed issue with not working `noSwiping` parameter
   * Parallax now considers `slidesPerGroup` parameter
   * Zoom: imporved gestures handling
@@ -327,19 +328,19 @@
   * Fixed issues with some effects being broken with enabled `breakpoints`
   * Minor fixes
 
-## [Swiper 4.0.3](https://github.com/nolimits4web/swiper/compare/v4.0.2...v4.0.3) - Released on October 27, 2017
+## [Swiper 4.0.3](https://github.com/nolimits4web/swiper/compare/v4.0.2...v4.0.3) - Released on October 27th, 2017
   * Fixed Parallax opacity and scale transitions
   * Better compatability with SSR by using dummy `document` object
   * Fixed styles for dynamic pagination buttons in RTL mode
   * Fixed issue with last pagination button not being active with `slidesPerView: 'auto'`
   * Renamed build tasks: `build-dev` -> `build:dev`, `build-prod` -> `build:prod`
 
-## [Swiper 4.0.2](https://github.com/nolimits4web/swiper/compare/v4.0.1...v4.0.2) - Released on October 18, 2017
+## [Swiper 4.0.2](https://github.com/nolimits4web/swiper/compare/v4.0.1...v4.0.2) - Released on October 18th, 2017
   * Lazy loading support for Virtual slides
   * Added `beforeResize` event
   * Minor fixes
 
-## [Swiper 4.0.1](https://github.com/nolimits4web/swiper/compare/v4.0.0...v4.0.1) - Released on October 11, 2017
+## [Swiper 4.0.1](https://github.com/nolimits4web/swiper/compare/v4.0.0...v4.0.1) - Released on October 11th, 2017
   * Fixed issue with pagination being broken with loop mode
   * Reworked `realIndex` calculation ordering
   * ES-module files renamed (**possible breaking change**):
@@ -347,7 +348,7 @@
     * `swiper.modular.js` -> `swiper.esm.js`
   * Minor fixes
 
-## [Swiper 4.0.0](https://github.com/nolimits4web/swiper/compare/v3.4.2...v4.0.0) - Released on October 4, 2017 🎉
+## [Swiper 4.0.0](https://github.com/nolimits4web/swiper/compare/v3.4.2...v4.0.0) - Released on October 4th, 2017 🎉
   * New API (check [Documentation](http://idangero.us/swiper/api/))
   * Virtual Slides - new module that keeps in DOM just required amount of slides
   * Source code has been fully rewritten in ES-next syntax
@@ -359,36 +360,36 @@
   * Imporved compatibility with server-side rendering
   * Hundreds of improvements and fixes
 
-## Swiper 4.0.0-beta.4 - Released on September 20, 2017
+## Swiper 4.0.0-beta.4 - Released on September 20th, 2017
   * Fixed issue with draggable Scrollbar in RTL layout
   * Minor fixes
 
-## Swiper 4.0.0-beta.3 - Released on September 13, 2017
+## Swiper 4.0.0-beta.3 - Released on September 13th, 2017
   * Dom7 update to latest version
   * Small core refactoring to get better results within tree-shaking bundles
 
-## Swiper 4.0.0-beta.2 - Released on September 2, 2017
+## Swiper 4.0.0-beta.2 - Released on September 2nd, 2017
   * Disable a11y by default
   * Fixed issue with events sharing between multiple swipers
   * Fixed issue with resize handling after destroy
   * Few minor fixes
 
-## Swiper 4.0.0-beta.1 - Released on August 30, 2017
+## Swiper 4.0.0-beta.1 - Released on August 30th, 2017
   * Initial 4.0.0 release
 
-## Swiper 3.4.2 - Released on March 10, 2017
+## Swiper 3.4.2 - Released on March 10th, 2017
   * Fixed an issue with lazy loading callbacks when swiper is destroyed
   * New `onAfterResize` and `onBeforeResize` callbacks
   * New `onKeyPress` callback when keyboard control is used
   * Fixed Chrome+Windows issue with not clickable links that have "title" attribute
   * Minor fixes
 
-## Swiper 3.4.1 - Released on December 13, 2016
+## Swiper 3.4.1 - Released on December 13th, 2016
   * Fixed Zoom for RTL
   * Improved slideToClickedSlide behavior when loop is enabled
   * Minor fixes
 
-## Swiper 3.4.0 - Released on October 16, 2016
+## Swiper 3.4.0 - Released on October 16th, 2016
   * **Custom build** available. Now you can create custom swiper build using the folowing modules: effects, lazy-load, scrollbar, controller, hashnav, history, keyboard, mousewheel, parallax, zoom, a11y. Using cli `gulp custom -zoom,effects,lazy-loading`
   * New **zoom** functionality that enables double tap and pinch to zoom slide's inner image:
     * Required slide layout for zoom:
@@ -427,7 +428,7 @@
   * New "swiper-slide-duplicate-active", "swiper-slide-duplicate-next", "swiper-slide-duplicate-prev" classes that will be added in loop mode to the slides representing duplicated looped slides
   * All css classes are now configurable via new parameters: lazyLoadingClass, notificationClass, containerModifierClass, paginationClickableClass, paginationModifierClass, lazyStatusLoadingClass, lazyStatusLoadedClass, lazyPreloaderClass, notificationClass, preloaderClass, zoomContainerClass, slideDuplicateActiveClass, slideDuplicateNextClass, slideDuplicatePrevClass
 
-## Swiper 3.3.1 - Released on February 7, 2016
+## Swiper 3.3.1 - Released on February 7th, 2016
   * New `uniqueNavElements` parameter. If enabled (by default) and navigation elements' parameters passed as the string (like `.pagination`) then Swiper will look for such elements through child elements first. Applies for pagination, prev/next buttons and scrollbar
   * New `onPaginationRendered` callback. Will be fired after pagination elements generated and added to DOM
   * New `.reLoop()` method, which combines `.destroyLoop()` + `.createLoop()` methods with additional positioning fixes. Useful to call after you have changed `slidesPerView` parameter, it will dynamically recreate duplicated slides required for loop
@@ -437,7 +438,7 @@
   * Fixed issues when using loop with breakpoints changing `slidesPerView/Group` parameters
   * Numerous minor fixes
 
-## Swiper 3.3.0 - Released on January 10, 2016
+## Swiper 3.3.0 - Released on January 10th, 2016
   * New 3D Flip effect. Can be enabled with `effect: 'flip' parameter
   * New types of pagination with new parameters:
     * `paginationType` - type of pagination. Can be `'bullets'` (default) or `'fraction'` or `'progress'` or `'custom'`
@@ -449,22 +450,22 @@
   * New `onAutoplay(swiper)` callback
   * Minor fixes
 
-## Swiper 3.2.7 - Released on December 7, 2015
+## Swiper 3.2.7 - Released on December 7th, 2015
   * Fixed issue with using HTMLElements for next/prevButton parameters with breakpoints
   * Fixed issue with not working Auto Height when using Controller
 
-## Swiper 3.2.6 - Released on November 28, 2015
+## Swiper 3.2.6 - Released on November 28th, 2015
   * Fixed issue in RTL layout using `mousewheelControl`
   * Fixed issue in RTL layout using Parallax
 
-## Swiper 3.2.5 - Released on November 21, 2015
+## Swiper 3.2.5 - Released on November 21st, 2015
   * New "Auto Height" mode when container/wrapper adopts to the height of currently active slide. Can be enabled with `autoHeight: true` parameter
   * Fixed issue with break points in FireFox
   * Fixed issue with wrong slides position when using effects
   * Fixed issue with none-updated scroll bar after using `setWrapperTranslate`
   * Minor fixes
 
-## Swiper 3.2.0 - Released on November 7, 2015
+## Swiper 3.2.0 - Released on November 7th, 2015
   * Added responsive breakpoints support using new `breakpoints` parameter. Now you can specify different `slidesPerView` and other similar parameters for different sizes:
     ```js
     slidesPerView: 5,
@@ -491,14 +492,14 @@
   * Fixed issue with mousewheel in Chrome
   * Minor fixes
 
-## Swiper 3.1.7 - Released on October 10, 2015
+## Swiper 3.1.7 - Released on October 10th, 2015
   * Fixed issue with lazy loading trying to download `undefined`-src images
   * Fixed lazy loading on slides using jQuery version
   * Fixed issue with `slideToClickedSlide` with `loop` and `centeredSlides`
   * Fixed issue with wrong slides fill when number of slides less than `slidesPerView * slidesPerColumn` with `slidesPerColumnFill: 'row'`
   * Minor fixes
 
-## Swiper 3.1.5 - Released on September 28, 2015
+## Swiper 3.1.5 - Released on September 28th, 2015
   * Added support for images `srcset` with lazy loading using `data-srcset` attribute
   * Fixed new Chrome errors with `WebkitCSSMatrix`
   * Fixed issue with `slideToClickedSlide` with `loop` and `centeredSlides`
@@ -508,7 +509,7 @@
     * `scrollbarSnapOnRelease` - (boolean) by default is `false`. Control slider snap on scrollbar release
   * Minor fixes
 
-## Swiper 3.1.2 - Released on August 22, 2015
+## Swiper 3.1.2 - Released on August 22nd, 2015
   * Fixed issues with loop and mousewheel when swiper stopped on last slide
   * Imporved mouse wheel behavior in latest Chrome
   * Fixed issue with `slidesPerView: 'auto'` and enabled `loop:true` mode to set `loopedSlides` to the amount of slides by default (if not specified)
@@ -522,7 +523,7 @@
   * Improved source maps
   * Minor fixes
 
-## Swiper 3.1.0 - Released on July 14, 2015
+## Swiper 3.1.0 - Released on July 14th, 2015
   * Accessibility (a11y)
     * Fixed issue with wrong buttons labels
     * Added support for pagination bullets
@@ -541,7 +542,7 @@
   * Added new `swiper.jquery.umd.js` version for the environment where both Swiper and jQuery included as modules
   * Minor fixes
 
-## Swiper 3.0.8 - Released on June 14, 2015
+## Swiper 3.0.8 - Released on June 14th, 2015
   * Fixed issue with wrong active index and callbacks in Fade effect
   * New mousewheel parameters:
     * `mousewheelReleaseOnEdges` - will release mousewheel event and allow page scrolling when swiper is on edge positions (in the beginning or in the end)
@@ -553,7 +554,7 @@
   * Fixed issue with nested fade-effect swipers
   * Minor fixes
 
-## Swiper 3.0.7 - Released on April 25, 2015
+## Swiper 3.0.7 - Released on April 25th, 2015
   * New `width` and `height` parameters to force Swiper size, useful when it is hidden on intialization
   * Better support for "Scroll Container". So now Swiper can be used as a scroll container with one single "scrollable"/"swipeable" slide
   * Added lazy loading for background images with `data-background` attribute on required elements
@@ -563,12 +564,12 @@
   * Fixed issues with Autoplay and Fade effect
   * Minor fixes
 
-## Swiper 3.0.6 - Released on March 27, 2015
+## Swiper 3.0.6 - Released on March 27th, 2015
   * Fixed sometimes wrong slides position when using "Fade" effect
   * `.destroy(deleteInstance, cleanupStyles)` method now has second `cleanupStyles` argument, when passed - all custom styles will be removed from slides, wrapper and container. Useful if you need to destroy Swiper and to init again with new options or in different direction
   * Minor fixes
 
-## Swiper 3.0.5 - Released on March 21, 2015
+## Swiper 3.0.5 - Released on March 21st, 2015
   * New Keyboard accessibility module to provide foucsable navigation buttons and basic ARIA for screen readers with new parameters:
     * `a11y: false` - enable accessibility
     * `prevSlideMessage: 'Previous slide'` - message for screen readers for previous button
@@ -593,7 +594,7 @@
   * Super basic support for IE 9 with swiper.jquery version. No animation and transitions, but basic stuff like switching slides/pagination/scrollbars works
 
 
-## Swiper 3.0.4 - Released on March 6, 2015
+## Swiper 3.0.4 - Released on March 6th, 2015
   * New Images Lazy Load component
     * With new parameters `lazyLoading`, `lazyLoadingInPrevNext`, `lazyLoadingOnTransitionStart` (all disabled by default)
     * With new callbacks `onLazyImageLoad` and `onLazyImageReady`
@@ -607,7 +608,7 @@
   * Hash Navigation will run callback dpending on `runCallbacksOnInit` parameter
   * `watchVisibility` parameter renamed to `watchSlidesVisibility`
 
-## Swiper 3.0.3 - Released on March 1, 2015
+## Swiper 3.0.3 - Released on March 1st, 2015
   * Fixed issue with not firing onSlideChangeEnd callback after calling .slideTo with
 runCallbacks=false
   * Fixed values of isBeginning/isEnd when there is only one slide
@@ -618,7 +619,7 @@ runCallbacks=false
   * Improved .update and .onResize methods
   * Minor fixes
 
-## Swiper 3.0.2 - Released on February 22, 2015
+## Swiper 3.0.2 - Released on February 22nd, 2015
   * Fixed issue with keyboard events not cleaned up with Swiper.destroy
   * Encoded inline SVG images for IE support
   * New callbacks
@@ -631,11 +632,11 @@ runCallbacks=false
     * `.removeSlide(index)` or `.removeSlide([indexes])` - to remove selected slides
     * `.removeAllSlides()` - to remove all slides
 
-## Swiper 3.0.1 - Released on February 13, 2015
+## Swiper 3.0.1 - Released on February 13th, 2015
   * Fixed issue with navigation buttons in Firefox in loop mode
   * Fixed issue with image dragging in IE 10+
 
-## Swiper 3.0.0 - Released on February 11, 2015
+## Swiper 3.0.0 - Released on February 11th, 2015
   * Initial release of all new Swiper 3
   * Removed features
     * Dropped support for old browsers. Now it is compatible with:


### PR DESCRIPTION
FIxed a typo in latest version 5.4.0 changelog (**lates** to **latest**) and update the release dates using a more proper way 
