### PR TITLE
fix: mobile touch on focusable elements jumps element to first position

### DIFF
--- a/src/modules/a11y/a11y.js
+++ b/src/modules/a11y/a11y.js
@@ -186,6 +186,7 @@ export default function A11y({ swiper, extendParams, on }) {
       swiper.visibleSlides &&
       swiper.visibleSlides.includes(slideEl);
     if (isActive || isVisible) return;
+    if (e.sourceCapabilities && e.sourceCapabilities.firesTouchEvents) return;
     if (swiper.isHorizontal()) {
       swiper.el.scrollLeft = 0;
     } else {


### PR DESCRIPTION
Fix:
- check if focus event triggered by touch
- don't jump the slide element

The problem has been discussed several times and a solution has already been implemented for desktop click events.

On mobile devices with touch gestures, however, the error is still present. If a UI element like select field or button is clicked in a slide element, the slide jumps to the first position.

Exactly as it is desired for the focus events. (if you navigate with tabulator key through the slider).

--> The problem was, with a touch event, the focus event is always triggered. For this I have now implemented a query.


Similar problems:
* #5962 
* #5878 
* #5814 
* #5513 
* #5625 

Always follow the [contribution guidelines](https://github.com/nolimits4web/swiper/blob/master/CONTRIBUTING.md) when submitting a pull request.
