### PR TITLE
#3897 | Type-check the `index` argument

### DIFF
--- a/src/components/core/slide/slideTo.js
+++ b/src/components/core/slide/slideTo.js
@@ -4,6 +4,37 @@ export default function slideTo(
   runCallbacks = true,
   internal,
 ) {
+  if (typeof index !== 'number' && typeof index !== 'string') {
+    throw new Error(
+      `The 'index' argument cannot have type other than 'number' or 'string'. [${typeof index}] given.`,
+    );
+  }
+
+  if (typeof index === 'string') {
+    /**
+     * The `index` argument converted from `string` to `number`.
+     * @type {number}
+     */
+    const indexAsNumber = parseInt(index, 10);
+
+    /**
+     * Determines whether the `index` argument is a valid `number`
+     * after being converted from the `string` type.
+     * @type {boolean}
+     */
+    const isValidNumber = isFinite(indexAsNumber);
+
+    if (!isValidNumber) {
+      throw new Error(
+        `The passed-in 'index' (string) couldn't be converted to 'number'. [${index}] given.`,
+      );
+    }
+
+    // Knowing that the converted `index` is a valid number,
+    // we can update the original argument's value.
+    index = indexAsNumber;
+  }
+
   const swiper = this;
   let slideIndex = index;
   if (slideIndex < 0) slideIndex = 0;


### PR DESCRIPTION
Perform the type checking on the `index` argument before using its value inside the `slideTo()` method.

Fixes #3897.