### PR TITLE
Adds check for navigation object. Fixes #3620

### DIFF
--- a/src/components/core/check-overflow/index.js
+++ b/src/components/core/check-overflow/index.js
@@ -19,7 +19,7 @@ function checkOverflow() {
 
   if (wasLocked && wasLocked !== swiper.isLocked) {
     swiper.isEnd = false;
-    swiper.navigation.update();
+    if(swiper.navigation) swiper.navigation.update();
   }
 }
 


### PR DESCRIPTION
Adds check for `swiper.navigation` before calling `swiper.navigation.update()`. 

This avoids "_Uncaught TypeError: Cannot read property 'update' of undefined_" when navigation is not configured.
