### PR TITLE
Fix scss interpolation error

### DIFF
--- a/src/components/pagination/pagination.scss
+++ b/src/components/pagination/pagination.scss
@@ -144,8 +144,8 @@
   }
 }
 @each $paginationColorName, $paginationColorValue in $colors {
-  .swiper-pagination-#{$paginationColorName} {
-    --swiper-pagination-color: #{$paginationColorValue};
+  .swiper-pagination-#{'' + $paginationColorName} {
+    --swiper-pagination-color: #{'' + $paginationColorValue};
   }
 }
 .swiper-pagination-lock {


### PR DESCRIPTION
Fixes nolimits4web/swiper#4553

Currently the implementation of scss interpolation causes a build error. This PR updates the syntax to prevent that.
