### PR TITLE
fix: add threshold option to thumbs examples

### DIFF
--- a/demos/300-thumbs-gallery.html
+++ b/demos/300-thumbs-gallery.html
@@ -55,6 +55,7 @@
       slidesPerView: 4,
       freeMode: true,
       watchSlidesProgress: true,
+      threshold: 1000
     });
     var galleryTop = new Swiper('.gallery-top', {
       spaceBetween: 10,

--- a/demos/310-thumbs-gallery-loop.html
+++ b/demos/310-thumbs-gallery-loop.html
@@ -57,6 +57,7 @@
       freeMode: true,
       loopedSlides: 5, //looped slides should be the same
       watchSlidesProgress: true,
+      threshold: 1000
     });
     var galleryTop = new Swiper('.gallery-top', {
       spaceBetween: 10,


### PR DESCRIPTION
### This PR
- [x] Adds `threshold` option to thumbs examples


### Context
Due to no `threshold` being set, clicking on thumbnail feels laggy and unresponsive. The intention is to [`threshold` option](https://swiperjs.com/swiper-api#param-threshold) to make the transition smoother and experience better. 

Value is taken from [this comment](https://github.com/nolimits4web/swiper/issues/2934#issuecomment-451178450) in [this issue.](https://github.com/nolimits4web/swiper/issues/2934) 