### PR TITLE
feat(build-config): allow to custom modules by process.env.SWIPER_BUILD_MODULES

### DIFF
--- a/scripts/build-config.js
+++ b/scripts/build-config.js
@@ -1,4 +1,8 @@
-export const modules = [
+import { parseSwiperBuildModulesEnv } from './utils/helper.js';
+
+const envBuildModules = parseSwiperBuildModulesEnv();
+
+export const modules = envBuildModules || [
   'virtual',
   'keyboard',
   'mousewheel',

--- a/scripts/build-js-bundle.js
+++ b/scripts/build-js-bundle.js
@@ -10,6 +10,7 @@ import { modules as configModules } from './build-config.js';
 import { outputDir } from './utils/output-dir.js';
 import { banner } from './utils/banner.js';
 import isProd from './utils/isProd.js';
+import { capitalizeString } from './utils/helper.js';
 
 async function buildEntry(modules, format, browser = false) {
   const isUMD = format === 'umd';
@@ -83,19 +84,7 @@ export default async function buildJsBundle() {
   elapsed.start('bundle');
   const modules = [];
   configModules.forEach((name) => {
-    // eslint-disable-next-line
-    const capitalized = name
-      .split('-')
-      .map((word) => {
-        return word
-          .split('')
-          .map((char, index) => {
-            if (index === 0) return char.toUpperCase();
-            return char;
-          })
-          .join('');
-      })
-      .join('');
+    const capitalized = capitalizeString(name);
     const jsFilePath = `./src/modules/${name}/${name}.js`;
     if (fs.existsSync(jsFilePath)) {
       modules.push({ name, capitalized });

--- a/scripts/build-js-core.js
+++ b/scripts/build-js-core.js
@@ -5,6 +5,7 @@ import elapsed from 'elapsed-time-logger';
 import { modules as configModules } from './build-config.js';
 import { outputDir } from './utils/output-dir.js';
 import { banner } from './utils/banner.js';
+import { capitalizeString } from './utils/helper.js';
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 /* eslint no-console: "off" */
 const exec = execSh.promise;
@@ -31,19 +32,7 @@ export default async function build() {
   elapsed.start('core');
   const modules = [];
   configModules.forEach((name) => {
-    // eslint-disable-next-line
-    const capitalized = name
-      .split('-')
-      .map((word) => {
-        return word
-          .split('')
-          .map((char, index) => {
-            if (index === 0) return char.toUpperCase();
-            return char;
-          })
-          .join('');
-      })
-      .join('');
+    const capitalized = capitalizeString(name);
     const jsFilePath = `./src/modules/${name}/${name}.js`;
     if (fs.existsSync(jsFilePath)) {
       modules.push({ name, capitalized });

--- a/scripts/utils/helper.js
+++ b/scripts/utils/helper.js
@@ -9,7 +9,9 @@ export function capitalizeString(str) {
  */
 export function parseSwiperBuildModulesEnv() {
   if (process.env.SWIPER_BUILD_MODULES) {
-    const buildModules = process.env.SWIPER_BUILD_MODULES.split(/[,\s]+/);
+    const buildModules = process.env.SWIPER_BUILD_MODULES.split(/[,\s]+/).filter(
+      (moduleName) => moduleName, // ensure to empty will be removed
+    );
     if (buildModules.length) return buildModules;
   }
   return null;

--- a/scripts/utils/helper.js
+++ b/scripts/utils/helper.js
@@ -1,0 +1,16 @@
+export function capitalizeString(str) {
+  return str.replace(/(?:^|-)([a-z])/g, (m, char) => char.toUpperCase());
+}
+
+/**
+ * Parse build modules from env `SWIPER_BUILD_MODULES`.<br>
+ * Will return null if env is not set or empty
+ * @returns {string[]|null}
+ */
+export function parseSwiperBuildModulesEnv() {
+  if (process.env.SWIPER_BUILD_MODULES) {
+    const buildModules = process.env.SWIPER_BUILD_MODULES.split(/[,\s]+/);
+    if (buildModules.length) return buildModules;
+  }
+  return null;
+}


### PR DESCRIPTION
I need to build a custom bundle swiperjs and I've followed [instruction here](https://swiperjs.com/swiper-api#using-build-script).
I want my `swiper` being up to date with master so I point `./swiper` as submodule of `nolimits4web/swiper#master`.
Problem that if I change  `var modules` in file `build-config.js` to build customize module, it looks good except that I can not commit changes of `build-config.js`
So I created this pull that can help me tell builder which modules should build by setup an environment variable `SWIPER_BUILD_MODULES` that includes build modules joined by comma `,`
```bash
SWIPER_BUILD_MODULES=navigation,pagination,lazy npm run build:bundle
```