### PR TITLE
Fix running with Snowpack

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -67,5 +67,8 @@
   "dependencies": {
     "dom7": "^3.0.0",
     "ssr-window": "^3.0.0"
+  },
+  "peerDependencies": {
+    "svelte": "^3.x"
   }
 }

--- a/scripts/build-js-core.js
+++ b/scripts/build-js-core.js
@@ -12,6 +12,7 @@ async function buildCore(components, format, cb) {
   const outputDir = env === 'development' ? 'build' : 'package';
   let coreContent = '';
   if (format === 'esm') {
+    coreContent += `export const __esModule = true;\n`;
     coreContent += `export { default as Swiper, default } from './components/core/core-class';\n`;
     coreContent += components
       .map(


### PR DESCRIPTION
These two small changes are the result of one hard day of work as a programmer with 19 years of experience trying to make Swiper work with Svelte and Snowpack.

1. `peerDependencies` is needed to avoid a second Svelte instance that almost completely stops Swiper from working.
There redundant`^` in the PR, you can remove it like this: `"svelte": "3.x"`, but everything works with it too.
2. `export const __esModule = true;` in `swiper.esm.js` is needed because of double `.default` attribute bug.
I'm tried to describe it here: https://github.com/nolimits4web/swiper/issues/4297, there same problem, but that commit didn't solve it completely.