### PR TITLE
Types: add missing AutoplayMethods members

### DIFF
--- a/src/types/modules/autoplay.d.ts
+++ b/src/types/modules/autoplay.d.ts
@@ -7,6 +7,21 @@ export interface AutoplayMethods {
   running: boolean;
 
   /**
+   * Whether autoplay is paused
+   */
+  paused: boolean;
+
+  /**
+   * Pause autoplay
+   */
+  pause(speed?: number): void;
+
+  /**
+   * Run the autoplay logic
+   */
+  run(): void;
+
+  /**
    * Start autoplay
    */
   start(): boolean;


### PR DESCRIPTION
Autoplay typing misses some members that might be handy to have (such as `paused` and `pause()`). This change fixes it.