### PR TITLE
fix(core): don't extend html elements

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -97,7 +97,7 @@ function extend(...args) {
   const noExtend = ['__proto__', 'constructor', 'prototype'];
   for (let i = 1; i < args.length; i += 1) {
     const nextSource = args[i];
-    if (nextSource !== undefined && nextSource !== null) {
+    if (nextSource !== undefined && nextSource !== null && !(nextSource instanceof HTMLElement)) {
       const keysArray = Object.keys(Object(nextSource)).filter((key) => noExtend.indexOf(key) < 0);
       for (let nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex += 1) {
         const nextKey = keysArray[nextIndex];

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -95,9 +95,15 @@ function isObject(o) {
 function extend(...args) {
   const to = Object(args[0]);
   const noExtend = ['__proto__', 'constructor', 'prototype'];
+  // eslint-disable-next-line
+  const HTMLElement = typeof window !== 'undefined' ? window.HTMLElement : undefined;
   for (let i = 1; i < args.length; i += 1) {
     const nextSource = args[i];
-    if (nextSource !== undefined && nextSource !== null && !(nextSource instanceof HTMLElement)) {
+    if (
+      nextSource !== undefined &&
+      nextSource !== null &&
+      !(HTMLElement && nextSource instanceof HTMLElement)
+    ) {
       const keysArray = Object.keys(Object(nextSource)).filter((key) => noExtend.indexOf(key) < 0);
       for (let nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex += 1) {
         const nextKey = keysArray[nextIndex];


### PR DESCRIPTION
Angular SSR build error:
run `npm run angular:dev:ssr` on `master` to reproduce.

```
ERROR RangeError: Maximum call stack size exceeded
    at Array.filter (<anonymous>)
    at extend (D:\projects\swiper\dist\demo\server\home-home-module.js:7616:55)
    at extend (D:\projects\swiper\dist\demo\server\home-home-module.js:7637:15)
    at extend (D:\projects\swiper\dist\demo\server\home-home-module.js:7637:15)
    at extend (D:\projects\swiper\dist\demo\server\home-home-module.js:7637:15)
    at extend (D:\projects\swiper\dist\demo\server\home-home-module.js:7637:15)
    at extend (D:\projects\swiper\dist\demo\server\home-home-module.js:7637:15)
    at extend (D:\projects\swiper\dist\demo\server\home-home-module.js:7637:15)
    at extend (D:\projects\swiper\dist\demo\server\home-home-module.js:7637:15)
    at extend (D:\projects\swiper\dist\demo\server\home-home-module.js:7637:15)
```


`extend()` function from `src/utils.js` passing object from `HTMLElement` type to itself as it recognizes it as Object (that is technically right). That's leading to recursion, as HTMLElement has a lot of inner objects.

This PR adds check `!(nextSource instanceof HTMLElement)` to `extend()` function to skip HTML Elements from extending.

closes #4576