### PR TITLE
Add z-index to ensure links can be clicked.

### DIFF
--- a/src/components/core/core.less
+++ b/src/components/core/core.less
@@ -48,6 +48,9 @@
 .swiper-slide-invisible-blank {
   visibility: hidden;
 }
+.swiper-slide-active {
+    z-index: 999999;
+}
 /* Auto Height */
 .swiper-container-autoheight,
 .swiper-container-autoheight .swiper-slide {

--- a/src/components/core/core.scss
+++ b/src/components/core/core.scss
@@ -48,6 +48,9 @@
 .swiper-slide-invisible-blank {
   visibility: hidden;
 }
+.swiper-slide-active {
+    z-index: 999999;
+}
 /* Auto Height */
 .swiper-container-autoheight {
   &,


### PR DESCRIPTION
**Issue** 

Cloned slides and specific effects can cause links to be "unclickable", despite using the `preventClicks` option. This can be replicated using the following options:

```javascript
{
    loop: true,
    effect: 'fade',
}
```

**What this does**
Adds z-index to the active slide. This is change is non-destructive.

**Related issues**

https://github.com/nolimits4web/swiper/issues/3471
https://github.com/nolimits4web/swiper/issues/1584
https://github.com/nolimits4web/swiper/issues/1152
