### PR TITLE
fix(core): centeredSlides won't work when use creative-effect

### DIFF
--- a/src/modules/effect-creative/effect-creative.js
+++ b/src/modules/effect-creative/effect-creative.js
@@ -32,14 +32,14 @@ export default function EffectCreative({ swiper, extendParams, on }) {
   };
 
   const setTranslate = () => {
-    const { slides, $wrapperEl } = swiper;
+    const { slides, $wrapperEl, slidesSizesGrid } = swiper;
     const params = swiper.params.creativeEffect;
     const { progressMultiplier: multiplier } = params;
 
     const isCenteredSlides = swiper.params.centeredSlides;
 
     if (isCenteredSlides) {
-      const margin = slides.eq(0)[0].offsetWidth / 2 - swiper.params.slidesOffsetBefore || 0;
+      const margin = slidesSizesGrid[0] / 2 - swiper.params.slidesOffsetBefore || 0;
       $wrapperEl.transform(`translateX(calc(50% - ${margin}px))`);
     }
 


### PR DESCRIPTION
Sorry for my poor english.

issue: #5113 

- When using centeredSlides, add a transform value to $wrapperEl
- slidesEl originalProgress use without centeredSlides

https://user-images.githubusercontent.com/16166356/137941678-4d7fb150-acd4-40eb-8a9c-cefac1e11d2c.mp4



