### PR TITLE
fix(utils): dom not writeable

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -78,7 +78,7 @@ const Methods = {
 };
 
 Object.keys(Methods).forEach((methodName) => {
-  Object.defineProperty($.fn, methodName, { value: Methods[methodName] });
+  Object.defineProperty($.fn, methodName, { value: Methods[methodName], writable: true });
 });
 
 export default $;


### PR DESCRIPTION
**Issue**
This is to fix the following error when using swiper.js with shadow root web component which is caused by (https://github.com/nolimits4web/swiper/commit/628980a93c9ea7f1fb10a7fe1ad47d5ac98f804f#diff-94256a3f213e569269dd6afb8702cbd9e477199f5d1c6c1ff0e4c263dff2afbfL81). 

`Cannot assign to read only property 'children' of object '[object Array]' ;`

**Reason for this change**
 Following the previous implementation on shadow root enable component (https://github.com/nolimits4web/swiper/blob/32092ae9544b0ba3ecc6c3b65346afa546d0547d/src/components/core/core-class.js#L418), We need the property self itself to be `writable` in order to reassign the children to return slot item and return the correct wrapper children elements 

