### PR TITLE
bump: angular peerDependencies to support 13 to 15

### DIFF
--- a/src/angular/package.json
+++ b/src/angular/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": "true",
   "peerDependencies": {
-    "@angular/common": "^12.2.0 || ^13.0.0 || ^14.0.0",
-    "@angular/core": "^12.2.0 || ^13.0.0 || ^14.0.0"
+    "@angular/common": "13 - 15",
+    "@angular/core": "13 - 15"
   },
   "dependencies": {
     "tslib": "^2.3.0"


### PR DESCRIPTION
update the angular peerDependencies, so swiper can work with angular 15.

Also, because the angular component use template, and current angular in packages.json version is 13.x, so the built package can not work with any version below 13, but it should work with angular 15.

Again thanks for this great package.