### PR TITLE
(fix)Added "svelte": "./swiper.esm.js" to package.json

### DIFF
--- a/src/copy/package.json
+++ b/src/copy/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./swiper.esm.js",
   "module": "./swiper.esm.js",
+  "svelte": "./swiper.esm.js",
   "exports": {
     ".": "./swiper.esm.js",
     "./core": "./swiper.esm.js",


### PR DESCRIPTION
Related to https://github.com/sveltejs/kit/issues/3015 and a few similar Issues

The "svelte" tag missing from package.json seems to cause some errors when building svelte kit applications.

In my testing adding this line to the package.json fixes the problem completely and there are no more errors.