### PR TITLE
🐛  Fix swiperRef for Vue swiperSlide

### DIFF
--- a/src/vue/swiper-slide.js
+++ b/src/vue/swiper-slide.js
@@ -37,7 +37,7 @@ const SwiperSlide = {
     }
 
     onMounted(() => {
-      if (!swiperRef.value) return;
+      if (!swiperRef || !swiperRef.value) return;
       swiperRef.value.on('_slideClass', updateClasses);
       eventAttached = true;
     });


### PR DESCRIPTION
In [this PR](https://github.com/nolimits4web/swiper/pull/4992) the `swiperRef` was made optional in the Vue `swiperSlide`, which will throw if during mount the swiperRef is absent. 
