### PR TITLE
Fix type Number in slideToLoop.js

### DIFF
--- a/src/core/slide/slideToLoop.js
+++ b/src/core/slide/slideToLoop.js
@@ -4,6 +4,31 @@ export default function slideToLoop(
   runCallbacks = true,
   internal,
 ) {
+  if (typeof index === 'string') {
+    /**
+     * The `index` argument converted from `string` to `number`.
+     * @type {number}
+     */
+    const indexAsNumber = parseInt(index, 10);
+
+    /**
+     * Determines whether the `index` argument is a valid `number`
+     * after being converted from the `string` type.
+     * @type {boolean}
+     */
+    const isValidNumber = isFinite(indexAsNumber);
+
+    if (!isValidNumber) {
+      throw new Error(
+        `The passed-in 'index' (string) couldn't be converted to 'number'. [${index}] given.`,
+      );
+    }
+
+    // Knowing that the converted `index` is a valid number,
+    // we can update the original argument's value.
+    index = indexAsNumber;
+  }
+  
   const swiper = this;
   let newIndex = index;
   if (swiper.params.loop) {

--- a/src/core/slide/slideToLoop.js
+++ b/src/core/slide/slideToLoop.js
@@ -28,7 +28,7 @@ export default function slideToLoop(
     // we can update the original argument's value.
     index = indexAsNumber;
   }
-  
+
   const swiper = this;
   let newIndex = index;
   if (swiper.params.loop) {


### PR DESCRIPTION
You should check **slideToLoop** function for Number type as you did in **slideTo**, because in case with custom pagination, developer may use own structure with data attributes and pass those arguments to **slideToLoop**. 

In my case I have broken pagination because **slideToLoop** function returned '35' with Math '3' + swiper.loopedSlides // 5

```
const index = Number(event.target.dataset.slideto); // '3'

if (this.options.loop) {
    this.slider.slideToLoop(index); //  => '35'
} else {
    this.slider.slideTo(index); // => 3
}
```

