### PR TITLE
fix(thumb): active class gets removed

### DIFF
--- a/src/modules/thumbs/thumbs.js
+++ b/src/modules/thumbs/thumbs.js
@@ -98,6 +98,36 @@ export default function Thumb({ swiper, extendParams, on }) {
         ? thumbsSwiper.slidesPerViewDynamic()
         : thumbsSwiper.params.slidesPerView;
 
+    // Activate thumbs
+    let thumbsToActivate = 1;
+    const thumbActiveClass = swiper.params.thumbs.slideThumbActiveClass;
+
+    if (swiper.params.slidesPerView > 1 && !swiper.params.centeredSlides) {
+      thumbsToActivate = swiper.params.slidesPerView;
+    }
+
+    if (!swiper.params.thumbs.multipleActiveThumbs) {
+      thumbsToActivate = 1;
+    }
+
+    thumbsToActivate = Math.floor(thumbsToActivate);
+
+    thumbsSwiper.slides.removeClass(thumbActiveClass);
+    if (
+      thumbsSwiper.params.loop ||
+      (thumbsSwiper.params.virtual && thumbsSwiper.params.virtual.enabled)
+    ) {
+      for (let i = 0; i < thumbsToActivate; i += 1) {
+        thumbsSwiper.$wrapperEl
+          .children(`[data-swiper-slide-index="${swiper.realIndex + i}"]`)
+          .addClass(thumbActiveClass);
+      }
+    } else {
+      for (let i = 0; i < thumbsToActivate; i += 1) {
+        thumbsSwiper.slides.eq(swiper.realIndex + i).addClass(thumbActiveClass);
+      }
+    }
+
     const autoScrollOffset = swiper.params.thumbs.autoScrollOffset;
     const useOffset = autoScrollOffset && !thumbsSwiper.params.loop;
     if (swiper.realIndex !== thumbsSwiper.realIndex || useOffset) {
@@ -164,36 +194,6 @@ export default function Thumb({ swiper, extendParams, on }) {
           // newThumbsIndex = newThumbsIndex - slidesPerView + 1;
         }
         thumbsSwiper.slideTo(newThumbsIndex, initial ? 0 : undefined);
-      }
-    }
-
-    // Activate thumbs
-    let thumbsToActivate = 1;
-    const thumbActiveClass = swiper.params.thumbs.slideThumbActiveClass;
-
-    if (swiper.params.slidesPerView > 1 && !swiper.params.centeredSlides) {
-      thumbsToActivate = swiper.params.slidesPerView;
-    }
-
-    if (!swiper.params.thumbs.multipleActiveThumbs) {
-      thumbsToActivate = 1;
-    }
-
-    thumbsToActivate = Math.floor(thumbsToActivate);
-
-    thumbsSwiper.slides.removeClass(thumbActiveClass);
-    if (
-      thumbsSwiper.params.loop ||
-      (thumbsSwiper.params.virtual && thumbsSwiper.params.virtual.enabled)
-    ) {
-      for (let i = 0; i < thumbsToActivate; i += 1) {
-        thumbsSwiper.$wrapperEl
-          .children(`[data-swiper-slide-index="${swiper.realIndex + i}"]`)
-          .addClass(thumbActiveClass);
-      }
-    } else {
-      for (let i = 0; i < thumbsToActivate; i += 1) {
-        thumbsSwiper.slides.eq(swiper.realIndex + i).addClass(thumbActiveClass);
       }
     }
   }


### PR DESCRIPTION
The thumbs active class get's applied and removed right after when the thumbs slider slides the next group of thumbs into view. This only happens when using the library or framework components as those are [emitting](https://github.com/nolimits4web/swiper/blob/master/src/core/core.js#L298) the `_slideClass` update event as part of [sliding to](https://github.com/nolimits4web/swiper/blob/master/src/modules/thumbs/thumbs.js#L166) the next thumbs group. At this time they do not yet contain the class information of the new active thumb, then the active thumbs class [gets toggled ](https://github.com/nolimits4web/swiper/blob/master/src/modules/thumbs/thumbs.js#L196) via direct dom manipulation and afterwards the emitted events from before that where being queued are executed and remove the active class again. This PR prevents this behavior by toggling the thumb active classes before emitting the events.

Relates issues: #5501, #4748
