### PR TITLE
Use Object.defineProperty do define dom7 methods

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -78,7 +78,7 @@ const Methods = {
 };
 
 Object.keys(Methods).forEach((methodName) => {
-  $.fn[methodName] = Methods[methodName];
+  Object.defineProperty($.fn, methodName, {value: Methods[methodName]});
 });
 
 export default $;

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -78,7 +78,7 @@ const Methods = {
 };
 
 Object.keys(Methods).forEach((methodName) => {
-  Object.defineProperty($.fn, methodName, {value: Methods[methodName]});
+  Object.defineProperty($.fn, methodName, { value: Methods[methodName] });
 });
 
 export default $;


### PR DESCRIPTION
We are creating a web component for clients to embed on their websites. For some Weebly sites, they define a `remove` method on the `Array.prototype` with the default of `writable: false`. This causes a TypeError when swiper tries to run:
> Uncaught TypeError: "remove" is read-only
>     js dom.js:41
>     js dom.js:40

Using `Object.defineProperty` rather than `$.fn[methodName] =` avoids trying to overwrite the array property.