### PR TITLE
Fix React types

### DIFF
--- a/src/swiper-react.d.ts
+++ b/src/swiper-react.d.ts
@@ -53,7 +53,15 @@ interface SwiperSlide {
 interface Swiper
   extends Omit<
     React.HTMLAttributes<HTMLElement>,
-    'onProgress' | 'onClick' | 'onTouchEnd' | 'onTouchMove' | 'onTouchStart' | 'onTransitionEnd'
+    | 'onProgress'
+    | 'onClick'
+    | 'onTouchEnd'
+    | 'onTouchMove'
+    | 'onTouchStart'
+    | 'onTransitionEnd'
+    | 'onKeyPress'
+    | 'onDoubleClick'
+    | 'onScroll'
   > {}
 interface SwiperSlide extends React.HTMLAttributes<HTMLElement> {}
 


### PR DESCRIPTION
Привет, земляк! Love your library ❤️

I recently upgraded the Swiper from v4 to v6 in my project and decided to replace `react-id-swiper` with your official `swiper/react` components. It works great, but my CI fails with the following error:

```
node_modules/swiper/swiper-react.d.ts:6:11 - error TS2430: Interface 'Swiper' incorrectly extends interface 'Pick<HTMLAttributes<HTMLElement>, "hidden" | "dir" | "slot" | "style" | "title" | "id" | "color" | "translate" | "prefix" | "children" | "defaultChecked" | ... 236 more ... | "onTransitionEndCapture">'.
  Types of property 'onKeyPress' are incompatible.
    Type '((swiper: Swiper, keyCode: string) => void) | undefined' is not assignable to type '((event: KeyboardEvent<HTMLElement>) => void) | undefined'.
      Type '(swiper: Swiper, keyCode: string) => void' is not assignable to type '(event: KeyboardEvent<HTMLElement>) => void'.
```

This PR fixes conflicting fields by adding `'onKeyPress' | 'onDoubleClick' | 'onScroll'` to `Omit`
