### PR TITLE
Stop using cloneNode in sliders without loops in SolidJS

### DIFF
--- a/src/solid/swiper.js
+++ b/src/solid/swiper.js
@@ -191,11 +191,7 @@ const Swiper = (props) => {
       return renderVirtual(swiperRef, slides, virtualData());
     }
     if (!params().params.loop || (swiperRef && swiperRef.destroyed)) {
-      return slides.map((child) => {
-        const node = child.cloneNode(true);
-        node.swiper = swiperRef;
-        return node;
-      });
+      return slides;
     }
     return renderLoop(swiperRef, slides, params().params);
   }

--- a/src/solid/virtual.js
+++ b/src/solid/virtual.js
@@ -10,10 +10,8 @@ function renderVirtual(swiper, slides, virtualData) {
   return slides
     .filter((child, index) => index >= virtualData.from && index <= virtualData.to)
     .map((child) => {
-      const node = child.cloneNode(true);
-      node.swiper = swiper;
-      Object.assign(node.style, style);
-      return node;
+      Object.assign(child.style, style);
+      return child;
     });
 }
 


### PR DESCRIPTION
This allows events to be assigned to the slides as usually

Before it didn't work:
```html
<Swiper>
  <SwiperSlide>
    <button onClick={() => window.alert("clicked")}>
      Click me!
    </button>
  </SwiperSlide>
</Swiper>
```

Now it works