### PR TITLE
Fix: "TypeError: Cannot read properties of undefined (reading 'length')" in on('virtualUpdate') by checking if swiper.slides is set

### DIFF
--- a/src/shared/effect-init.js
+++ b/src/shared/effect-init.js
@@ -28,7 +28,7 @@ export default function effectInit(params) {
       requireUpdateOnVirtual = true;
     }
     requestAnimationFrame(() => {
-      if (requireUpdateOnVirtual && swiper.slides.length) {
+      if (requireUpdateOnVirtual && swiper.slides && swiper.slides.length) {
         setTranslate();
         requireUpdateOnVirtual = false;
       }


### PR DESCRIPTION
Hello

I'm using the react components with in a fairly complex component using the virtual settings. To force a full rebuild of swiper (e.g. while toggling between fullscreen and not fullscreen view) I update the `key` param. 

By doing so I experienced that an unhandled exception in the `requestAnimationFrame` enqueued by `on('virtualUpdate')`. 

Chrome: `TypeError: Cannot read properties of undefined (reading 'length')`
Firefor: `TypeError: swiper.slides is undefined`

I suppose this happens because the requested animation frame is being processed after or while the change of the `key` reset the swiper object. 

I've only added a check if `swiper.slides` is set at all and could remove the error in my code.

Thank you!
