### PR TITLE
fix(react, svelte, solid): Add wrapperClass property

### DIFF
--- a/src/react/swiper-react.d.ts
+++ b/src/react/swiper-react.d.ts
@@ -18,6 +18,13 @@ interface SwiperProps extends SwiperOptions {
   wrapperTag?: string;
 
   /**
+   * CSS class name of slides' wrapper
+   *
+   * @default 'swiper-wrapper'
+   */
+  wrapperClass?: string;
+
+  /**
    * Get Swiper instance
    */
   onSwiper?: (swiper: SwiperClass) => void;

--- a/src/react/swiper.js
+++ b/src/react/swiper.js
@@ -24,6 +24,7 @@ const Swiper = forwardRef(
       className,
       tag: Tag = 'div',
       wrapperTag: WrapperTag = 'div',
+      wrapperClass = 'swiper-wrapper',
       children,
       onSwiper,
       ...rest
@@ -205,7 +206,7 @@ const Swiper = forwardRef(
       >
         <SwiperContext.Provider value={swiperRef.current}>
           {slots['container-start']}
-          <WrapperTag className="swiper-wrapper">
+          <WrapperTag className={uniqueClasses(wrapperClass)}>
             {slots['wrapper-start']}
             {renderSlides()}
             {slots['wrapper-end']}

--- a/src/solid/swiper-solid.d.ts
+++ b/src/solid/swiper-solid.d.ts
@@ -17,6 +17,13 @@ interface SwiperProps extends SwiperOptions {
   wrapperTag?: string;
 
   /**
+   * CSS class name of slides' wrapper
+   *
+   * @default 'swiper-wrapper'
+   */
+  wrapperClass?: string;
+
+  /**
    * Get Swiper instance
    */
   onSwiper?: (swiper: SwiperClass) => void;

--- a/src/solid/swiper.jsx
+++ b/src/solid/swiper.jsx
@@ -51,6 +51,7 @@ const Swiper = (props) => {
     'ref',
     'tag',
     'wrapperTag',
+    'wrapperClass',
   ]);
 
   const params = createMemo(() => getParams(rest));
@@ -221,7 +222,7 @@ const Swiper = (props) => {
       <SwiperContext.Provider value={swiperRef}>
         {slidesSlots().slots['container-start']}
 
-        <div class="swiper-wrapper">
+        <div class={uniqueClasses(local.wrapperClass)}>
           {slidesSlots().slots['wrapper-start']}
           {renderSlides()}
           {slidesSlots().slots['wrapper-end']}

--- a/src/svelte/swiper.svelte
+++ b/src/svelte/swiper.svelte
@@ -20,6 +20,7 @@
 
   export let tag = 'div';
   export let wrapperTag = 'div';
+  export let wrapperClass = 'swiper-wrapper';
 
   let containerClasses = 'swiper';
   let breakpointChanged = false;
@@ -158,7 +159,7 @@
   {...restProps}
 >
   <slot name="container-start" />
-  <svelte:element this={wrapperTag} class="swiper-wrapper">
+  <svelte:element this={wrapperTag} class={uniqueClasses(wrapperClass)}>
     <slot name="wrapper-start" />
     <slot {virtualData} />
     <slot name="wrapper-end" />


### PR DESCRIPTION
Related to: #5942
Close: #6164

Add `wrapperClass` property to swiper/react, swiper/svelte, and swiper/solid.

As `wrapperClass` in Vue is already handled in #5942, you can merge this PR with it.

FYI: After checking the implementation of Angular, `wrapperClass` is already handled.
And later, we can modify the [document](https://swiperjs.com/swiper-api#param-wrapperClass) to remove `Not supported in Swiper Angular/React/Svelte/Vue`
