### PR TITLE
Allow slideLabelMessage: null

### DIFF
--- a/src/modules/a11y/a11y.js
+++ b/src/modules/a11y/a11y.js
@@ -185,16 +185,18 @@ export default function A11y({ swiper, extendParams, on }) {
       ? swiper.slides.filter((el) => !el.classList.contains(swiper.params.slideDuplicateClass))
           .length
       : swiper.slides.length;
-    swiper.slides.each((slideEl, index) => {
-      const $slideEl = $(slideEl);
-      const slideIndex = swiper.params.loop
-        ? parseInt($slideEl.attr('data-swiper-slide-index'), 10)
-        : index;
-      const ariaLabelMessage = params.slideLabelMessage
-        .replace(/\{\{index\}\}/, slideIndex + 1)
-        .replace(/\{\{slidesLength\}\}/, slidesLength);
-      addElLabel($slideEl, ariaLabelMessage);
-    });
+    if (params.slideLabelMessage) {
+      swiper.slides.each((slideEl, index) => {
+        const $slideEl = $(slideEl);
+        const slideIndex = swiper.params.loop
+          ? parseInt($slideEl.attr('data-swiper-slide-index'), 10)
+          : index;
+        const ariaLabelMessage = params.slideLabelMessage
+          .replace(/\{\{index\}\}/, slideIndex + 1)
+          .replace(/\{\{slidesLength\}\}/, slidesLength);
+        addElLabel($slideEl, ariaLabelMessage);
+      });
+    }
   };
 
   const init = () => {


### PR DESCRIPTION
Related issue: #5782

This is an attempt to solve the error when slideLabelMessage is set to null in a11y settings. Seems to work with a quick test.

Food for thought: slideLabelMessage should be null by default, instead of `slideLabelMessage: '{{index}} / {{slidesLength}}',`. It's not practical to add text-overriding slide numbering for screen-readers. I decided to not include that null-default in my PR though at this time.