### PR TITLE
Fix no swiping class in shadow copmonent

### DIFF
--- a/src/components/core/events/onTouchStart.js
+++ b/src/components/core/events/onTouchStart.js
@@ -31,7 +31,7 @@ export default function onTouchStart(event) {
     $targetEl = $(event.path[0]);
   }
 
-  if (params.noSwiping && ($targetEl.closest(params.noSwipingSelector ? params.noSwipingSelector : "." + params.noSwipingClass)[0] || shadowRootWithSwipingClass)) {
+  if (params.noSwiping && ($targetEl.closest(params.noSwipingSelector ? params.noSwipingSelector : "." + params.noSwipingClass)[0])) {
       swiper.allowClick = true;
       return;
   }

--- a/src/components/core/events/onTouchStart.js
+++ b/src/components/core/events/onTouchStart.js
@@ -25,10 +25,11 @@ export default function onTouchStart(event) {
   if (!data.isTouchEvent && 'button' in e && e.button > 0) return;
   if (data.isTouched && data.isMoved) return;
 
+  // change target el for shadow root componenet
   const swipingClassHasValue = !!params.noSwipingClass && params.noSwipingClass !== '';
-  const hasShadowRoot = event && event.target && event.target.shadowRoot;
-  // additional check for shadow root component where closest is not always found
-  const shadowRootWithSwipingClass = swipingClassHasValue && hasShadowRoot && event && event.path && event.path[0] && event.path[0].classList.contains(params.noSwipingClass);
+  if (swipingClassHasValue && e.target && e.target.shadowRoot && event.path && event.path[0]) {
+    $targetEl = $(event.path[0]);
+  }
 
   if (params.noSwiping && ($targetEl.closest(params.noSwipingSelector ? params.noSwipingSelector : "." + params.noSwipingClass)[0] || shadowRootWithSwipingClass)) {
       swiper.allowClick = true;

--- a/src/components/core/events/onTouchStart.js
+++ b/src/components/core/events/onTouchStart.js
@@ -24,10 +24,11 @@ export default function onTouchStart(event) {
   if (!data.isTouchEvent && 'which' in e && e.which === 3) return;
   if (!data.isTouchEvent && 'button' in e && e.button > 0) return;
   if (data.isTouched && data.isMoved) return;
+
   const swipingClassHasValue = !!params.noSwipingClass && params.noSwipingClass !== '';
   const hasShadowRoot = event && event.target && event.target.shadowRoot;
   // additional check for shadow root component where closest is not always found
-  const shadowRootWithSwipingClass = swipingClassHasValue &&hasShadowRoot && event && event.path.findIndex(item => item.classList && item.classList.contains(params.noSwipingClass)) > -1;
+  const shadowRootWithSwipingClass = swipingClassHasValue && hasShadowRoot && event && event.path && event.path[0] && event.path[0].classList.contains(params.noSwipingClass);
 
   if (params.noSwiping && ($targetEl.closest(params.noSwipingSelector ? params.noSwipingSelector : "." + params.noSwipingClass)[0] || shadowRootWithSwipingClass)) {
       swiper.allowClick = true;

--- a/src/components/core/events/onTouchStart.js
+++ b/src/components/core/events/onTouchStart.js
@@ -24,15 +24,16 @@ export default function onTouchStart(event) {
   if (!data.isTouchEvent && 'which' in e && e.which === 3) return;
   if (!data.isTouchEvent && 'button' in e && e.button > 0) return;
   if (data.isTouched && data.isMoved) return;
-  if (
-    params.noSwiping &&
-    $targetEl.closest(
-      params.noSwipingSelector ? params.noSwipingSelector : `.${params.noSwipingClass}`,
-    )[0]
-  ) {
-    swiper.allowClick = true;
-    return;
+  const swipingClassHasValue = !!params.noSwipingClass && params.noSwipingClass !== '';
+  const hasShadowRoot = event && event.target && event.target.shadowRoot;
+  // additional check for shadow root component where closest is not always found
+  const shadowRootWithSwipingClass = swipingClassHasValue &&hasShadowRoot && event && event.path.findIndex(item => item.classList && item.classList.contains(params.noSwipingClass)) > -1;
+
+  if (params.noSwiping && ($targetEl.closest(params.noSwipingSelector ? params.noSwipingSelector : "." + params.noSwipingClass)[0] || shadowRootWithSwipingClass)) {
+      swiper.allowClick = true;
+      return;
   }
+
   if (params.swipeHandler) {
     if (!$targetEl.closest(params.swipeHandler)[0]) return;
   }


### PR DESCRIPTION
Problem 

`$targetEl.closest` does not find element with swiping class if the element is within a web component with shawroot. 

Fix 
Replace targetEl to be the first element in the event touch path   
