### PR TITLE
fix(mousewheel): do not register event handlers if swiper.isLocked

### DIFF
--- a/src/components/mousewheel/mousewheel.js
+++ b/src/components/mousewheel/mousewheel.js
@@ -408,7 +408,7 @@ const Mousewheel = {
       swiper.wrapperEl.removeEventListener(event, swiper.mousewheel.handle);
       return true;
     }
-    if (!event) return false;
+    if (!event || swiper.isLocked) return false;
     if (swiper.mousewheel.enabled) return false;
     let target = swiper.$el;
     if (swiper.params.mousewheel.eventsTarget !== 'container') {


### PR DESCRIPTION
Fixes #4089