### PR TITLE
A11y enhancements

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -9,10 +9,10 @@
 </head>
 
 <body>
-  <div class="swiper-container">
+  <section class="swiper-container">
     <div class="swiper-scrollbar"></div>
-    <div class="swiper-button-prev"></div>
-    <div class="swiper-button-next"></div>
+    <button class="swiper-button-prev"></button>
+    <button class="swiper-button-next"></button>
     <div class="swiper-wrapper">
       <div class="swiper-slide">Slide 1</div>
       <div class="swiper-slide">Slide 2</div>
@@ -26,7 +26,7 @@
       <div class="swiper-slide">Slide 10</div>
     </div>
     <div class="swiper-pagination"></div>
-  </div>
+  </section>
   <style>
     body,
     html {
@@ -74,6 +74,11 @@
       navigation: {
         nextEl: '.swiper-button-next',
         prevEl: '.swiper-button-prev',
+      },
+      a11y: {
+        containerMessage: 'Example content',
+        containerRoleDescriptionMessage: 'carousel',
+        itemRoleDescriptionMessage: 'slide',
       },
     });
   </script>

--- a/src/components/a11y/a11y.js
+++ b/src/components/a11y/a11y.js
@@ -2,6 +2,10 @@ import $ from '../../utils/dom';
 import { bindModuleMethods } from '../../utils/utils';
 
 const A11y = {
+  getRandomNumber(size = 16) {
+    const randomChar = () => Math.round(16 * Math.random()).toString(16);
+    return 'x'.repeat(size).replace(/x/g, randomChar);
+  },
   makeElFocusable($el) {
     $el.attr('tabIndex', '0');
     return $el;
@@ -14,8 +18,24 @@ const A11y = {
     $el.attr('role', role);
     return $el;
   },
+  addElRoleDescription($el, description) {
+    $el.attr('aria-role-description', description);
+    return $el;
+  },
+  addElControls($el, controls) {
+    $el.attr('aria-controls', controls);
+    return $el;
+  },
   addElLabel($el, label) {
     $el.attr('aria-label', label);
+    return $el;
+  },
+  addElId($el, id) {
+    $el.attr('id', id);
+    return $el;
+  },
+  addElLive($el, live) {
+    $el.attr('aria-live', live);
     return $el;
   },
   disableEl($el) {
@@ -111,11 +131,43 @@ const A11y = {
   },
   init() {
     const swiper = this;
+    const params = swiper.params.a11y;
 
     swiper.$el.append(swiper.a11y.liveRegion);
 
+    // Container
+    const $containerEl = swiper.$el;
+    if (params.containerRoleDescriptionMessage) {
+      swiper.a11y.addElRoleDescription($containerEl, params.containerRoleDescriptionMessage);
+    }
+    if (params.containerMessage) {
+      swiper.a11y.addElLabel($containerEl, params.containerMessage);
+    }
+
+    // Wrapper
+    const $wrapperEl = swiper.$wrapperEl;
+    const randomWrapperId = `swiper-wrapper-${swiper.a11y.getRandomNumber(16)}`;
+    let live;
+    swiper.a11y.addElId($wrapperEl, randomWrapperId);
+
+    if (swiper.params.autoplay && swiper.params.autoplay.enabled) {
+      live = 'off';
+    } else {
+      live = 'polite';
+    }
+    swiper.a11y.addElLive($wrapperEl, live);
+
+    // Slide
+    if (params.itemRoleDescriptionMessage) {
+      swiper.a11y.addElRoleDescription($(swiper.slides), params.itemRoleDescriptionMessage);
+    }
+    swiper.a11y.addElRole($(swiper.slides), 'group');
+    swiper.slides.each((slideEl) => {
+      const $slideEl = $(slideEl);
+      swiper.a11y.addElLabel($slideEl, `${$slideEl.index() + 1} / ${swiper.slides.length}`);
+    });
+
     // Navigation
-    const params = swiper.params.a11y;
     let $nextEl;
     let $prevEl;
     if (swiper.navigation && swiper.navigation.$nextEl) {
@@ -124,17 +176,24 @@ const A11y = {
     if (swiper.navigation && swiper.navigation.$prevEl) {
       $prevEl = swiper.navigation.$prevEl;
     }
+
     if ($nextEl) {
       swiper.a11y.makeElFocusable($nextEl);
-      swiper.a11y.addElRole($nextEl, 'button');
+      if ($nextEl[0].tagName !== 'BUTTON') {
+        swiper.a11y.addElRole($nextEl, 'button');
+        $nextEl.on('keydown', swiper.a11y.onEnterKey);
+      }
       swiper.a11y.addElLabel($nextEl, params.nextSlideMessage);
-      $nextEl.on('keydown', swiper.a11y.onEnterKey);
+      swiper.a11y.addElControls($nextEl, randomWrapperId);
     }
     if ($prevEl) {
       swiper.a11y.makeElFocusable($prevEl);
-      swiper.a11y.addElRole($prevEl, 'button');
+      if ($prevEl[0].tagName !== 'BUTTON') {
+        swiper.a11y.addElRole($prevEl, 'button');
+        $prevEl.on('keydown', swiper.a11y.onEnterKey);
+      }
       swiper.a11y.addElLabel($prevEl, params.prevSlideMessage);
-      $prevEl.on('keydown', swiper.a11y.onEnterKey);
+      swiper.a11y.addElControls($prevEl, randomWrapperId);
     }
 
     // Pagination
@@ -197,6 +256,9 @@ export default {
       firstSlideMessage: 'This is the first slide',
       lastSlideMessage: 'This is the last slide',
       paginationBulletMessage: 'Go to slide {{index}}',
+      containerMessage: null,
+      containerRoleDescriptionMessage: null,
+      itemRoleDescriptionMessage: null,
     },
   },
   create() {

--- a/src/components/a11y/a11y.js
+++ b/src/components/a11y/a11y.js
@@ -146,9 +146,9 @@ const A11y = {
 
     // Wrapper
     const $wrapperEl = swiper.$wrapperEl;
-    const randomWrapperId = `swiper-wrapper-${swiper.a11y.getRandomNumber(16)}`;
+    const wrapperId = $wrapperEl.attr('id') || `swiper-wrapper-${swiper.a11y.getRandomNumber(16)}`;
     let live;
-    swiper.a11y.addElId($wrapperEl, randomWrapperId);
+    swiper.a11y.addElId($wrapperEl, wrapperId);
 
     if (swiper.params.autoplay && swiper.params.autoplay.enabled) {
       live = 'off';
@@ -184,7 +184,7 @@ const A11y = {
         $nextEl.on('keydown', swiper.a11y.onEnterKey);
       }
       swiper.a11y.addElLabel($nextEl, params.nextSlideMessage);
-      swiper.a11y.addElControls($nextEl, randomWrapperId);
+      swiper.a11y.addElControls($nextEl, wrapperId);
     }
     if ($prevEl) {
       swiper.a11y.makeElFocusable($prevEl);
@@ -193,7 +193,7 @@ const A11y = {
         $prevEl.on('keydown', swiper.a11y.onEnterKey);
       }
       swiper.a11y.addElLabel($prevEl, params.prevSlideMessage);
-      swiper.a11y.addElControls($prevEl, randomWrapperId);
+      swiper.a11y.addElControls($prevEl, wrapperId);
     }
 
     // Pagination

--- a/src/types/components/a11y.d.ts
+++ b/src/types/components/a11y.d.ts
@@ -51,4 +51,25 @@ export interface A11yOptions {
    * @default 'swiper-notification'
    */
   notificationClass?: string;
+
+  /**
+   * Message for screen readers for outer swiper container
+   *
+   * @default null
+   */
+  containerMessage?: string;
+
+  /**
+   * Message for screen readers describing the role of outer swiper container
+   *
+   * @default null
+   */
+  containerRoleDescriptionMessage?: string;
+
+  /**
+   * Message for screen readers describing the role of slide element
+   *
+   * @default null
+   */
+  itemRoleDescriptionMessage?: string;
 }


### PR DESCRIPTION
This pull request is related to https://github.com/nolimits4web/swiper/issues/3149.
It contains three new parameters for a11y:

- containerMessage (String)
- containerRoleDescriptionMessage (String)
- itemRoleDescriptionMessage (String)

Their default value is null, considering that the a11y community doesn't share a common opinion about aria-roledescription (s. https://github.com/nolimits4web/swiper/issues/3149).

There are some new functions in the a11y section:
- getRandomNumber(size), returning a random number, used to create a random id for the wrapper element.
- addElRoleDescription($el, description), adding the attribute "aria-roledescription" with value "description" to $el
- addElControls($el, controls), adding the attribute "aria-controls" with value "controls" to $el
- addElId($el, id), adding the attribute "id" with value "id" to $el
- addElLive($el, live), adding the attribute "aria-live" with value "live" to $el

In the code you can find the desired enhancement features:
- `<section>` as the outer container, instead of a `<div>` element: changed in playground/index.html
- outer container has aria-roledescription="carousel": changed in a11y (optional, default value is null)
- outer container has aria-label="Example Content" (Label can be set like the next/prev slider buttons text): changed in a11y (optional, default value is null)
- next and previous buttons are `<a>`-tags: changed in playground/index.html, but used `<button>`-tags instead of `<a>`-tags
- next and previous buttons have role="button": changed in a11y (role is only set if buttons have no `<button>`-tag)
- next and previous buttons has aria-controls="swiperID" (this connects with the id of the content): changed in a11y (relates to next feature)
- content container has id="swiperID" (this connects with the aria-attribute of the next and previous buttons): changed in a11y (a random id which is also used for aria-controls in next and previous buttons is generated)
- content container has aria-live="off" when autoplay is on and aria-live="polite" when autoplay is off: changed in a11y (checks autoplay status and sets aria-live accordingly)
- content item has role="group": changed in a11y
- content item has aria-roledescription="slide": changed in a11y (optional, default value is null)
- content item has the slide number as aria-label. Example :aria-label="1 / 6": changed in a11y


There is also a pull request for an according change in the documentation for swiper-website: https://github.com/nolimits4web/swiper-website/pull/74