### PR TITLE
Fixed typo `progressMultipler` -> `progressMultiplier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@
 - **angular:** better typing ([e132ee8](https://github.com/nolimits4web/Swiper/commit/e132ee8bf420bc7fa38054aaf40e664c2f93dc28))
 - **angular:** better typing ([6b562fa](https://github.com/nolimits4web/Swiper/commit/6b562fa8e403982d6adfae6130497c1cf841ea78))
 - **angular:** support 'strictTemplates' flag ([613f12c](https://github.com/nolimits4web/Swiper/commit/613f12c5ba01e99991fe416bd37ad640bee22d72))
-- **effect-creative:** add `progressMultipler` option ([ed3bd7a](https://github.com/nolimits4web/Swiper/commit/ed3bd7a72b5f8eef23d46319a112b609cf021346))
+- **effect-creative:** add `progressMultiplier` option ([ed3bd7a](https://github.com/nolimits4web/Swiper/commit/ed3bd7a72b5f8eef23d46319a112b609cf021346))
 - **angular:** partial ivy build ([#4834](https://github.com/nolimits4web/Swiper/issues/4834)) ([e86b2b3](https://github.com/nolimits4web/Swiper/commit/e86b2b3011cb15bd41c30db9bad8994128c7b7af))
 - **core** `swiper-container` class to `swiper` ([ad8002c](https://github.com/nolimits4web/Swiper/commit/ad8002c87689936457110350e734766f2fc43dee))
 - **core** `swiper-container` class to `swiper` ([c763c9c](https://github.com/nolimits4web/Swiper/commit/c763c9c92cc05c1426a7250790725e032925b78e))

--- a/src/types/modules/effect-creative.d.ts
+++ b/src/types/modules/effect-creative.d.ts
@@ -83,7 +83,7 @@ export interface CreativeEffectOptions {
    *
    * @default 1
    */
-  progressMultipler?: number;
+  progressMultiplier?: number;
   /**
    * Enable this parameter if your custom transforms require 3D transformations (`translateZ`, `rotateX`, `rotateY` )
    *


### PR DESCRIPTION
Fixed typo `progressMultipler` -> `progressMultiplier`

Fix https://github.com/nolimits4web/swiper-website/issues/191


P.S. @nolimits4web You might want to take a look at this too: https://github.com/nolimits4web/swiper-website/issues/169

Thanks.