### PR TITLE
chore: auto issue close on missing demo

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -1,0 +1,17 @@
+name: Issue Close Require
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: missing demo
+        uses: actions-cool/issues-helper@v2.2.1
+        with:
+          actions: 'close-issues'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'missing demo'
+          inactive-day: 3


### PR DESCRIPTION
> Please provide a link to a repo that can reproduce the problem you ran into. You can fork one of our [demos](https://swiperjs.com/demos) in codesandbox to get start. A reproduction is required unless you are absolutely sure that the issue is obvious and the provided information is enough to understand the problem. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "missing demo" label. If no reproduction **is provided after 3 days, it will be auto-closed**.