### PR TITLE
Avoid using cached dimensions for keyboard inView calculations

### DIFF
--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -56,15 +56,19 @@ const Keyboard = {
       ) {
         return undefined;
       }
+
+      const $el = swiper.$el;
+      const swiperWidth = $el[0].clientWidth;
+      const swiperHeight = $el[0].clientHeight;
       const windowWidth = window.innerWidth;
       const windowHeight = window.innerHeight;
       const swiperOffset = swiper.$el.offset();
       if (rtl) swiperOffset.left -= swiper.$el[0].scrollLeft;
       const swiperCoord = [
         [swiperOffset.left, swiperOffset.top],
-        [swiperOffset.left + swiper.width, swiperOffset.top],
-        [swiperOffset.left, swiperOffset.top + swiper.height],
-        [swiperOffset.left + swiper.width, swiperOffset.top + swiper.height],
+        [swiperOffset.left + swiperWidth, swiperOffset.top],
+        [swiperOffset.left, swiperOffset.top + swiperHeight],
+        [swiperOffset.left + swiperWidth, swiperOffset.top + swiperHeight],
       ];
       for (let i = 0; i < swiperCoord.length; i += 1) {
         const point = swiperCoord[i];


### PR DESCRIPTION
This PR follows on from [my comments](https://github.com/nolimits4web/swiper/pull/3922#issuecomment-806026531) on a previous inView PR.

If a Swiper instance is initialised and subsequently hidden, the inView flag will be set based on the dimensions that the element previously had, because `swiper.height` and `swiper.width` are cached values. Referencing the element’s height properties directly addresses this.

(I wondered whether `swiper.updateSize()` should be used here, but it’s no help as it will only update width and height values that are greater than 0, which hidden elements won’t be.)