### PR TITLE
Use real classes for hover so that the transition is completed.

### DIFF
--- a/demos/430-slideable-menu.html
+++ b/demos/430-slideable-menu.html
@@ -96,15 +96,15 @@
 			transition: .3s;
 		}
 
-		.menu-button:hover .bar:nth-of-type(1) {
+		.menu-button.hover .bar:nth-of-type(1) {
 			-webkit-transform: translateY(1.5px) rotate(-4.5deg);
 			-ms-transform: translateY(1.5px) rotate(-4.5deg);
 			transform: translateY(1.5px) rotate(-4.5deg);
 		}
-		.menu-button:hover .bar:nth-of-type(2) {
+		.menu-button.hover .bar:nth-of-type(2) {
 			opacity: .9;
 		}
-		.menu-button:hover .bar:nth-of-type(3) {
+		.menu-button.hover .bar:nth-of-type(3) {
 			-webkit-transform: translateY(-1.5px) rotate(4.5deg);
 			-ms-transform: translateY(-1.5px) rotate(4.5deg);
 			transform: translateY(-1.5px) rotate(4.5deg);
@@ -123,18 +123,21 @@
 			-ms-transform: translateY(-15px) rotate(45deg);
 			transform: translateY(-15px) rotate(45deg);
 		}
-		.cross:hover .bar:nth-of-type(1) {
+		.cross.hover .bar:nth-of-type(1) {
 			-webkit-transform: translateY(13.5px) rotate(-40.5deg);
 			-ms-transform: translateY(13.5px) rotate(-40.5deg);
 			transform: translateY(13.5px) rotate(-40.5deg);
+            background-color: green
 		}
-		.cross:hover .bar:nth-of-type(2) {
+		.cross.hover .bar:nth-of-type(2) {
 			opacity: .1;
+            background-color: green
 		}
-		.cross:hover .bar:nth-of-type(3) {
+		.cross.hover .bar:nth-of-type(3) {
 			-webkit-transform: translateY(-13.5px) rotate(40.5deg);
 			-ms-transform: translateY(-13.5px) rotate(40.5deg);
 			transform: translateY(-13.5px) rotate(40.5deg);
+            background-color: green
 		}
 	</style>
 </head>
@@ -159,7 +162,15 @@
 
 	<!-- Initialize Swiper -->
 	<script>
-    var menuButton = document.querySelector('.menu-button');
+      var menuButton = document.querySelector('.menu-button');
+      var toggleHover = function (e)  {
+        if ( e.type === "mouseover" )
+          e.target.classList.add('hover')
+        else
+          e.target.classList.remove('hover')
+      }
+      menuButton.addEventListener('mouseover', toggleHover, true )
+      menuButton.addEventListener('mouseout', toggleHover, true )
     var openMenu = function () {
       swiper.slidePrev();
     };
@@ -173,10 +184,11 @@
           var slider = this;
           if (slider.activeIndex === 0) {
             menuButton.classList.add('cross');
+            menuButton.classList.remove('hover');
             // required because of slideToClickedSlide
             menuButton.removeEventListener('click', openMenu, true);
           } else {
-            menuButton.classList.remove('cross');
+            menuButton.classList.remove('cross', 'hover');
           }
         }
         , slideChangeTransitionEnd: function () {


### PR DESCRIPTION
This is not the most important change, but it turns out that after transitions in javascript the psuedo-classes are not recalculated until there is a new browser event.  In particular, elements with a :hover psuedo-class before the transition keep that psuedo-class until there is another event (like a `mousemove`).  The visible result is that the transition appears incomplete.  This is more noticeable on mobile devices without a mouse since you have to actively touch the screen again to trigger the psuedo-class recalculation.

More details can be found in [this issue](https://github.com/nolimits4web/swiper/issues/3519).  I closed it before I realized I could fix the demo myself.

Regards,
-Doug
