### PR TITLE
fix(lazy): only activate preloader-spin animation when slide is activ…

### DIFF
--- a/src/modules/lazy/lazy.less
+++ b/src/modules/lazy/lazy.less
@@ -14,7 +14,6 @@
   margin-top: -21px;
   z-index: 10;
   transform-origin: 50%;
-  animation: none;
   box-sizing: border-box;
   border: 4px solid var(--swiper-preloader-color, var(--swiper-theme-color));
   border-radius: 50%;

--- a/src/modules/lazy/lazy.less
+++ b/src/modules/lazy/lazy.less
@@ -14,11 +14,15 @@
   margin-top: -21px;
   z-index: 10;
   transform-origin: 50%;
-  animation: swiper-preloader-spin 1s infinite linear;
+  animation: none;
   box-sizing: border-box;
   border: 4px solid var(--swiper-preloader-color, var(--swiper-theme-color));
   border-radius: 50%;
   border-top-color: transparent;
+}
+
+.swiper-slide-active .swiper-lazy-preloader {
+  animation: swiper-preloader-spin 1s infinite linear;
 }
 
 .swiper-lazy-preloader-white {

--- a/src/modules/lazy/lazy.less
+++ b/src/modules/lazy/lazy.less
@@ -20,7 +20,7 @@
   border-top-color: transparent;
 }
 
-.swiper-slide-active .swiper-lazy-preloader {
+.swiper-slide-visible .swiper-lazy-preloader {
   animation: swiper-preloader-spin 1s infinite linear;
 }
 

--- a/src/modules/lazy/lazy.scss
+++ b/src/modules/lazy/lazy.scss
@@ -14,7 +14,6 @@
   margin-top: -21px;
   z-index: 10;
   transform-origin: 50%;
-  animation: none;
   box-sizing: border-box;
   border: 4px solid var(--swiper-preloader-color, var(--swiper-theme-color));
   border-radius: 50%;

--- a/src/modules/lazy/lazy.scss
+++ b/src/modules/lazy/lazy.scss
@@ -14,11 +14,15 @@
   margin-top: -21px;
   z-index: 10;
   transform-origin: 50%;
-  animation: swiper-preloader-spin 1s infinite linear;
+  animation: none;
   box-sizing: border-box;
   border: 4px solid var(--swiper-preloader-color, var(--swiper-theme-color));
   border-radius: 50%;
   border-top-color: transparent;
+}
+
+.swiper-slide-active .swiper-lazy-preloader {
+  animation: swiper-preloader-spin 1s infinite linear;
 }
 
 .swiper-lazy-preloader-white {

--- a/src/modules/lazy/lazy.scss
+++ b/src/modules/lazy/lazy.scss
@@ -20,7 +20,7 @@
   border-top-color: transparent;
 }
 
-.swiper-slide-active .swiper-lazy-preloader {
+.swiper-slide-visible .swiper-lazy-preloader {
   animation: swiper-preloader-spin 1s infinite linear;
 }
 


### PR DESCRIPTION
Related to the #5202

When Swiper with Lazy Images module is used, CPU usage is always high on the page even when there is no activity.

Solved by removing spinner animation from all non-activated lazy-preloader elements