### PR TITLE
Fix typos on L#33 and L#167

### DIFF
--- a/src/types/swiper-class.d.ts
+++ b/src/types/swiper-class.d.ts
@@ -164,7 +164,7 @@ interface Swiper extends SwiperClass<SwiperEvents> {
   rtlTranslate: boolean;
 
   /**
-   * Disable Swiper (if it was enabled). When Swiper is disabled, it will hide all navigation elements and won't respond to any events and interractions
+   * Disable Swiper (if it was enabled). When Swiper is disabled, it will hide all navigation elements and won't respond to any events and interactions
    *
    */
   disable(): void;

--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -30,7 +30,7 @@ export interface SwiperOptions {
   init?: boolean;
 
   /**
-   * Whether Swiper initially enabled. When Swiper is disabled, it will hide all navigation elements and won't respond to any events and interractions
+   * Whether Swiper initially enabled. When Swiper is disabled, it will hide all navigation elements and won't respond to any events and interactions
    *
    * @default true
    */


### PR DESCRIPTION
Noticed a typo in the demo documentation. Found two places where it was used incorrectly. Changed them from "interractions" to "interactions".