### PR TITLE
build(svelte): include *.svelte files into package

### DIFF
--- a/scripts/build-svelte.js
+++ b/scripts/build-svelte.js
@@ -41,13 +41,6 @@ async function buildSvelte(format, cb) {
   swiperSlide = swiperSlideResult.js.code;
   fs.writeFileSync(`./${outputDir}/${format}/svelte/swiper-slide.js`, swiperSlide);
 
-  try {
-    fs.unlinkSync(`./${outputDir}/svelte/swiper-slide.svelte`);
-    fs.unlinkSync(`./${outputDir}/svelte/swiper.svelte`);
-  } catch (err) {
-    // no files
-  }
-
   if (cb) cb();
 }
 


### PR DESCRIPTION
closes #4013 
maybe #3961

@btakita
This PR includes `swiper.svelte` & `swiper-slide.svelte` files according to your request.
![image](https://user-images.githubusercontent.com/5851280/101448748-455f0280-3930-11eb-9ced-06eea389851e.png)
Is just putting it in the root enough or they should be exported somewhere?
