### PR TITLE
fix(react): add 'observer', etc. to params-list

### DIFF
--- a/src/react/params-list.js
+++ b/src/react/params-list.js
@@ -92,6 +92,9 @@ const paramsList = [
   'slideDuplicatePrevClass',
   'wrapperClass',
   'runCallbacksOnInit',
+  'observer',
+  'observeParents',
+  'observeSlideChildren',
 
   // modules
   'a11y',


### PR DESCRIPTION
Hi, 

When using one of `observer`, `observeParents`, `observeSlideChildren`, one will get this error and Swiper will ignore those params and pass them over to the root 'div' resulting in these errors: 

(reproducible by adding the params to the demo App.js)

```
react-dom.development.js:88 Warning: Received `true` for a non-boolean attribute `observer`.

If you want to write it to the DOM, pass a string instead: observer="true" or observer={value.toString()}.
    in div (created by Swiper)
react-dom.development.js:88 Warning: React does not recognize the `observeParents` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `observeparents` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by Swiper)
react-dom.development.js:88 Warning: React does not recognize the `observeSlideChildren` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `observeslidechildren` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by Swiper)
```
(there isn't any existing issue)

This was rendering the Mutation Observer completely unavailable in React as far as I can see.