### PR TITLE
chore(ci): run on branches 7, 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: Build
 on:
   push:
-    branches: [master, Swiper6]
+    branches: [master, Swiper6, Swiper7, Swiper8]
   pull_request:
-    branches: [master, Swiper6]
+    branches: [master, Swiper6, Swiper7, Swiper8]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,9 @@
 name: E2E
 on:
   push:
-    branches: [master, Swiper6]
+    branches: [master, Swiper6, Swiper7, Swiper8]
   pull_request:
-    branches: [master, Swiper6]
+    branches: [master, Swiper6, Swiper7, Swiper8]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,9 +1,9 @@
 name: Formatting
 on:
   push:
-    branches: [master, Swiper6]
+    branches: [master, Swiper6, Swiper7, Swiper8]
   pull_request:
-    branches: [master, Swiper6]
+    branches: [master, Swiper6, Swiper7, Swiper8]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,9 @@
 name: Lint
 on:
   push:
-    branches: [master, Swiper6]
+    branches: [master, Swiper6, Swiper7, Swiper8]
   pull_request:
-    branches: [master, Swiper6]
+    branches: [master, Swiper6, Swiper7, Swiper8]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Run CI on Swiper8 (and future Swiper7) branches.
I considered adding it as `Swiper*`, but not sure if it will work (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches) also I dont think we want it to run on < Swiper6 branches.