### PR TITLE
fix sub-package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swiper-src",
-  "version": "5.3.8",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package/package.json
+++ b/package/package.json
@@ -50,7 +50,7 @@
     "Samsung >= 5"
   ],
   "dependencies": {
-    "dom7": "^2.1.3",
-    "ssr-window": "^1.0.1"
+    "dom7": "^2.1.5",
+    "ssr-window": "^2.0.0"
   }
 }


### PR DESCRIPTION
Hello! I wanted to follow up on an issue that came across ionic's issue tracker.

https://github.com/ionic-team/ionic/issues/21138

TL;DR, the update to `ssr-window` fixed some ssr bugs, but the package.json in the package dir did not get the ssr-window version bump.

This PR should address that.