### PR TITLE
a11y: allow disabling slideRole

### DIFF
--- a/src/modules/a11y/a11y.js
+++ b/src/modules/a11y/a11y.js
@@ -179,7 +179,9 @@ export default function A11y({ swiper, extendParams, on }) {
     if (params.itemRoleDescriptionMessage) {
       addElRoleDescription($(swiper.slides), params.itemRoleDescriptionMessage);
     }
-    addElRole($(swiper.slides), params.slideRole);
+    if (params.slideRole) {
+      addElRole($(swiper.slides), params.slideRole);
+    }
 
     const slidesLength = swiper.params.loop
       ? swiper.slides.filter((el) => !el.classList.contains(swiper.params.slideDuplicateClass))


### PR DESCRIPTION
I want to add the slides as `ul > li` like in this [W3C example](https://www.w3.org/WAI/tutorials/carousels/working-example/). 

```
<ul className="swiper-wrapper" [..]>
  <li className="swiper-slide" [..]>
    [..]
  </li>
</ul>
```

Now I have to set `slideRole: 'listitem'`, which is redundant. This allows setting slideRole to null.