### PR TITLE
Fix minor sentence construction issue

### DIFF
--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -653,7 +653,7 @@ export interface SwiperOptions {
   loopPreventsSlide?: boolean;
 
   /**
-   * Allows to set different parameter for different responsive breakpoints (screen sizes). Not all parameters can be changed in breakpoints, only those which are not required different layout and logic, like `slidesPerView`, `slidesPerGroup`, `spaceBetween`, `grid.rows`. Such parameters like `loop` and `effect` won't work
+   * Allows to set different parameter for different responsive breakpoints (screen sizes). Not all parameters can be changed in breakpoints, only those which do not require different layout and logic, like `slidesPerView`, `slidesPerGroup`, `spaceBetween`, `grid.rows`. Such parameters like `loop` and `effect` won't work
    *
    * @example
    * ```js


### PR DESCRIPTION
This fix aims to improve readability of the `breakpoints` attribute option in the documentation