### PR TITLE
fix(vue): HMR error

### DIFF
--- a/src/vue/get-children.js
+++ b/src/vue/get-children.js
@@ -29,7 +29,7 @@ function getChildren(originalSlots = {}, slidesRef, oldSlidesRef) {
   };
 
   Object.keys(originalSlots).forEach((slotName) => {
-    if (typeof originalSlots[slotName] !== "function") return;
+    if (typeof originalSlots[slotName] !== 'function') return;
     const els = originalSlots[slotName]();
     getSlidesFromElements(els, slotName);
   });

--- a/src/vue/get-children.js
+++ b/src/vue/get-children.js
@@ -29,6 +29,7 @@ function getChildren(originalSlots = {}, slidesRef, oldSlidesRef) {
   };
 
   Object.keys(originalSlots).forEach((slotName) => {
+    if (typeof originalSlots[slotName] !== "function") return;
     const els = originalSlots[slotName]();
     getSlidesFromElements(els, slotName);
   });


### PR DESCRIPTION
this fixes `TypeError: originalSlots[slotName] is not a function` error during HMR in vue by ensuring the function exists.

I havn't opend a issue because it is quite some work to provide a repo and the change is just an assertment.
But I'm not the only one getting this error https://github.com/ionic-team/ionic-framework/issues/24134
