### PR TITLE
fix(types): add null types

### DIFF
--- a/src/types/components/a11y.d.ts
+++ b/src/types/components/a11y.d.ts
@@ -57,19 +57,19 @@ export interface A11yOptions {
    *
    * @default null
    */
-  containerMessage?: string;
+  containerMessage?: string | null;
 
   /**
    * Message for screen readers describing the role of outer swiper container
    *
    * @default null
    */
-  containerRoleDescriptionMessage?: string;
+  containerRoleDescriptionMessage?: string | null;
 
   /**
    * Message for screen readers describing the role of slide element
    *
    * @default null
    */
-  itemRoleDescriptionMessage?: string;
+  itemRoleDescriptionMessage?: string | null;
 }

--- a/src/types/components/mousewheel.d.ts
+++ b/src/types/components/mousewheel.d.ts
@@ -58,12 +58,12 @@ export interface MousewheelOptions {
    *
    * @default null
    */
-  thresholdDelta?: number;
+  thresholdDelta?: number | null;
 
   /**
    * Minimum mousewheel scroll time delta (in ms) to trigger swiper slide change
    *
    * @default null
    */
-  thresholdTime?: number;
+  thresholdTime?: number | null;
 }

--- a/src/types/components/navigation.d.ts
+++ b/src/types/components/navigation.d.ts
@@ -36,7 +36,7 @@ export interface NavigationOptions {
    *
    * @default null
    */
-  nextEl?: CSSSelector | HTMLElement;
+  nextEl?: CSSSelector | HTMLElement | null;
 
   /**
    * String with CSS selector or HTML element of the element that will work
@@ -44,7 +44,7 @@ export interface NavigationOptions {
    *
    * @default null
    */
-  prevEl?: CSSSelector | HTMLElement;
+  prevEl?: CSSSelector | HTMLElement | null;
 
   /**
    * Toggle navigation buttons visibility after click on Slider's container

--- a/src/types/components/thumbs.d.ts
+++ b/src/types/components/thumbs.d.ts
@@ -15,7 +15,7 @@ export interface ThumbsOptions {
    *
    * @default null
    */
-  swiper?: Swiper;
+  swiper?: Swiper | null;
   /**
    * Additional class that will be added to activated thumbs swiper slide
    *

--- a/src/types/components/virtual.d.ts
+++ b/src/types/components/virtual.d.ts
@@ -100,13 +100,13 @@ export interface VirtualOptions {
    *
    * @default null
    */
-  renderSlide?: (slide: any, index: any) => any;
+  renderSlide?: (slide: any, index: any) => any | null;
   /**
    * Function for external rendering (e.g. using some other library to handle DOM manipulations and state like React.js or Vue.js). As an argument it accepts data object with the following properties:
    *
    * @default null
    */
-  renderExternal?: (data: VirtualData) => any;
+  renderExternal?: (data: VirtualData) => any | null;
   /**
    * When enabled (by default) it will update Swiper layout right after renderExternal called. Useful to disable and update swiper manually when used with render libraries that renders asynchronously
    *

--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -76,7 +76,7 @@ export interface SwiperOptions {
    * @note Setting this parameter will make Swiper not responsive
    * @default null
    */
-  width?: number;
+  width?: number | null;
 
   /**
    * Swiper height (in px). Parameter allows to force Swiper height.
@@ -85,7 +85,7 @@ export interface SwiperOptions {
    * @note Setting this parameter will make Swiper not responsive
    * @default null
    */
-  height?: number;
+  height?: number | null;
 
   /**
    * Set to true and slider wrapper will adopt its height to the height of the currently active slide
@@ -388,7 +388,7 @@ export interface SwiperOptions {
    *
    * @default null
    */
-  swipeHandler?: CSSSelector | HTMLElement;
+  swipeHandler?: CSSSelector | HTMLElement | null;
 
   // Clicks
   /**
@@ -520,7 +520,7 @@ export interface SwiperOptions {
    *
    * @default null
    */
-  loopedSlides?: number;
+  loopedSlides?: number | null;
 
   /**
    * Enable and loop mode will fill groups with insufficient number of slides with blank slides. Good to be used with slidesPerGroup parameter
@@ -581,13 +581,13 @@ export interface SwiperOptions {
    *
    * @default null
    */
-  userAgent?: string;
+  userAgent?: string | null;
   /**
    * Required for active slide detection when rendered on server-side and enabled history
    *
    * @default null
    */
-  url?: string;
+  url?: string | null;
 
   a11y?: A11yOptions;
   autoplay?: AutoplayOptions | boolean;


### PR DESCRIPTION
This PR adds `null` types. Example:

```typescript

  /**
   * String with CSS selector or HTML element of the element that will work
   * like "prev" button after click on it
   *
   * @default null
   */
  prevEl?: CSSSelector | HTMLElement;
```

Optional character `?` tells Typescript that it accepts `undefined` but not null, but according to the `@default` null is acceptable.
So `null` type is missing here and in places like this. 

closes #3866 