### PR TITLE
Fix of virtual events (#4352)

### DIFF
--- a/src/components/virtual/virtual.js
+++ b/src/components/virtual/virtual.js
@@ -14,7 +14,6 @@ const Virtual = {
       renderSlide,
       offset: previousOffset,
     } = swiper.virtual;
-    swiper.updateActiveIndex();
     const activeIndex = swiper.activeIndex || 0;
 
     let offsetProp;
@@ -229,11 +228,6 @@ export default {
     beforeInit(swiper) {
       if (!swiper.params.virtual.enabled) return;
       swiper.classNames.push(`${swiper.params.containerModifierClass}virtual`);
-      const overwriteParams = {
-        watchSlidesProgress: true,
-      };
-      extend(swiper.params, overwriteParams);
-      extend(swiper.originalParams, overwriteParams);
 
       if (!swiper.params.initialSlide) {
         swiper.virtual.update();


### PR DESCRIPTION
fixes #4352 (probably also #2862)

The intention of this these sections are probably that the activeIndex must be updated onTranslate for the virtual mechanism to "known" how many slides ahead needs to be rendered. However updating the active index at this point messes up the events slideChange and slideChangeTransitionEnd (likely more?).
The removal of these sections introduces a breaking change: if one would slide to the end of the virtual rendered items (e.g. drag three slides in one long drag) the virtual updater does not know, if it should render the next items and the user will see only empty slides until the user drags again (and the rendering kicks in).

It is however _very_ easy to avoid that case simply by adding the parameters "addSlidesAfter" and "addSlidesBefore" that matches the viewport. This could possibly be done by default?
Another possibility could be to not use the activeIndex but another variable or calculation for the amount of virtual slides that needs rendering.
Furthermore it is questionable if the _entire_ .virtual.update() needs to be called onTranslate as is the case atm. It could be called onTransitionEnd if the viewport was big enough - this would probably also mean a performance boost.

Here is a working example with the implementation of addSlidesAfter and addSlidesBefore:
https://github.com/wiegell/swiper/tree/virt-with-logs