### PR TITLE
Mousewheel: add threshold for wheel scroll event

### DIFF
--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -319,10 +319,18 @@ const Mousewheel = {
     const window = getWindow();
 
     if (
-      this.params.mousewheel.preventSwipeThreshold &&
-      newEvent.delta < this.params.mousewheel.preventSwipeThreshold
+      this.params.mousewheel.preventSwipeThresholdDelta &&
+      newEvent.delta < this.params.mousewheel.preventSwipeThresholdDelta
     ) {
-      // Prevent swipe if delta of wheel scroll is below threshold
+      // Prevent if delta of wheel scroll delta is below configured threshold
+      return false;
+    }
+
+    if (
+      this.params.mousewheel.preventSwipeThresholdTime &&
+      now() - swiper.mousewheel.lastScrollTime < this.params.mousewheel.preventSwipeThresholdTime
+    ) {
+      // Prevent if time between scrolls is below configured threshold
       return false;
     }
 
@@ -421,7 +429,8 @@ export default {
       forceToAxis: false,
       sensitivity: 1,
       eventsTarget: 'container',
-      preventSwipeThreshold: null,
+      preventSwipeThresholdDelta: null,
+      preventSwipeThresholdTime: null,
     },
   },
   create() {

--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -317,6 +317,15 @@ const Mousewheel = {
   animateSlider(newEvent) {
     const swiper = this;
     const window = getWindow();
+
+    if (
+      this.params.mousewheel.preventSwipeThreshold &&
+      newEvent.delta < this.params.mousewheel.preventSwipeThreshold
+    ) {
+      // Prevent swipe if delta of wheel scroll is below threshold
+      return false;
+    }
+
     // If the movement is NOT big enough and
     // if the last time the user scrolled was too close to the current one (avoid continuously triggering the slider):
     //   Don't go any further (avoid insignificant scroll movement).
@@ -412,6 +421,7 @@ export default {
       forceToAxis: false,
       sensitivity: 1,
       eventsTarget: 'container',
+      preventSwipeThreshold: null,
     },
   },
   create() {

--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -319,16 +319,16 @@ const Mousewheel = {
     const window = getWindow();
 
     if (
-      this.params.mousewheel.preventSwipeThresholdDelta &&
-      newEvent.delta < this.params.mousewheel.preventSwipeThresholdDelta
+      this.params.mousewheel.thresholdDelta &&
+      newEvent.delta < this.params.mousewheel.thresholdDelta
     ) {
       // Prevent if delta of wheel scroll delta is below configured threshold
       return false;
     }
 
     if (
-      this.params.mousewheel.preventSwipeThresholdTime &&
-      now() - swiper.mousewheel.lastScrollTime < this.params.mousewheel.preventSwipeThresholdTime
+      this.params.mousewheel.thresholdTime &&
+      now() - swiper.mousewheel.lastScrollTime < this.params.mousewheel.thresholdTime
     ) {
       // Prevent if time between scrolls is below configured threshold
       return false;
@@ -429,8 +429,8 @@ export default {
       forceToAxis: false,
       sensitivity: 1,
       eventsTarget: 'container',
-      preventSwipeThresholdDelta: null,
-      preventSwipeThresholdTime: null,
+      thresholdDelta: null,
+      thresholdTime: null,
     },
   },
   create() {


### PR DESCRIPTION
When scrolling, the carousel often jumps two pages of slides instead of one, due to inertia of the scroll. It's particularly noticeable with a mac trackpad.

To improve, I've added preventSwipeThresholdDelta and preventSwipeThresholdTime params to the mousewheel module, so that:

1. only scroll events over that delta threshold will be acknowledged.

and

2. only scroll events which happen after a threshold time in milliseconds will be acknowledged.

To make this work, you can add the following params to the config:

```
{
  slidesPerView: 3,
  slidesPerGroup: 3,
  spaceBetween: 20,
  direction: 'horizontal',
  speed: 500,
  mousewheel: {
    forceToAxis: true,
    // This only allows scrolls with a delta greater than 120 to be acknowledged. 
    preventSwipeThresholdDelta: 120,
    // This only allows scrolls once every 3 seconds to be acknowledged. 
    preventSwipeThresholdTime: 3000,
  },
}
```