### PR TITLE
Fix control type in ControllerOptions interface

### DIFF
--- a/src/types/components/controller.d.ts
+++ b/src/types/components/controller.d.ts
@@ -15,7 +15,7 @@ export interface ControllerOptions {
    * Pass here another Swiper instance or array with Swiper instances that should be controlled
    * by this Swiper
    */
-  control?: Swiper;
+  control?: Swiper | Swiper[];
 
   /**
    * Set to `true` and controlling will be in inverse direction


### PR DESCRIPTION
Regarding the documentation `control` could be  Swiper instance or array with Swiper instances.
Read more - https://swiperjs.com/swiper-api#controller-methods.