### PR TITLE
fix(core): Stop click propagation.

### DIFF
--- a/src/components/core/events/onClick.js
+++ b/src/components/core/events/onClick.js
@@ -1,10 +1,14 @@
 export default function onClick(e) {
   const swiper = this;
+  const { lastClickTime, touchStartTime } = swiper.touchEventsData;
+  const dTime = lastClickTime - touchStartTime;
+
   if (!swiper.allowClick) {
     if (swiper.params.preventClicks) e.preventDefault();
-    if (swiper.params.preventClicksPropagation && swiper.animating) {
-      e.stopPropagation();
-      e.stopImmediatePropagation();
-    }
+  }
+
+  if (swiper.params.preventClicksPropagation && (swiper.animating || dTime < 0 || dTime >= 150)) {
+    e.stopPropagation();
+    e.stopImmediatePropagation();
   }
 }


### PR DESCRIPTION
* Moved `preventClicksPropagation` outside of `allowClick` check.
* Stopped the event propagation if the time delta gets smaller than 0 or larger than 150.

fixes #4103