### PR TITLE
ci: change stale label & add exception labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,8 +2,10 @@ daysUntilStale: 180
 daysUntilClose: 60
 exemptLabels:
   - feature request
+  - probably bug
+  - bug confirmed
   - in progress
-staleLabel: wontfix
+staleLabel: stale
 markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. Thank you


### PR DESCRIPTION
Changing label `wontfix` to `stale`. I think it will be a more proper label?
adding following labels to exceptions:
  - feature request
  - probably bug
  - bug confirmed
  - in progress

if merged: rename wontfix to stale in https://github.com/nolimits4web/swiper/labels