### PR TITLE
feat: export Swiper options and class interfaces

### DIFF
--- a/src/vue/swiper-vue.d.ts
+++ b/src/vue/swiper-vue.d.ts
@@ -474,4 +474,9 @@ declare const SwiperSlide: DefineComponent<{
   };
 }>;
 
-export { Swiper, SwiperSlide };
+export { 
+  Swiper, 
+  SwiperSlide,
+  SwiperOptions, 
+  SwiperClass   
+};


### PR DESCRIPTION
When need import `SwiperOptions` interface in typescript project is necessary to import from other module, as below:
```typescript
import { Swiper, SwiperSlide } from 'swiper/vue';
import { SwiperOptions } from 'swiper/types';

const carouselOptions: SwiperOptions = {
...
}
```

But is possible to export the SwiperOptions on `swiper/vue` module, improving the imported module as well.