### PR TITLE
Fix Typescript errors with ref

### DIFF
--- a/src/react/swiper-react.d.ts
+++ b/src/react/swiper-react.d.ts
@@ -78,8 +78,9 @@ interface SwiperProps
     | 'onScroll'
   > {}
 interface SwiperSlideProps extends React.HTMLAttributes<HTMLElement> {}
+interface SwiperInstance = typeof SwiperClass
 
-declare const Swiper: React.FunctionComponent<SwiperProps>;
+declare const Swiper: React.ForwardRefExoticComponent<SwiperProps & React.RefAttributes<SwiperClass>>;
 declare const SwiperSlide: React.VoidFunctionComponent<SwiperSlideProps>;
 
 declare const useSwiper: () => SwiperClass;


### PR DESCRIPTION
Since swiper for react uses forward ref, we need to fix exported types. Also, we need type as alias for `SwiperCore`

With this fix we can write code like this:

```tsx
import type { SwiperInstance } from 'swiper/react/swiper-react';
import { Swiper, SwiperSlide } from 'swiper/react/swiper-react';

// ...
const swiperRef = useRef<SwiperInstance>(null);

// ...
<button
  className="button-outside-of-swiper-area"
  type="button"
  onClick={() => swiperRef.current?.slideNext()}
/>
<Swiper
  ref={swiperRef}
></Swiper>
// ...

```

Related issues: 
- #5500
- #5668
