### PR TITLE
fix(core): fallback $selector to $wrapperEl if no children exist

### DIFF
--- a/cypress/integration/modules/core.js
+++ b/cypress/integration/modules/core.js
@@ -468,4 +468,29 @@ context('Core', () => {
     cy.get(`.swiper-scrollbar`).should('exist');
     cy.get(`.swiper-pagination`).should('exist');
   });
+
+  it('allow init empty Swiper', () => {
+    cy.window().then(async (_window) => {
+      _window.document.body.innerHTML = `
+      <div class="swiper-container">
+        <div class="swiper-wrapper"></div>
+        <div class="swiper-slide"></div>
+      </div>
+      `;
+      _window.swiperRef = new _window.Swiper('.swiper-container', {
+        loop: true,
+        loopedSlides: 0,
+        loopPreventsSlide: false,
+        on: {
+          init: () => {
+            cy.get('.swiper-slide').then((slide) => {
+              _window.swiperRef.addSlide(0, slide);
+            });
+          },
+        },
+      });
+      return _window.swiperRef;
+    });
+    cy.getActiveSlide();
+  });
 });

--- a/src/core/loop/loopCreate.js
+++ b/src/core/loop/loopCreate.js
@@ -6,7 +6,8 @@ export default function loopCreate() {
   const document = getDocument();
   const { params, $wrapperEl } = swiper;
   // Remove duplicated slides
-  const $selector = $($wrapperEl.children()[0].parentNode);
+  const $selector =
+    $wrapperEl.children().length > 0 ? $($wrapperEl.children()[0].parentNode) : $wrapperEl;
   $selector.children(`.${params.slideClass}.${params.slideDuplicateClass}`).remove();
 
   let slides = $selector.children(`.${params.slideClass}`);


### PR DESCRIPTION
issue: https://github.com/nolimits4web/swiper/issues/5172

can not init an empty swiper after this PR was merged: https://github.com/nolimits4web/swiper/pull/5117