### PR TITLE
Fix #4705. Install modules in SvelteKit

### DIFF
--- a/src/svelte/init-swiper.js
+++ b/src/svelte/init-swiper.js
@@ -2,7 +2,8 @@
 import Swiper from '../../core';
 import { needsNavigation, needsPagination, needsScrollbar } from './utils';
 
-function initSwiper(swiperParams) {
+function initSwiper(swiperParams, modules) {
+  if (modules) Swiper.use(modules);
   return new Swiper(swiperParams);
 }
 

--- a/src/svelte/swiper.svelte
+++ b/src/svelte/swiper.svelte
@@ -17,6 +17,7 @@
 
   let className = undefined;
   export { className as class };
+  export let modules = null;
 
   let containerClasses = 'swiper-container';
   let breakpointChanged = false;
@@ -79,7 +80,7 @@
     },
   });
 
-  swiperInstance = initSwiper(swiperParams);
+  swiperInstance = initSwiper(swiperParams, modules);
   if (swiperInstance.virtual && swiperInstance.params.virtual.enabled) {
     const extendWith = {
       cache: false,


### PR DESCRIPTION
Add a new "modules" property to the Svelte component. To solve the problem with installing additional Swiper modules when used in SvelteKit.

Fix #4705