### PR TITLE
fix(lazy): update slider sizes after lazy image loaded

### DIFF
--- a/src/components/lazy/lazy.js
+++ b/src/components/lazy/lazy.js
@@ -91,9 +91,7 @@ const Lazy = {
           }
         }
         swiper.emit('lazyImageReady', $slideEl[0], $imageEl[0]);
-        if (swiper.params.autoHeight) {
-          swiper.updateAutoHeight();
-        }
+        swiper.update();
       });
 
       swiper.emit('lazyImageLoad', $slideEl[0], $imageEl[0]);


### PR DESCRIPTION
closes #3929 
This is the easiest way to fix the issue, but maybe there is a more efficient way. Take a look at the issue for more details.