### PR TITLE
fix: try catch for postinstall script

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -18,7 +18,7 @@
     "swiper-bundle.esm.js"
   ],
   "scripts": {
-    "postinstall": "node postinstall.js"
+    "postinstall": "node -e \"try{require('./postinstall')}catch(e){}\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Should avoid this kind of errors #4485 

```
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! swiper@6.5.8 postinstall: node postinstall.js
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the swiper@6.5.8 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```