### PR TITLE
Fix issue #3692 by omitting generic HTMLElement type properties that …

### DIFF
--- a/src/swiper-react.d.ts
+++ b/src/swiper-react.d.ts
@@ -43,7 +43,11 @@ interface SwiperSlide {
   zoom?: boolean;
 }
 
-interface Swiper extends Omit<React.HTMLAttributes<HTMLElement>, 'onProgress' | 'onClick' | 'onTouchEnd' | 'onTouchMove' | 'onTouchStart' | 'onTransitionEnd'> {}
+interface Swiper
+  extends Omit<
+    React.HTMLAttributes<HTMLElement>,
+    'onProgress' | 'onClick' | 'onTouchEnd' | 'onTouchMove' | 'onTouchStart' | 'onTransitionEnd'
+  > {}
 interface SwiperSlide extends React.HTMLAttributes<HTMLElement> {}
 
 declare const Swiper: React.FunctionComponent<Swiper>;

--- a/src/swiper-react.d.ts
+++ b/src/swiper-react.d.ts
@@ -43,7 +43,7 @@ interface SwiperSlide {
   zoom?: boolean;
 }
 
-interface Swiper extends React.HTMLAttributes<HTMLElement> {}
+interface Swiper extends Omit<React.HTMLAttributes<HTMLElement>, 'onProgress' | 'onClick' | 'onTouchEnd' | 'onTouchMove' | 'onTouchStart' | 'onTransitionEnd'> {}
 interface SwiperSlide extends React.HTMLAttributes<HTMLElement> {}
 
 declare const Swiper: React.FunctionComponent<Swiper>;


### PR DESCRIPTION
This issue is cause by this line interface Swiper extends React.HTMLAttributes<HTMLElement> {} in swiper-react.d.ts

It extends the React.HTMLAttributes which defines properties like onProgress with the type ((event: SyntheticEvent<HTMLElement, Event>) => void) | undefined'. The Swiper has the same property with type ((swiper: Swiper, progress: number) => void) | undefined'.

The fix is to omitting generic HTMLElement type properties that are defined in `swiper-events.d.ts` when extending the Swiper interface with React.HTMLAttributes<HTMLElement>.