### PR TITLE
Fixes safari scroll issue

### DIFF
--- a/src/components/core/breakpoints/getBreakpoint.js
+++ b/src/components/core/breakpoints/getBreakpoint.js
@@ -5,7 +5,6 @@ export default function getBreakpoint(breakpoints, base = 'window', containerEl)
   let breakpoint = false;
 
   const window = getWindow();
-  const currentWidth = base === 'window' ? window.innerWidth : containerEl.clientWidth;
   const currentHeight = base === 'window' ? window.innerHeight : containerEl.clientHeight;
 
   const points = Object.keys(breakpoints).map((point) => {
@@ -20,7 +19,11 @@ export default function getBreakpoint(breakpoints, base = 'window', containerEl)
   points.sort((a, b) => parseInt(a.value, 10) - parseInt(b.value, 10));
   for (let i = 0; i < points.length; i += 1) {
     const { point, value } = points[i];
-    if (value <= currentWidth) {
+    if (base === 'window') {
+      if (window.matchMedia(`(min-width: ${value}px)`).matches) {
+        breakpoint = point;
+      }
+    } else if (value <= containerEl.clientWidth) {
       breakpoint = point;
     }
   }


### PR DESCRIPTION
Fixes issue: https://github.com/nolimits4web/swiper/issues/4682

If merged, this will use the [window.matchMedia API](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) instead of doing a comparison with the window.innerWidth, which can be flakey in some devices.

This also attains the benefit of making the breakpoint election closer to the CSS counterpart in media queries.

Browser support for window.matchMedia is wide ( https://caniuse.com/matchmedia ) and has no known gotchas associated (apart from using addEventListener on it in Safari, which we don't need).