### PR TITLE
fix: swiper-slide-duplicate-next class typo

### DIFF
--- a/src/react/swiper-slide.js
+++ b/src/react/swiper-slide.js
@@ -53,7 +53,7 @@ const SwiperSlide = forwardRef(
           slideClasses.indexOf('swiper-slide-duplicate-prev') >= 0,
         isNext:
           slideClasses.indexOf('swiper-slide-next') >= 0 ||
-          slideClasses.indexOf('swiper-slide-duplicate next') >= 0,
+          slideClasses.indexOf('swiper-slide-duplicate-next') >= 0,
       };
     }
 

--- a/src/svelte/swiper-slide.svelte
+++ b/src/svelte/swiper-slide.svelte
@@ -43,7 +43,7 @@
       slideClasses.indexOf('swiper-slide-duplicate-prev') >= 0,
     isNext:
       slideClasses.indexOf('swiper-slide-next') >= 0 ||
-      slideClasses.indexOf('swiper-slide-duplicate next') >= 0,
+      slideClasses.indexOf('swiper-slide-duplicate-next') >= 0,
   };
 
   onMount(() => {

--- a/src/vue/swiper-slide.js
+++ b/src/vue/swiper-slide.js
@@ -64,7 +64,7 @@ const SwiperSlide = {
         slideClasses.value.indexOf('swiper-slide-duplicate-prev') >= 0,
       isNext:
         slideClasses.value.indexOf('swiper-slide-next') >= 0 ||
-        slideClasses.value.indexOf('swiper-slide-duplicate next') >= 0,
+        slideClasses.value.indexOf('swiper-slide-duplicate-next') >= 0,
     }));
     return () => {
       return h(


### PR DESCRIPTION
Vue, Svelte and Vue checking `swiper-slide-duplicate next` class to identicate `slideData.isNext` variable.
But I see that the right class is `swiper-slide-duplicate-next` (**with** dash)
![image](https://user-images.githubusercontent.com/5851280/100896961-ddd82b80-34c7-11eb-94e9-466eee1dd917.png)
