### PR TITLE
feat: core-js postinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Become a financial contributor and help us sustain our community. [[Contribute](
 
 #### `postinstall` message
 
-Swiper is searching for bakers, so the package shows a message about it after installation. If it causes problems for you, you can disable it:
+Swiper is searching for backers, so the package shows a message about it after installation. If it causes problems for you, you can disable it:
 
 ```
 ADBLOCK=true npm install

--- a/README.md
+++ b/README.md
@@ -308,6 +308,18 @@ This project exists thanks to all the people who contribute. [[Contribute](CONTR
 
 Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/swiper/contribute)]
 
+#### `postinstall` message
+
+Swiper is searching for bakers, so the package shows a message about it after installation. If it causes problems for you, you can disable it:
+
+```
+ADBLOCK=true npm install
+// or
+DISABLE_OPENCOLLECTIVE=true npm install
+// or
+npm install --loglevel silent
+```
+
 #### Organizations
 
 Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/swiper/contribute)]

--- a/package/package.json
+++ b/package/package.json
@@ -18,7 +18,7 @@
     "swiper-bundle.esm.js"
   ],
   "scripts": {
-    "postinstall": "node postinstall.js"
+    "postinstall": "node -e \"try{require('./postinstall')}catch(e){}\""
   },
   "repository": {
     "type": "git",

--- a/package/postinstall.js
+++ b/package/postinstall.js
@@ -1,3 +1,56 @@
-console.log('\u001b[35m\u001b[1m','Love Swiper? Support Vladimir\'s work by donating or pledging on patreon:');
-console.log('\u001b[22m\u001b[39m\u001b[32m','> On Patreon https://patreon.com/vladimirkharlampidi');
-console.log('\u001b[22m\u001b[39m\u001b[32m','> On Open Collective https://opencollective.com/swiper');
+/* eslint-disable max-len -- for better formatting */
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+var env = process.env;
+
+var ADBLOCK = is(env.ADBLOCK);
+var COLOR = is(env.npm_config_color);
+var DISABLE_OPENCOLLECTIVE = is(env.DISABLE_OPENCOLLECTIVE);
+var SILENT = ['silent', 'error', 'warn'].indexOf(env.npm_config_loglevel) !== -1;
+var OPEN_SOURCE_CONTRIBUTOR = is(env.OPEN_SOURCE_CONTRIBUTOR);
+var MINUTE = 60 * 1000;
+
+// you could add a PR with an env variable for your CI detection
+var CI = [
+  'BUILD_NUMBER',
+  'CI',
+  'CONTINUOUS_INTEGRATION',
+  'DRONE',
+  'RUN_ID'
+].some(function (it) { return is(env[it]); });
+
+var BANNER = '\u001b[35m\u001b[1mLove Swiper? Support Vladimir\'s work by donating or pledging: \u001B[0m\n' +
+'\u001b[22m\u001b[39m\u001b[32m> On Patreon https://patreon.com/vladimirkharlampidi \u001B[0m\n' +
+'\u001b[22m\u001b[39m\u001b[32m> On Open Collective https://opencollective.com/swiper';
+
+function is(it) {
+  return !!it && it !== '0' && it !== 'false';
+}
+
+function isBannerRequired() {
+  if (ADBLOCK || CI || DISABLE_OPENCOLLECTIVE || SILENT || OPEN_SOURCE_CONTRIBUTOR) return false;
+  var file = path.join(os.tmpdir(), 'swiper-banners');
+  var banners = [];
+  try {
+    var DELTA = Date.now() - fs.statSync(file).mtime;
+    if (DELTA >= 0 && DELTA < MINUTE * 3) {
+        banners = JSON.parse(fs.readFileSync(file, 'utf8'));
+        if (banners.indexOf(BANNER) !== -1) return false;
+      }
+    } catch (error) {
+      banners = [];
+    }
+  try {
+    banners.push(BANNER);
+    fs.writeFileSync(file, JSON.stringify(banners), 'utf8');
+  } catch (error) { /* empty */ }
+  return true;
+}
+
+function showBanner() {
+  // eslint-disable-next-line no-console,no-control-regex -- output
+  console.log(COLOR ? BANNER : BANNER.replace(/\u001B\[\d+m/g, ''));
+}
+
+if (isBannerRequired()) showBanner();

--- a/package/postinstall.js
+++ b/package/postinstall.js
@@ -1,7 +1,4 @@
 /* eslint-disable max-len -- for better formatting */
-var fs = require('fs');
-var os = require('os');
-var path = require('path');
 var env = process.env;
 
 var ADBLOCK = is(env.ADBLOCK);
@@ -9,7 +6,6 @@ var COLOR = is(env.npm_config_color);
 var DISABLE_OPENCOLLECTIVE = is(env.DISABLE_OPENCOLLECTIVE);
 var SILENT = ['silent', 'error', 'warn'].indexOf(env.npm_config_loglevel) !== -1;
 var OPEN_SOURCE_CONTRIBUTOR = is(env.OPEN_SOURCE_CONTRIBUTOR);
-var MINUTE = 60 * 1000;
 
 // you could add a PR with an env variable for your CI detection
 var CI = [
@@ -29,23 +25,7 @@ function is(it) {
 }
 
 function isBannerRequired() {
-  if (ADBLOCK || CI || DISABLE_OPENCOLLECTIVE || SILENT || OPEN_SOURCE_CONTRIBUTOR) return false;
-  var file = path.join(os.tmpdir(), 'swiper-banners');
-  var banners = [];
-  try {
-    var DELTA = Date.now() - fs.statSync(file).mtime;
-    if (DELTA >= 0 && DELTA < MINUTE * 3) {
-        banners = JSON.parse(fs.readFileSync(file, 'utf8'));
-        if (banners.indexOf(BANNER) !== -1) return false;
-      }
-    } catch (error) {
-      banners = [];
-    }
-  try {
-    banners.push(BANNER);
-    fs.writeFileSync(file, JSON.stringify(banners), 'utf8');
-  } catch (error) { /* empty */ }
-  return true;
+  return !(ADBLOCK || CI || DISABLE_OPENCOLLECTIVE || SILENT || OPEN_SOURCE_CONTRIBUTOR);
 }
 
 function showBanner() {


### PR DESCRIPTION
This PR implements `core-js` postinstall script for swiper.
Looks like `core-js` did really good job for postinstall message:
- shows once in 3 minutes (write a file in temp folder, using its `mtime`)
- not showing message in CI
- ability to block ads via multiple env variables and cli arguments
```js
var DISABLE_OPENCOLLECTIVE = is(env.DISABLE_OPENCOLLECTIVE);
var SILENT = ['silent', 'error', 'warn'].indexOf(env.npm_config_loglevel) !== -1;
var OPEN_SOURCE_CONTRIBUTOR = is(env.OPEN_SOURCE_CONTRIBUTOR);
```

Original: https://github.com/zloirock/core-js/blob/master/packages/core-js/postinstall.js

Also, I've added an instruction on how to block banner based on:
https://github.com/zloirock/core-js/blob/eb8f4e1df395c6abc8b679cd56fe476e9f155ced/README.md#postinstall-message
