### PR TITLE
feat(coverflow) : allow function modifier

### DIFF
--- a/src/modules/effect-coverflow/effect-coverflow.js
+++ b/src/modules/effect-coverflow/effect-coverflow.js
@@ -28,8 +28,11 @@ export default function EffectCoverflow({ swiper, extendParams, on }) {
       const $slideEl = slides.eq(i);
       const slideSize = slidesSizesGrid[i];
       const slideOffset = $slideEl[0].swiperSlideOffset;
-      const offsetMultiplier =
-        ((center - slideOffset - slideSize / 2) / slideSize) * params.modifier;
+      const centerOffset = (center - slideOffset - slideSize / 2) / slideSize
+      const offsetMultiplier = 
+            typeof params.modifier === 'function' ?
+            params.modifier(centerOffset) :
+            centerOffset * params.modifier;
 
       let rotateY = isHorizontal ? rotate * offsetMultiplier : 0;
       let rotateX = isHorizontal ? 0 : rotate * offsetMultiplier;


### PR DESCRIPTION
## Why

For a project I need to have a coverflow effect that only zoom on the current Item. The coverflow effect is nice but it's not possible to lessen the scaling effect. With this proposal a custom function can be used as a modifier to handle more complex scaling for the coverflow effect.

## Use case

For instance : 

```js
modifier: (v) => between(1, -1, Math.round(v))
```

Would create a scaling that won't affect the elements further they are from the center.