### PR TITLE
Added option to allow next nav element at the end of slides, which returns back to the first slide

### DIFF
--- a/playground/react/App.jsx
+++ b/playground/react/App.jsx
@@ -14,7 +14,7 @@ const App = () => {
         slidesPerView={3}
         spaceBetween={50}
         navigation
-        loop
+        allowNextElementAtTheEnd
         scrollbar={{ draggable: true }}
         pagination={{ clickable: true }}
       >

--- a/src/angular/src/swiper.component.ts
+++ b/src/angular/src/swiper.component.ts
@@ -99,6 +99,7 @@ export class SwiperComponent implements OnInit {
   @Input() longSwipesMs: SwiperOptions['longSwipesMs'];
   @Input() followFinger: SwiperOptions['followFinger'];
   @Input() allowTouchMove: SwiperOptions['allowTouchMove'];
+  @Input() allowNextElementAtTheEnd: SwiperOptions['allowNextElementAtTheEnd'];
   @Input() threshold: SwiperOptions['threshold'];
   @Input() touchMoveStopPropagation: SwiperOptions['touchMoveStopPropagation'];
   @Input() touchStartPreventDefault: SwiperOptions['touchStartPreventDefault'];

--- a/src/angular/src/utils/params-list.ts
+++ b/src/angular/src/utils/params-list.ts
@@ -46,6 +46,7 @@ export const paramsList = [
   'longSwipesMs',
   '_followFinger',
   'allowTouchMove',
+  'allowNextElementAtTheEnd',
   '_threshold',
   'touchMoveStopPropagation',
   'touchStartPreventDefault',

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -206,6 +206,8 @@ class Swiper {
       // Touches
       allowTouchMove: swiper.params.allowTouchMove,
 
+      allowNextElementAtTheEnd: swiper.params.allowNextElementAtTheEnd,
+
       touches: {
         startX: 0,
         startY: 0,

--- a/src/core/defaults.js
+++ b/src/core/defaults.js
@@ -72,6 +72,7 @@ export default {
   longSwipesMs: 300,
   followFinger: true,
   allowTouchMove: true,
+  allowNextElementAtTheEnd: false,
   threshold: 0,
   touchMoveStopPropagation: false,
   touchStartPreventDefault: true,

--- a/src/modules/navigation/navigation.js
+++ b/src/modules/navigation/navigation.js
@@ -53,7 +53,7 @@ export default function Navigation({ swiper, extendParams, on, emit }) {
     const { $nextEl, $prevEl } = swiper.navigation;
 
     toggleEl($prevEl, swiper.isBeginning);
-    toggleEl($nextEl, swiper.isEnd);
+    toggleEl($nextEl, swiper.isEnd && !swiper.allowNextElementAtTheEnd);
   }
   function onPrevClick(e) {
     e.preventDefault();
@@ -62,8 +62,12 @@ export default function Navigation({ swiper, extendParams, on, emit }) {
   }
   function onNextClick(e) {
     e.preventDefault();
-    if (swiper.isEnd && !swiper.params.loop) return;
-    swiper.slideNext();
+    if (swiper.isEnd && !swiper.params.loop && !swiper.allowNextElementAtTheEnd) return;
+    if (swiper.isEnd && swiper.allowNextElementAtTheEnd) {
+      swiper.slideTo(0);
+    } else {
+      swiper.slideNext();
+    }
   }
   function init() {
     const params = swiper.params.navigation;

--- a/src/react/params-list.js
+++ b/src/react/params-list.js
@@ -48,6 +48,7 @@ const paramsList = [
   'longSwipesMs',
   '_followFinger',
   'allowTouchMove',
+  'allowNextElementAtTheEnd',
   '_threshold',
   'touchMoveStopPropagation',
   'touchStartPreventDefault',

--- a/src/svelte/params-list.js
+++ b/src/svelte/params-list.js
@@ -48,6 +48,7 @@ const paramsList = [
   'longSwipesMs',
   '_followFinger',
   'allowTouchMove',
+  'allowNextElementAtTheEnd',
   '_threshold',
   'touchMoveStopPropagation',
   'touchStartPreventDefault',

--- a/src/types/swiper-class.d.ts
+++ b/src/types/swiper-class.d.ts
@@ -176,6 +176,11 @@ interface Swiper extends SwiperClass<SwiperEvents> {
   allowTouchMove: boolean;
 
   /**
+   * Do not hide element at the end of carousel - Carousel will go to start after click
+   */
+  allowNextElementAtTheEnd: boolean;
+
+  /**
    * !INTERNAL
    */
   rtlTranslate: boolean;

--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -417,6 +417,11 @@ export interface SwiperOptions {
   allowTouchMove?: boolean;
 
   /**
+   * Do not hide element at the end of carousel - Carousel will go to start after click
+   */
+  allowNextElementAtTheEnd?: boolean | undefined;
+
+  /**
    * Threshold value in px. If "touch distance" will be lower than this value then swiper will not move
    *
    * @default 0

--- a/src/vue/params-list.js
+++ b/src/vue/params-list.js
@@ -48,6 +48,7 @@ const paramsList = [
   'longSwipesMs',
   '_followFinger',
   'allowTouchMove',
+  'allowNextElementAtTheEnd',
   '_threshold',
   'touchMoveStopPropagation',
   'touchStartPreventDefault',

--- a/src/vue/swiper-vue.d.ts
+++ b/src/vue/swiper-vue.d.ts
@@ -195,6 +195,10 @@ declare const Swiper: DefineComponent<
       type: BooleanConstructor;
       default: undefined;
     };
+    allowNextElementAtTheEnd: {
+      type: BooleanConstructor;
+      default: undefined;
+    };
     threshold: { type: NumberConstructor; default: undefined };
     touchMoveStopPropagation: {
       type: BooleanConstructor;

--- a/src/vue/swiper.js
+++ b/src/vue/swiper.js
@@ -70,6 +70,7 @@ const Swiper = {
     longSwipesMs: { type: Number, default: undefined },
     followFinger: { type: Boolean, default: undefined },
     allowTouchMove: { type: Boolean, default: undefined },
+    allowNextElementAtTheEnd: { type: Boolean, default: undefined },
     threshold: { type: Number, default: undefined },
     touchMoveStopPropagation: { type: Boolean, default: undefined },
     touchStartPreventDefault: { type: Boolean, default: undefined },


### PR DESCRIPTION
Hi, I just added small feature for "custom" loop. Recently we had issues with rendering performance of swiper in react and we find out many things in our code to improve and also our UX guys had proposal of making custom loop. This feature allows next navigation element to be shown also at last slide and it allows user to click on it and then it navigates back to first slide. This is much better for performance, since we won't duplicate any slides which would be also rendered and it does help user to navigate back even without loop turned on.

Do you think it would be possible to add this feature to swiper? I also updated app.jsx in react playground, so anyone could try it.
(This is a first time I'm trying to contribute to any GitHub project, so I'm sorry if there is something I should do different in this process.)
Thanks!