### PR TITLE
3-side looped cube face overlapping fix

### DIFF
--- a/src/components/effect-cube/effect-cube.less
+++ b/src/components/effect-cube/effect-cube.less
@@ -56,4 +56,12 @@
       filter: blur(50px);
     }
   }
+  .swiper-slide-prev:not(.swiper-slide-duplicate-next) {
+    pointer-events: auto;
+    visibility: visible;
+  }
+  .swiper-slide-prev.swiper-slide-duplicate-next.swiper-slide-duplicate {
+    pointer-events: none;
+    visibility: hidden;
+  }
 }

--- a/src/components/effect-cube/effect-cube.scss
+++ b/src/components/effect-cube/effect-cube.scss
@@ -56,4 +56,12 @@
       filter: blur(50px);
     }
   }
+  .swiper-slide-prev:not(.swiper-slide-duplicate-next) {
+    pointer-events: auto;
+    visibility: visible;
+  }
+  .swiper-slide-prev.swiper-slide-duplicate-next.swiper-slide-duplicate {
+    pointer-events: none;
+    visibility: hidden;
+  }
 }


### PR DESCRIPTION
The changes applies to the behaviour of duplicated slides (from 3rd to 1st and from 1st to 3rd) for the issue shown with 3-sides cube with loop option enabled. This issue has been previously reported although not followed, the following fix, should resolve these edge-cases that only happen when:

1. Swiper has 3 slides only
2. The loop option is enabled
3. The "Cube effect" is activated.

Related issues:
https://github.com/nolimits4web/swiper/issues/3386
https://github.com/nolimits4web/swiper/issues/1772
https://github.com/nolimits4web/swiper/issues/1752

Probably this can be done better however this solves the issue in a pretty easy way.
