### PR TITLE
fix(build): add cross-env to support windows

### DIFF
--- a/scripts/build-js-core.js
+++ b/scripts/build-js-core.js
@@ -64,7 +64,9 @@ async function buildCore(components, format, cb) {
     '"src/swiper-svelte.js"',
   ];
   await exec.promise(
-    `MODULES=${format} npx babel src --out-dir ${outputDir}/${format} --ignore ${ignore.join(',')}`,
+    `cross-env MODULES=${format} npx babel src --out-dir ${outputDir}/${format} --ignore ${ignore.join(
+      ',',
+    )}`,
   );
 
   // Remove unused dirs

--- a/scripts/build-react.js
+++ b/scripts/build-react.js
@@ -10,10 +10,10 @@ async function buildReact(format, cb) {
 
   // Babel
   await exec.promise(
-    `MODULES=${format} npx babel --config-file ./babel.config.react.js src/react --out-dir ${outputDir}/${format}/react`,
+    `cross-env MODULES=${format} npx babel --config-file ./babel.config.react.js src/react --out-dir ${outputDir}/${format}/react`,
   );
   await exec.promise(
-    `MODULES=${format} npx babel --config-file ./babel.config.react.js src/swiper-react.js --out-file ${outputDir}/swiper-react.${format}.js`,
+    `cross-env MODULES=${format} npx babel --config-file ./babel.config.react.js src/swiper-react.js --out-file ${outputDir}/swiper-react.${format}.js`,
   );
 
   // Fix import paths

--- a/scripts/build-svelte.js
+++ b/scripts/build-svelte.js
@@ -10,10 +10,10 @@ async function buildSvelte(format, cb) {
   const outputDir = env === 'development' ? 'build' : 'package';
   // Babel
   await exec.promise(
-    `MODULES=${format} npx babel --config-file ./babel.config.svelte.js src/svelte --out-dir ${outputDir}/${format}/svelte`,
+    `cross-env MODULES=${format} npx babel --config-file ./babel.config.svelte.js src/svelte --out-dir ${outputDir}/${format}/svelte`,
   );
   await exec.promise(
-    `MODULES=${format} npx babel --config-file ./babel.config.svelte.js src/swiper-svelte.js --out-file ${outputDir}/swiper-svelte.${format}.js`,
+    `cross-env MODULES=${format} npx babel --config-file ./babel.config.svelte.js src/swiper-svelte.js --out-file ${outputDir}/swiper-svelte.${format}.js`,
   );
 
   // Fix import paths

--- a/scripts/build-vue.js
+++ b/scripts/build-vue.js
@@ -9,10 +9,10 @@ async function buildVue(format, cb) {
   const outputDir = env === 'development' ? 'build' : 'package';
   // Babel
   await exec.promise(
-    `MODULES=${format} npx babel --config-file ./babel.config.vue.js src/vue --out-dir ${outputDir}/${format}/vue`,
+    `cross-env MODULES=${format} npx babel --config-file ./babel.config.vue.js src/vue --out-dir ${outputDir}/${format}/vue`,
   );
   await exec.promise(
-    `MODULES=${format} npx babel --config-file ./babel.config.vue.js src/swiper-vue.js --out-file ${outputDir}/swiper-vue.${format}.js`,
+    `cross-env MODULES=${format} npx babel --config-file ./babel.config.vue.js src/swiper-vue.js --out-file ${outputDir}/swiper-vue.${format}.js`,
   );
 
   // Fix import paths


### PR DESCRIPTION
You build scripts using ENV variables without cross-env, as a result, I didn't succeed to run a build on Windows.
This PR adding `cross-env` before `MODULES=` the same way as it's done in `package.json` scripts. 

now:
```js
await exec.promise(
    `MODULES=${format} npx babel src --out-dir ${outputDir}/${format} --ignore ${ignore.join(
      ',',
    )}`,
  );
```
to:

```js
await exec.promise(
    `cross-env MODULES=${format} npx babel src --out-dir ${outputDir}/${format} --ignore ${ignore.join(
      ',',
    )}`,
  );
```

Error log:

```bash
$ npm run build:prod

> swiper-src@6.3.4 build:prod D:\projects\swiper
> cross-env NODE_ENV=production node scripts/build

'MODULES' is not recognized as an internal or external command,
operable program or batch file.
'MODULES' is not recognized as an internal or external command,
operable program or batch file.
'MODULES' is not recognized as an internal or external command,
operable program or batch file.
'MODULES' is not recognized as an internal or external command,
operable program or batch file.
'MODULES' is not recognized as an internal or external command,
operable program or batch file.
'MODULES' is not recognized as an internal or external command,
operable program or batch file.
(node:16004) UnhandledPromiseRejectionWarning: Error: Shell command exit with non zero code: 1
    at ChildProcess.<anonymous> (D:\projects\swiper\node_modules\exec-sh\lib\exec-sh.js:73:15)
    at ChildProcess.emit (events.js:315:20)
    at maybeClose (internal/child_process.js:1048:16)
```

Closed #3820 