### PR TITLE
History plugin fixes and new option adding

### DIFF
--- a/src/modules/history/history.js
+++ b/src/modules/history/history.js
@@ -7,7 +7,7 @@ export default function History({ swiper, extendParams, on }) {
       root: '',
       replaceState: false,
       key: 'slides',
-      keepQuery: true,
+      keepQuery: false,
     },
   });
 

--- a/src/modules/history/history.js
+++ b/src/modules/history/history.js
@@ -59,7 +59,7 @@ export default function History({ swiper, extendParams, on }) {
     } else if (!location.pathname.includes(key)) {
       value = `${key}/${value}`;
     }
-    if (swiper.params.h.keepQuery) {
+    if (swiper.params.history.keepQuery) {
       value += location.search;
     }
     const currentState = window.history.state;

--- a/src/modules/history/history.js
+++ b/src/modules/history/history.js
@@ -7,6 +7,7 @@ export default function History({ swiper, extendParams, on }) {
       root: '',
       replaceState: false,
       key: 'slides',
+      keepQuery: true,
     },
   });
 
@@ -58,6 +59,9 @@ export default function History({ swiper, extendParams, on }) {
     } else if (!location.pathname.includes(key)) {
       value = `${key}/${value}`;
     }
+    if (swiper.params.h.keepQuery) {
+      value += location.search;
+    }
     const currentState = window.history.state;
     if (currentState && currentState.value === value) {
       return;
@@ -86,7 +90,7 @@ export default function History({ swiper, extendParams, on }) {
 
   const setHistoryPopState = () => {
     paths = getPathValues(swiper.params.url);
-    scrollToSlide(swiper.params.speed, swiper.paths.value, false);
+    scrollToSlide(swiper.params.speed, paths.value, false);
   };
 
   const init = () => {

--- a/src/types/modules/history.d.ts
+++ b/src/types/modules/history.d.ts
@@ -4,6 +4,13 @@ export interface HistoryEvents {}
 
 export interface HistoryOptions {
   /**
+   * Enables History Plugin.
+   *
+   * @default false
+   */
+  enabled?: boolean;
+
+  /**
    * Swiper page root, useful to specify when you use Swiper history mode not on root website page.
    * For example can be `https://my-website.com/` or `https://my-website.com/subpage/` or `/subpage/`
    *
@@ -26,4 +33,11 @@ export interface HistoryOptions {
    * @default 'slides'
    */
   key?: string;
+
+  /**
+   * Keep query parameters when changing browser url.
+   *
+   * @default false
+   */
+  keepQuery?: boolean;
 }


### PR DESCRIPTION
- [ADDED] (keepQuery) New option to keep the query string parameters when changing user when navigating
- [FIXED] History back via browser button not working
- [ADDED] typing for History plugin options
> - enabled?: boolean
> - keepQuery?: boolean