### PR TITLE
add backface visiblity to prevent blur on slide change

### DIFF
--- a/src/components/core/core.less
+++ b/src/components/core/core.less
@@ -50,6 +50,8 @@
   height: 100%;
   position: relative;
   transition-property: transform;
+  transform: translateZ(0);
+  backface-visibility: hidden;
 }
 .swiper-slide-invisible-blank {
   visibility: hidden;

--- a/src/components/core/core.scss
+++ b/src/components/core/core.scss
@@ -50,6 +50,8 @@
   height: 100%;
   position: relative;
   transition-property: transform;
+  transform: translateZ(0);
+  backface-visibility: hidden;
 }
 .swiper-slide-invisible-blank {
   visibility: hidden;


### PR DESCRIPTION
This PR fixes https://github.com/nolimits4web/swiper/issues/4166 where images are blurry on slide change. 

The workaround by @opiepj solved the issue for my react based app by adding the code to my CSS file so this PR is a potential long term fix for others that might be facing this issue.