### PR TITLE
chore: add react as a peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,14 @@
       },
       "engines": {
         "node": ">= 4.7.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -171,6 +171,14 @@
     "dom7": "^4.0.4",
     "ssr-window": "^4.0.2"
   },
+  "peerDependencies": {
+    "react": "^17 || ^18"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
   "lint-staged": {
     "*.{js,svelte,jsx}": "eslint --cache --fix"
   }

--- a/src/copy/package.json
+++ b/src/copy/package.json
@@ -160,5 +160,13 @@
   "dependencies": {
     "dom7": "^4.0.4",
     "ssr-window": "^4.0.2"
+  },
+  "peerDependencies": {
+    "react": "^17 || ^18"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
This makes the dependency on react explicit, which makes Yarn PnP happy. It's listed as an optional peerDependency so it's not automatically installed. Feel free to update the version ranges as needed.