### PR TITLE
fix(core): correcly update clickedSlide when other elements are present in slides wrapper

### DIFF
--- a/src/components/core/update/updateClickedSlide.js
+++ b/src/components/core/update/updateClickedSlide.js
@@ -5,9 +5,15 @@ export default function updateClickedSlide(e) {
   const params = swiper.params;
   const slide = $(e.target).closest(`.${params.slideClass}`)[0];
   let slideFound = false;
+  let slideIndex;
+
   if (slide) {
     for (let i = 0; i < swiper.slides.length; i += 1) {
-      if (swiper.slides[i] === slide) slideFound = true;
+      if (swiper.slides[i] === slide) {
+        slideFound = true;
+        slideIndex = i;
+        break;
+      }
     }
   }
 
@@ -16,7 +22,7 @@ export default function updateClickedSlide(e) {
     if (swiper.virtual && swiper.params.virtual.enabled) {
       swiper.clickedIndex = parseInt($(slide).attr('data-swiper-slide-index'), 10);
     } else {
-      swiper.clickedIndex = $(slide).index();
+      swiper.clickedIndex = slideIndex;
     }
   } else {
     swiper.clickedSlide = undefined;


### PR DESCRIPTION
Use case: tens of slides of which only some are visible/enabled at a time by toggling `swiper-slide` on both the thumbs slider and the main slider (and updating the slider ofc). More specifically, a product page where the product pictures are updated depending on the selected color.

```
<div class="swiper-container>
  <div class="swiper-wrapper">
    ....
    <div class="not-a-slide-for-now"></div>
    <div class="swiper-slide"></div>
    <div class="swiper-slide"></div>
    <div class="not-a-slide-for-now"></div>
    .....
  </div>
</div>
```
results in Swiper setting `swiper.clickedIndex` to the DOM position of the slide node instead of the position relative to the actual slides (i.e. `.swiper-slide`). In my use case, this breaks the thumbs module which is not able to properly update the clicked slide in the main slider (see `onThumbClick` which relies on `swiper.clickedIndex`.

Added `break` to the loop as a bonus and just in case someone puts hundreds+ of siblings to the slides.