### PR TITLE
chore: browserlist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,12 @@
+# This file is used by the build system to adjust CSS and JS output to support the specified browsers below.
+# For additional information regarding the format and rule options, please see:
+# https://github.com/browserslist/browserslist#queries
+
+
+# You can see what browsers were selected by your queries by running:
+#   npx browserslist
+
+last 2 version
+> 1%
+not IE 9-10 # Swiper not supporting IE 9-10 To opt-in, remove the 'not' prefix on this line.
+not IE 11 # Swiper not supporting IE 11

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -6,9 +6,9 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-last 2 Chrome version
-last 2 Firefox version
-last 2 Edge major versions
-last 2 Safari major versions
-last 2 iOS major versions
-Firefox ESR
+Android >= 7
+IOS >= 11
+Safari >= 11
+Chrome >= 80
+Firefox >= 80
+Samsung >= 10

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -6,7 +6,9 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-last 2 version
-> 1%
-not IE 9-10 # Swiper not supporting IE 9-10 To opt-in, remove the 'not' prefix on this line.
-not IE 11 # Swiper not supporting IE 11
+last 2 Chrome version
+last 2 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+last 2 iOS major versions
+Firefox ESR

--- a/package.json
+++ b/package.json
@@ -74,14 +74,6 @@
   "engines": {
     "node": ">= 4.7.0"
   },
-  "browserslist": [
-    "Android >= 7",
-    "IOS >= 11",
-    "Safari >= 11",
-    "Chrome >= 49",
-    "Firefox >= 31",
-    "Samsung >= 5"
-  ],
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1101.1",
     "@angular/animations": "~11.1.0",


### PR DESCRIPTION
Move browserlist configurations from `package.json` to `.browserslistrc` file with following settings:
```
last 2 version
> 1%
not IE 9-10 # Swiper not supporting IE 9-10 To opt-in, remove the 'not' prefix on this line.
not IE 11 # Swiper not supporting IE 11
```

that resolves to:

```
$ npx browserslist
and_chr 85
and_ff 79
and_qq 10.4
and_uc 12.12
android 81
baidu 7.12
bb 10
bb 7
chrome 86
chrome 85
chrome 84
edge 86
edge 85
firefox 82
firefox 81
firefox 80
ie_mob 11
ie_mob 10
ios_saf 14
ios_saf 13.4-13.7
ios_saf 13.3
ios_saf 12.2-12.4
kaios 2.5
op_mini all
op_mob 59
op_mob 12.1
opera 71
opera 70
safari 14
safari 13.1
samsung 12.0
samsung 11.1-11.2
```