### PR TITLE
fix(core) Don't process transitions or updates on Thumbs module if swiper is destroyed

### DIFF
--- a/src/modules/thumbs/thumbs.js
+++ b/src/modules/thumbs/thumbs.js
@@ -21,7 +21,8 @@ export default function Thumb({ swiper, extendParams, on }) {
 
   function onThumbClick() {
     const thumbsSwiper = swiper.thumbs.swiper;
-    if (!thumbsSwiper) return;
+    if (!thumbsSwiper || thumbsSwiper.destroyed) return;
+
     const clickedIndex = thumbsSwiper.clickedIndex;
     const clickedSlide = thumbsSwiper.clickedSlide;
     if (clickedSlide && $(clickedSlide).hasClass(swiper.params.thumbs.slideThumbActiveClass))
@@ -90,7 +91,7 @@ export default function Thumb({ swiper, extendParams, on }) {
 
   function update(initial) {
     const thumbsSwiper = swiper.thumbs.swiper;
-    if (!thumbsSwiper) return;
+    if (!thumbsSwiper || thumbsSwiper.destroyed) return;
 
     const slidesPerView =
       thumbsSwiper.params.slidesPerView === 'auto'
@@ -204,18 +205,17 @@ export default function Thumb({ swiper, extendParams, on }) {
     update(true);
   });
   on('slideChange update resize observerUpdate', () => {
-    if (!swiper.thumbs.swiper) return;
     update();
   });
   on('setTransition', (_s, duration) => {
     const thumbsSwiper = swiper.thumbs.swiper;
-    if (!thumbsSwiper) return;
+    if (!thumbsSwiper || thumbsSwiper.destroyed) return;
     thumbsSwiper.setTransition(duration);
   });
   on('beforeDestroy', () => {
     const thumbsSwiper = swiper.thumbs.swiper;
-    if (!thumbsSwiper) return;
-    if (swiperCreated && thumbsSwiper) {
+    if (!thumbsSwiper || thumbsSwiper.destroyed) return;
+    if (swiperCreated) {
       thumbsSwiper.destroy();
     }
   });


### PR DESCRIPTION
There is a weird situation in React / Next when you can switch between multiple instances of the Thumb swiper when switching between pages. It hits some edge cases of the Thumb module where it calls transitions and updates on a swiper which is destroyed, which obviously causes a ton of errors.

This MR aims to be a bit more defensive about these things to avoid trying to trigger transitions or updates on destroyed swipers.

Give me a shout if you want me to explain further or if I missed a critical step.

I struggled reproducing it in a small example, because it's linked to some pretty complex navigation behaviour in Next. But I have a production environment application I can point you to that triggers it an awful lot. I can always send a link to that one in a DM. 