### PR TITLE
Prevent touch events added as non-passive listeners

### DIFF
--- a/src/core/events/index.js
+++ b/src/core/events/index.js
@@ -18,11 +18,11 @@ const events = (swiper, method) => {
   const swiperMethod = method;
 
   // Touch Events
-  if (!support.touch) {
+  if (!support.touch && params.simulateTouch) {
     el[domMethod](touchEvents.start, swiper.onTouchStart, false);
     document[domMethod](touchEvents.move, swiper.onTouchMove, capture);
     document[domMethod](touchEvents.end, swiper.onTouchEnd, false);
-  } else {
+  } else if (support.touch) {
     const passiveListener =
       touchEvents.start === 'touchstart' && support.passiveListener && params.passiveListeners
         ? { passive: true, capture: false }


### PR DESCRIPTION
I’m seeing the error "Does not use passive listeners to improve scrolling performance" in the Google PageSpeed **Desktop** section coming from the Swiper library, but notably not from the **Mobile** section of Google PageSpeed. I tracked this down to the fact that I am using the option `{ simulateTouch: false }` in my code which will cause swiper core `touchEvents` to return touch events instead of pointer events when there is no touch support on a device (like Google PageSpeed Desktop mode) because of [line 179](https://github.com/nolimits4web/swiper/blob/master/src/core/core.js#L179) of core.js:

`return swiper.support.touch || !swiper.params.simulateTouch
          ? swiper.touchEventsTouch
          : swiper.touchEventsDesktop;`

In core/events/index.js this results in touch events used in the first block of the if/else statement started on [line 21](https://github.com/nolimits4web/swiper/blob/master/src/core/events/index.js#L21) without passive event listeners.

My pull request adds additional checks so that a device without touch support while using the `{ simulateTouch: false }` option does not add any event listeners as I would expect.

I believe this is a similar issue to #3853