### PR TITLE
Enable forced animation in loop mode via loopForceSlide

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Swiper Playground</title>
-  <link rel="stylesheet" href="../build/swiper-bundle.css">
+  <link rel="stylesheet" href="../package/swiper-bundle.css">
   <meta name="viewport" content="width=device-width">
 </head>
 
@@ -49,7 +49,7 @@
       line-height: 300px;
     }
   </style>
-  <script src="../build/swiper-bundle.js"></script>
+  <script src="../package/swiper-bundle.js"></script>
   <script>
     var swiper = new Swiper({
       el: '.swiper-container',

--- a/src/components/core/defaults.js
+++ b/src/components/core/defaults.js
@@ -111,6 +111,7 @@ export default {
   loopAdditionalSlides: 0,
   loopedSlides: null,
   loopFillGroupWithBlank: false,
+  loopForceSlide: false,
 
   // Swiping/no swiping
   allowSlidePrev: true,

--- a/src/components/core/slide/slideNext.js
+++ b/src/components/core/slide/slideNext.js
@@ -4,7 +4,7 @@ export default function slideNext(speed = this.params.speed, runCallbacks = true
   const { params, animating } = swiper;
   const increment = swiper.activeIndex < params.slidesPerGroupSkip ? 1 : params.slidesPerGroup;
   if (params.loop) {
-    if (animating) return false;
+    if (animating && !params.loopForceSlide) return false;
     swiper.loopFix();
     // eslint-disable-next-line
     swiper._clientLeft = swiper.$wrapperEl[0].clientLeft;

--- a/src/components/core/slide/slidePrev.js
+++ b/src/components/core/slide/slidePrev.js
@@ -4,7 +4,7 @@ export default function slidePrev(speed = this.params.speed, runCallbacks = true
   const { params, animating, snapGrid, slidesGrid, rtlTranslate } = swiper;
 
   if (params.loop) {
-    if (animating) return false;
+    if (animating && !params.loopForceSlide) return false;
     swiper.loopFix();
     // eslint-disable-next-line
     swiper._clientLeft = swiper.$wrapperEl[0].clientLeft;


### PR DESCRIPTION
Enable forced animation in loop mode via `loopForceSlide` config option. Fixes #3552 (but admittedly could introduce breaking changes).

See also: https://codepen.io/cfxd/pen/zYrPoyL