### PR TITLE
fix: postinstall echo on windows

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -18,7 +18,7 @@
     "swiper-bundle.esm.js"
   ],
   "scripts": {
-    "postinstall": "echo \"\u001b[35m\u001b[1mLove Swiper? Support Vladimir's work by donating or pledging on patreon:\u001b[22m\u001b[39m\n > \u001b[32mhttps://patreon.com/vladimirkharlampidi\u001b[0m\n\""
+    "postinstall": "echo \"\u001b[35m\u001b[1mLove Swiper? Support Vladimir's work by donating or pledging on patreon:\u001b[22m\u001b[39m \" && echo \"> \u001b[32mhttps://patreon.com/vladimirkharlampidi\u001b[0m\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
closes  #3985 
looks like echo with \n is failing in postinstall script on windows.

In windows 10 it's not crashing but it's not writing the second line:
```
$ npm run postinstall

> swiper@6.4.1 postinstall D:\projects\swiper\package
> echo "Love Swiper? Support Vladimir's work by donating or pledging on patreon:
 > https://patreon.com/vladimirkharlampidi
"

"Love Swiper? Support Vladimir's work by donating or pledging on patreon:
```
On Windows NT and probably other old windows versions its crashes.
echo ** & echo ** should work fine on both platforms I think.