### PR TITLE
fix(pagination): formatter functions now accept strings as return values

### DIFF
--- a/src/types/modules/pagination.d.ts
+++ b/src/types/modules/pagination.d.ts
@@ -120,13 +120,13 @@ export interface PaginationOptions {
    * format fraction pagination current number. Function receives current number,
    * and you need to return formatted value
    */
-  formatFractionCurrent?: (number: number) => number;
+  formatFractionCurrent?: (number: number) => number | string;
 
   /**
    * format fraction pagination total number. Function receives total number, and you
    * need to return formatted value
    */
-  formatFractionTotal?: (number: number) => number;
+  formatFractionTotal?: (number: number) => number | string;
 
   /**
    * This parameter allows totally customize pagination bullets, you need to pass here a function that accepts `index` number of


### PR DESCRIPTION
Currently both `formatFractionCurrent` and `formatFractionTotal` accept only callbacks which return a number. This makes it impossible write functions like this when using TypeScript (without using `any`):

```ts
pagination: {
  el: '#swiper',
  formatFractionCurrent(number) {
      const formatter = new Intl.NumberFormat('en-US', { ... })
      return formatter.format(number)
  },
},
```

The above code produces this error: `Type '(number: number) => string' is not assignable to type '(number: number) => number'.`

Since the values returned by theese functions are directly used inside the DOM7 elements `.text()` functions (see [this](https://github.com/nolimits4web/swiper/blob/95c882c50a798ebe7adc20fcb61765aace0edbfc/src/modules/pagination/pagination.js#L184) and [this](https://github.com/nolimits4web/swiper/blob/95c882c50a798ebe7adc20fcb61765aace0edbfc/src/modules/pagination/pagination.js#L185) line) it's safe to change the function signatures.