### PR TITLE
Make swiper update for virtual mode React.StrictMode compatible

### DIFF
--- a/src/react/swiper.js
+++ b/src/react/swiper.js
@@ -39,16 +39,6 @@ const Swiper = forwardRef(
 
     const { slides, slots } = getChildren(children);
 
-    const changedParams = getChangedParams(
-      passedParams,
-      oldPassedParamsRef.current,
-      slides,
-      oldSlides.current,
-    );
-
-    oldPassedParamsRef.current = passedParams;
-    oldSlides.current = slides;
-
     const onBeforeBreakpoint = () => {
       setBreakpointChanged(!breakpointChanged);
     };
@@ -127,6 +117,14 @@ const Swiper = forwardRef(
 
     // watch for params change
     useIsomorphicLayoutEffect(() => {
+      const changedParams = getChangedParams(
+        passedParams,
+        oldPassedParamsRef.current,
+        slides,
+        oldSlides.current,
+      );
+      oldPassedParamsRef.current = passedParams;
+      oldSlides.current = slides;
       if (changedParams.length && swiperRef.current && !swiperRef.current.destroyed) {
         updateSwiper(swiperRef.current, slides, passedParams, changedParams);
       }


### PR DESCRIPTION
Due to react strict mode additional checks, swiper was not being updated correctly, specifically in virtual mode. Code change of the PR will make sure that it works on strict mode without any issues.

You can replicate issue by creating react virtual swiper and adding slides dynamically in development with react strict mode enabled. After these changes, it seems to be working just fine in development with react strict mode.