### PR TITLE
Fix for lazy loading in free mode

### DIFF
--- a/src/components/core/events/onTouchEnd.js
+++ b/src/components/core/events/onTouchEnd.js
@@ -218,7 +218,7 @@ export default function onTouchEnd(event) {
             });
           }, 0);
         });
-      } else if (swiper.velocity) {
+      } else {
         swiper.updateProgress(newPosition);
         swiper.setTransition(momentumDuration);
         swiper.setTranslate(newPosition);
@@ -230,8 +230,6 @@ export default function onTouchEnd(event) {
             swiper.transitionEnd();
           });
         }
-      } else {
-        swiper.updateProgress(newPosition);
       }
 
       swiper.updateActiveIndex();


### PR DESCRIPTION
If both lazy loading and free mode are enabled, lazy loading may not work in some circumstances.
Basically if you move to not loaded yet slides with a mouse and completely stop moving before releasing, slides are not loaded.

I recorded a video showing it: https://youtu.be/zvfhp20sccA.
At first I'm opening a tab with an example built using current master branch of Swiper.
Then I'm opening a tab with the version patched with this proposed change. 

Here are examples:
The version from master branch: https://bcmk.github.io/swiper/master.html
Fixed version: https://bcmk.github.io/swiper/fixed.html

I haven't created test cases yet and I would be grateful if someone points me to the correct way to add them.

Corresponding issue: https://github.com/nolimits4web/swiper/issues/4274

P.S. It fixes the behavior only for `loadOnTransitionStart: true`.
The issue for `loadOnTransitionStart: false` still exists.