### PR TITLE
Reduce pagination border-radius

### DIFF
--- a/src/components/pagination/pagination.less
+++ b/src/components/pagination/pagination.less
@@ -64,7 +64,7 @@
   width: 8px;
   height: 8px;
   display: inline-block;
-  border-radius: 100%;
+  border-radius: 50%;
   background: #000;
   opacity: 0.2;
   button& {

--- a/src/components/pagination/pagination.scss
+++ b/src/components/pagination/pagination.scss
@@ -54,7 +54,7 @@
   width: 8px;
   height: 8px;
   display: inline-block;
-  border-radius: 100%;
+  border-radius: 50%;
   background: #000;
   opacity: 0.2;
   @at-root button#{&} {


### PR DESCRIPTION
Setting `border-radius: 100%` can actually _decrease_ roundness on some browsers.