### PR TITLE
fix: slide card click event would occasionally fail due to triggering…

### DIFF
--- a/src/core/events/onTouchStart.js
+++ b/src/core/events/onTouchStart.js
@@ -38,7 +38,7 @@ export default function onTouchStart(event) {
   if (params.touchEventsTarget === 'wrapper') {
     if (!$targetEl.closest(swiper.wrapperEl).length) return;
   }
-  data.isTouchEvent = e.type === 'touchstart';
+  data.isTouchEvent = e.type === 'touchstart' || e.type === 'pointerdown';
   if (!data.isTouchEvent && 'which' in e && e.which === 3) return;
   if (!data.isTouchEvent && 'button' in e && e.button > 0) return;
   if (data.isTouched && data.isMoved) return;


### PR DESCRIPTION
I have found the PC click event occasionally failed. The reason is that the click event did not take effect because pointerDown/PointerMove  events(Touch Events) was triggered and the event was not blocked at the boundary condition, the current version only intercepts the TouchStart event on mobile. But Pointerdown also belongs to Touch Events
