### PR TITLE
Fix getPropertyValue call in updateSlides

### DIFF
--- a/src/components/core/update/updateSlides.js
+++ b/src/components/core/update/updateSlides.js
@@ -167,7 +167,7 @@ export default function updateSlides() {
         const paddingRight = getDirectionPropertyValue(slideStyles, 'padding-right');
         const marginLeft = getDirectionPropertyValue(slideStyles, 'margin-left');
         const marginRight = getDirectionPropertyValue(slideStyles, 'margin-right');
-        const boxSizing = slideStyles.getPropertyValue(slideStyles, 'box-sizing');
+        const boxSizing = slideStyles.getPropertyValue('box-sizing');
         if (boxSizing && boxSizing === 'border-box') {
           slideSize = width + marginLeft + marginRight;
         } else {


### PR DESCRIPTION
This is a fix for a bug I have encountered. 

In my case, the swiper with `slidesPerView: 'auto'` has an extra empty space after the last slide, which is visible if you scroll to the end of the gallery.

I don't know if this fixes any other issues that have been reported before.
