### PR TITLE
ci: split test to three ci workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Build
 on:
   push:
     branches: [master]
@@ -7,7 +7,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Test
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
@@ -17,5 +16,5 @@ jobs:
           node-version: 14
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
-      - name: Run tests
-        run: npm test
+      - name: Run build
+        run: npm run build:prod

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,20 @@
+name: Formatting
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+      - name: Run prettier check
+        run: npm run check-format

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+      - name: Run eslint
+        run: npm run lint

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-![Test](https://github.com/nolimits4web/swiper/workflows/Test/badge.svg) [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/swiper/badge?style=rounded)](https://www.jsdelivr.com/package/npm/swiper)
+![Build](https://github.com/nolimits4web/swiper/workflows/Build/badge.svg) [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/swiper/badge?style=rounded)](https://www.jsdelivr.com/package/npm/swiper)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-173-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <a href="https://opencollective.com/swiper/" target="_blank">


### PR DESCRIPTION
split test workflow into three workflows:
- Formatting (`npm run check-format`)
- Lint (`npm run lint`)
- Build (`npm run build:prod`)

I think this way indication will be more informative and in the future, it will be easier to add new tests, like e2e and etc.
What do you think?