### PR TITLE
fix: make `swiperRef` prop not required in SwiperSlide vue component

### DIFF
--- a/src/vue/swiper-slide.js
+++ b/src/vue/swiper-slide.js
@@ -8,7 +8,7 @@ const SwiperSlide = {
       type: String,
       default: 'div',
     },
-    swiperRef: Object,
+    swiperRef: { type: Object, required: false },
     zoom: { type: Boolean, default: undefined },
     virtualIndex: {
       type: [String, Number],

--- a/src/vue/swiper-vue.d.ts
+++ b/src/vue/swiper-vue.d.ts
@@ -466,7 +466,7 @@ declare const SwiperSlide: DefineComponent<{
     type: StringConstructor;
     default: string;
   };
-  swiperRef: SwiperClass;
+  swiperRef: { type: SwiperClass; required: false };
   zoom: { type: BooleanConstructor; default: undefined };
   virtualIndex: {
     type: StringConstructor | NumberConstructor;


### PR DESCRIPTION
I believe this is just a bug that should be fixed since `swiperRef` props is *actually* not a required prop. 

it caught my eye thanks to Volar