### PR TITLE
Ignore the origin [0,0] inView.

### DIFF
--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -69,6 +69,7 @@ const Keyboard = {
       for (let i = 0; i < swiperCoord.length; i += 1) {
         const point = swiperCoord[i];
         if (point[0] >= 0 && point[0] <= windowWidth && point[1] >= 0 && point[1] <= windowHeight) {
+          if (point[0] === 0 && point[1] === 0) continue; // eslint-disable-line
           inView = true;
         }
       }


### PR DESCRIPTION
Fix issue #3895, by ignore the origin [0,0] inView.
[0,0] not inView could avoid keyboard trigger slide change in hidden swiper.

When hidden swiper , the swiperCoord was:
```
0: (2) [0, 0]
1: (2) [NaN, 0]
2: (2) [0, NaN]
3: (2) [NaN, NaN]
```
