### PR TITLE
fix(vue): virtualUpdate event is not declared

### DIFF
--- a/src/vue/swiper.js
+++ b/src/vue/swiper.js
@@ -224,6 +224,7 @@ const Swiper = {
     'transitionStart',
     'unlock',
     'update',
+    'virtualUpdate',
     'zoomChange',
   ],
   setup(props, { slots: originalSlots, emit }) {


### PR DESCRIPTION
Hello,

While using Virtual module, Vue displays the warning below
<img width="904" alt="Screen Shot 2022-06-28 at 11 32 48" src="https://user-images.githubusercontent.com/33267776/176133275-eb824e31-cd54-4d61-a407-9f9e80dd1c11.png">

This PR fixed it.
