### PR TITLE
fix a typo in updateSize()

### DIFF
--- a/src/components/core/update/updateSize.js
+++ b/src/components/core/update/updateSize.js
@@ -10,7 +10,7 @@ export default function updateSize() {
   } else {
     width = $el[0].clientWidth;
   }
-  if (typeof swiper.params.height !== 'undefined' && swiper.params.width !== null) {
+  if (typeof swiper.params.height !== 'undefined' && swiper.params.height !== null) {
     height = swiper.params.height;
   } else {
     height = $el[0].clientHeight;


### PR DESCRIPTION
I believe this is a real typo, when detecting if there is a height in options, you always test height and width, then without the width in options, this will always fall, and there are so many issues with this height problems.

Always follow the [contribution guidelines](https://github.com/nolimits4web/Swiper/blob/master/CONTRIBUTING.md) when submitting a pull request.
