### PR TITLE
feat(core): add support to loop with slotted elements

### DIFF
--- a/src/core/loop/loopCreate.js
+++ b/src/core/loop/loopCreate.js
@@ -6,9 +6,10 @@ export default function loopCreate() {
   const document = getDocument();
   const { params, $wrapperEl } = swiper;
   // Remove duplicated slides
-  $wrapperEl.children(`.${params.slideClass}.${params.slideDuplicateClass}`).remove();
+  const $selector = $($wrapperEl.children()[0].parentNode);
+  $selector.children(`.${params.slideClass}.${params.slideDuplicateClass}`).remove();
 
-  let slides = $wrapperEl.children(`.${params.slideClass}`);
+  let slides = $selector.children(`.${params.slideClass}`);
 
   if (params.loopFillGroupWithBlank) {
     const blankSlidesNum = params.slidesPerGroup - (slides.length % params.slidesPerGroup);
@@ -17,9 +18,9 @@ export default function loopCreate() {
         const blankNode = $(document.createElement('div')).addClass(
           `${params.slideClass} ${params.slideBlankClass}`,
         );
-        $wrapperEl.append(blankNode);
+        $selector.append(blankNode);
       }
-      slides = $wrapperEl.children(`.${params.slideClass}`);
+      slides = $selector.children(`.${params.slideClass}`);
     }
   }
 
@@ -44,9 +45,9 @@ export default function loopCreate() {
     slide.attr('data-swiper-slide-index', index);
   });
   for (let i = 0; i < appendSlides.length; i += 1) {
-    $wrapperEl.append($(appendSlides[i].cloneNode(true)).addClass(params.slideDuplicateClass));
+    $selector.append($(appendSlides[i].cloneNode(true)).addClass(params.slideDuplicateClass));
   }
   for (let i = prependSlides.length - 1; i >= 0; i -= 1) {
-    $wrapperEl.prepend($(prependSlides[i].cloneNode(true)).addClass(params.slideDuplicateClass));
+    $selector.prepend($(prependSlides[i].cloneNode(true)).addClass(params.slideDuplicateClass));
   }
 }


### PR DESCRIPTION
Hello, when we are working with web components and elements that are being introduced via Slot I have detected that the creation of the loop is not working correctly, since it assumes that the children slides are directly mounted on the wrapper node, but in this case the nodes slides are children of the container.

With this change I pretend that the node that I find is the parent node always starting from one of the slides children nodes.

Example:

```
 <my-custom-element>
  <div class="swiper-slide"><p>lorem ipsum</p></div>
  <div class="swiper-slide"><p>lorem ipsum</p></div>
 <div class="swiper-slide"><p>lorem ipsum</p></div>
 </my-custom-element>
```

Inside my webComponent I have the following structure:

```
 <my-custom-element>
   shadow-root
       <div class="container">
          <div class="swipper-wrapper">
                <slot></slot>
          </div>
      </div>
</my-custom-element>
```


my nodes with the swiper-slide class are in my ligthDom when the loop is created it assumes that it has to put the duplicate nodes inside the wrapper, thus eliminating the slot and causing the swiper to stop working.

functional codePen Example all in shadowDom https://codepen.io/davidigza/pen/XWajKmv
CodePen with slotted content and loop this break the node order https://codepen.io/davidigza/pen/rNzMWVv



