### PR TITLE
Problem: swiper.swipeDirection after swipe and use other event

### DIFF
--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -303,6 +303,7 @@ const Mousewheel = {
             swiper.mousewheel.lastEventBeforeSnap = newEvent;
             recentWheelEvents.splice(0);
             swiper.mousewheel.timeout = nextTick(() => {
+              swiper.swipeDirection = undefined;
               swiper.slideToClosest(swiper.params.speed, true, undefined, snapToThreshold);
             }, 0); // no delay; move on next tick
           }
@@ -312,6 +313,7 @@ const Mousewheel = {
             // for 500ms.
             swiper.mousewheel.timeout = nextTick(() => {
               const snapToThreshold = 0.5;
+              swiper.swipeDirection = undefined;
               swiper.mousewheel.lastEventBeforeSnap = newEvent;
               recentWheelEvents.splice(0);
               swiper.slideToClosest(swiper.params.speed, true, undefined, snapToThreshold);

--- a/src/components/navigation/navigation.js
+++ b/src/components/navigation/navigation.js
@@ -35,12 +35,14 @@ const Navigation = {
     const swiper = this;
     e.preventDefault();
     if (swiper.isBeginning && !swiper.params.loop) return;
+    swiper.swipeDirection = undefined;
     swiper.slidePrev();
   },
   onNextClick(e) {
     const swiper = this;
     e.preventDefault();
     if (swiper.isEnd && !swiper.params.loop) return;
+    swiper.swipeDirection = undefined;
     swiper.slideNext();
   },
   init() {

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -273,6 +273,7 @@ const Pagination = {
       $el.on('click', `.${params.bulletClass.replace(/ /g, '.')}`, function onClick(e) {
         e.preventDefault();
         let index = $(this).index() * swiper.params.slidesPerGroup;
+        swiper.swipeDirection = undefined;
         if (swiper.params.loop) index += swiper.loopedSlides;
         swiper.slideTo(index);
       });


### PR DESCRIPTION
Problem: after use swipe, all other events (that change slide) not clear param swiper.swipeDirection. Consequently difficult understand what the next event changed slide.

fix swiper.swipeDirection param when
* click on navigation
* click on pagination
* use mousewhell
If before used swipe event.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/nolimits4web/Swiper/blob/master/CONTRIBUTING.md) when submitting a pull request.
