### PR TITLE
#3417 if pagination.renderbullet is set, don’t add role/aria-label

### DIFF
--- a/src/components/a11y/a11y.js
+++ b/src/components/a11y/a11y.js
@@ -96,8 +96,8 @@ const A11y = {
       swiper.pagination.bullets &&
       swiper.pagination.bullets.length
     ) {
-      swiper.pagination.bullets.each(function (bulletEl) {
-        var $bulletEl = $(bulletEl);
+      swiper.pagination.bullets.each((bulletEl) => {
+        const $bulletEl = $(bulletEl);
         swiper.a11y.makeElFocusable($bulletEl);
         if (!swiper.params.pagination.renderBullet) {
           swiper.a11y.addElRole($bulletEl, 'button');

--- a/src/components/a11y/a11y.js
+++ b/src/components/a11y/a11y.js
@@ -96,14 +96,17 @@ const A11y = {
       swiper.pagination.bullets &&
       swiper.pagination.bullets.length
     ) {
-      swiper.pagination.bullets.each((bulletEl) => {
-        const $bulletEl = $(bulletEl);
+      swiper.pagination.bullets.each(function (bulletEl) {
+        var $bulletEl = $(bulletEl);
         swiper.a11y.makeElFocusable($bulletEl);
-        swiper.a11y.addElRole($bulletEl, 'button');
-        swiper.a11y.addElLabel(
-          $bulletEl,
-          params.paginationBulletMessage.replace(/\{\{index\}\}/, $bulletEl.index() + 1),
-        );
+        if (!swiper.params.pagination.renderBullet) {
+          swiper.a11y.addElRole($bulletEl, 'button');
+          swiper.a11y.addElLabel(
+            $bulletEl,
+            params.paginationBulletMessage.replace(/\{\{index\}\}/, $bulletEl.index() + 1),
+          );
+        } else {
+        }
       });
     }
   },


### PR DESCRIPTION
Hi there,

This is a proposed fix for issue #3417. Please go easy on me, I hope this is useful as I don't want to raise an issue and not try t work towards a solution.

If pagination.renderbullet is set, (and the user wishes to implement their own html code to render each bullet), hand off responsibility of making that code accessible by not forcing `role="button"` and `aria-label` on it. Adding these unasked might even hurt the accessibility of what the user is trying to achieve.

I tested this locally and it worked as expected for me as summarized above!
