### PR TITLE
fix(navigation): remove duplicated rules

### DIFF
--- a/src/modules/navigation/navigation.less
+++ b/src/modules/navigation/navigation.less
@@ -27,7 +27,6 @@
     font-size: var(--swiper-navigation-size);
     text-transform: none !important;
     letter-spacing: 0;
-    text-transform: none;
     font-variant: initial;
     line-height: 1;
   }

--- a/src/modules/navigation/navigation.scss
+++ b/src/modules/navigation/navigation.scss
@@ -30,7 +30,6 @@
     font-size: var(--swiper-navigation-size);
     text-transform: none !important;
     letter-spacing: 0;
-    text-transform: none;
     font-variant: initial;
     line-height: 1;
   }


### PR DESCRIPTION
Removed duplicated `text-transform: none;` property from pagination module, there is already one with the `!important` flag
