### PR TITLE
Remove unnecessary vendor prefixes

### DIFF
--- a/src/core/grab-cursor/setGrabCursor.js
+++ b/src/core/grab-cursor/setGrabCursor.js
@@ -10,6 +10,6 @@ export default function setGrabCursor(moving) {
   const el = swiper.params.touchEventsTarget === 'container' ? swiper.el : swiper.wrapperEl;
   el.style.cursor = 'move';
   el.style.cursor = moving ? '-webkit-grabbing' : '-webkit-grab';
-  el.style.cursor = moving ? '-moz-grabbin' : '-moz-grab';
+  el.style.cursor = moving ? '-moz-grabbing' : '-moz-grab';
   el.style.cursor = moving ? 'grabbing' : 'grab';
 }

--- a/src/core/grab-cursor/setGrabCursor.js
+++ b/src/core/grab-cursor/setGrabCursor.js
@@ -9,7 +9,5 @@ export default function setGrabCursor(moving) {
     return;
   const el = swiper.params.touchEventsTarget === 'container' ? swiper.el : swiper.wrapperEl;
   el.style.cursor = 'move';
-  el.style.cursor = moving ? '-webkit-grabbing' : '-webkit-grab';
-  el.style.cursor = moving ? '-moz-grabbing' : '-moz-grab';
   el.style.cursor = moving ? 'grabbing' : 'grab';
 }


### PR DESCRIPTION
The values of the `grab` and `grabbing` style properties are supported from   
Chrome v68+, and Firefox v27+ without vendor prefixes.
https://caniuse.com/css3-cursors-grab


According to the [browserslist](https://github.com/nolimits4web/swiper/blob/65f96c13707c0301b1f4b32cd108540d8126342b/.browserslistrc) rule, Chrome and Firefox are supported up  
to the latest version 5, and Safari only supports 13 or higher.  
```env
# browserslist
IOS >= 13
Safari >= 13
last 5 Chrome versions
last 5 Firefox versions
Samsung >= 12
```
But now Chrome version is 99, Firefox is 98 and Safari is 15.
Therefore, the `-webkit` and `-moz` vendor prefixes in cursor style are unnecessary,