### PR TITLE
fix(pagination): bullet class mistake

### DIFF
--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -270,7 +270,7 @@ const Pagination = {
     }
 
     if (params.clickable) {
-      $el.on('click', `.${params.bulletClass.replace(/ /g, '.')}}`, function onClick(e) {
+      $el.on('click', `.${params.bulletClass.replace(/ /g, '.')}`, function onClick(e) {
         e.preventDefault();
         let index = $(this).index() * swiper.params.slidesPerGroup;
         if (swiper.params.loop) index += swiper.loopedSlides;
@@ -299,7 +299,7 @@ const Pagination = {
     $el.removeClass(params.modifierClass + params.type);
     if (swiper.pagination.bullets) swiper.pagination.bullets.removeClass(params.bulletActiveClass);
     if (params.clickable) {
-      $el.off('click', `.${params.bulletClass.replace(/ /g, '.')}}`);
+      $el.off('click', `.${params.bulletClass.replace(/ /g, '.')}`);
     }
   },
 };


### PR DESCRIPTION
I've made a mistake in PR #3913 
Extra braces after the class name:
```js
`.${params.bulletClass.replace(/ /g, '.')}}<-- two braces instead of one
```
this PR fixes it.