### PR TITLE
Fix in pagination detect uniqueNaVElements

### DIFF
--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -207,7 +207,6 @@ const Pagination = {
       swiper.params.uniqueNavElements
       && typeof params.el === 'string'
       && $el.length > 1
-      && swiper.$el.find(params.el).length === 1
     ) {
       $el = swiper.$el.find(params.el);
     }


### PR DESCRIPTION
Removed the restriction on one unique pagination element.

I would like to be able to use several instances of swiper on the page, in which there are two pagination elements (on top of the slide and below)
