### PR TITLE
fix: fix server side judge (close #4787)

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -94,7 +94,7 @@ function isObject(o) {
 }
 function isNode(node) {
   // eslint-disable-next-line
-  if (typeof window !== 'undefined' && typeof window.screen !== 'undefined') {
+  if (typeof window !== 'undefined' && typeof window.HTMLElement !== 'undefined') {
     return node instanceof HTMLElement;
   }
   return node && (node.nodeType === 1 || node.nodeType === 11);

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -94,7 +94,7 @@ function isObject(o) {
 }
 function isNode(node) {
   // eslint-disable-next-line
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && typeof window.screen !== 'undefined') {
     return node instanceof HTMLElement;
   }
   return node && (node.nodeType === 1 || node.nodeType === 11);


### PR DESCRIPTION
Mock window object is very frequent in server side rendering, the `isNode` judge is inaccurate。
Maybe we should judge further