### PR TITLE
fix: navigation, pagination, scrollbar props #4181

### DIFF
--- a/src/react/get-params.js
+++ b/src/react/get-params.js
@@ -33,7 +33,17 @@ function getParams(obj = {}) {
     }
   });
   ['navigation', 'pagination', 'scrollbar'].forEach((key) => {
-    if (params[key] === true || params[key] === false) params[key] = {};
+    if (params[key] === true) params[key] = {};
+    if (params[key] === false) {
+      switch (key) {
+        case 'navigation':
+          params[key] = { nextEl: null, prevEl: null };
+          break;
+        default:
+          params[key] = { el: null };
+          break;
+      }
+    }
   });
 
   return { params, passedParams, rest };

--- a/src/react/get-params.js
+++ b/src/react/get-params.js
@@ -34,16 +34,6 @@ function getParams(obj = {}) {
   });
   ['navigation', 'pagination', 'scrollbar'].forEach((key) => {
     if (params[key] === true) params[key] = {};
-    if (params[key] === false) {
-      switch (key) {
-        case 'navigation':
-          params[key] = { nextEl: null, prevEl: null };
-          break;
-        default:
-          params[key] = { el: null };
-          break;
-      }
-    }
   });
 
   return { params, passedParams, rest };

--- a/src/svelte/get-params.js
+++ b/src/svelte/get-params.js
@@ -34,7 +34,7 @@ function getParams(obj = {}) {
   });
 
   ['navigation', 'pagination', 'scrollbar'].forEach((key) => {
-    if (params[key] === true || params[key] === false) params[key] = {};
+    if (params[key] === true) params[key] = {};
   });
 
   return { params, passedParams, rest };

--- a/src/vue/get-params.js
+++ b/src/vue/get-params.js
@@ -35,7 +35,7 @@ function getParams(obj = {}) {
   });
 
   ['navigation', 'pagination', 'scrollbar'].forEach((key) => {
-    if (params[key] === true || params[key] === false) params[key] = {};
+    if (params[key] === true) params[key] = {};
   });
 
   return { params, passedParams, rest };


### PR DESCRIPTION
fix: #4181 

In the case of `{}`, `needsNavigation`, `needsPagination`, and `needsScrollbar` will be true, so if each props is false, the initial value is given so that element is null.