### PR TITLE
fix incorrect parameters in event dispatching in Svelte

### DIFF
--- a/src/svelte/swiper.svelte
+++ b/src/svelte/swiper.svelte
@@ -77,7 +77,7 @@
   };
 
   swiperParams.onAny = (event, ...args) => {
-    dispatch(event, [args]);
+    dispatch(event, args);
   };
   Object.assign(swiperParams.on, {
     _beforeBreakpoint: onBeforeBreakpoint,


### PR DESCRIPTION
The Svelte type definitions for custom events are declared as:
```typescript
declare class Swiper extends SvelteComponentTyped<
  SwiperProps,
  {
    swiper: CustomEvent<void>;
    autoplayStart: CustomEvent<[swiper: SwiperClass]>;
    // ...
    lazyImageLoad: CustomEvent<[swiper: SwiperClass, slideEl: HTMLElement, imageEl: HTMLElement]>;
    // ...
}
```

I couldn't find those in the [sources](https://github.com/nolimits4web/swiper/blob/master/src/svelte/swiper-svelte.d.ts), so I assume they're [generated](https://github.com/nolimits4web/swiper/blob/master/scripts/build-types.js) during the build process.

As you can see, an event handler subscribing to one of these events, should receive an array with either a single element (i.e. the swiper instance) or more parameters.

Theres a bug in the event delegation from Swipers internal state to Svelte at [`swiper.svelte`](https://github.com/nolimits4web/swiper/blob/master/src/svelte/swiper.svelte#L80). Instead of passing the original event parameters along, they're instead wrapped in another array. This is due to the fact of incorrect usage of the `...args` spread parameter. The actual type is something like `CustomEvent<[[swiper: SwiperClass]]>`, right now.

One problem arises, though, because this is sort of a breaking change. Project that currently rely on that misbehavior would break. If anyone used TypeScript and the definitions, they should've already noticed that.

~I feel like this could also be checked in the CI. Unfortunately, you're not building svelte in the CI yet or at least on GitHub, as it seems. How do you feel about adding examples for all the integrations (e.g. Svelte, Vue and React) and then just build them as well to see if any warnings/errors are emitted. We could use the TypeScript compiler in "check" mode to spot any obvious type incompatibilities. The svelte template also ships with a handy [check command](https://github.com/sveltejs/template/blob/master/scripts/setupTypeScript.js#L35), to verify all files.~ Only if `swiper.svelte` was strongly typed, this might be detectable by static checks.