### PR TITLE
fix(angular): slidesPerGroupAuto is missing in params list for angular

### DIFF
--- a/src/angular/src/utils/params-list.ts
+++ b/src/angular/src/utils/params-list.ts
@@ -30,6 +30,7 @@ export const paramsList = [
   '_grid',
   '_slidesPerGroup',
   '_slidesPerGroupSkip',
+  '_slidesPerGroupAuto',
   '_centeredSlides',
   '_centeredSlidesBounds',
   '_slidesOffsetBefore',


### PR DESCRIPTION
Without this `_slidesPerGroup` param, using the following config doesn't take `slidesPerGroupAuto` into account:
```javascript
config = {
  slidesPerView: 'auto',
  slidesPerGroupAuto: true,
  navigation: true,
}
```

A temporary workaround could be defining it in `extendDefaults`:
```javascript
SwiperCore.extendDefaults({
  slidesPerGroupAuto: true,
});
```

Fixes https://github.com/nolimits4web/swiper/issues/5932