### PR TITLE
chore(css-mode): add scroll snap stop

### DIFF
--- a/src/core/core.less
+++ b/src/core/core.less
@@ -156,5 +156,6 @@
 
   > .swiper-wrapper > .swiper-slide {
     scroll-snap-align: center center;
+    scroll-snap-stop: always;
   }
 }

--- a/src/core/core.scss
+++ b/src/core/core.scss
@@ -158,5 +158,6 @@
 
   > .swiper-wrapper > .swiper-slide {
     scroll-snap-align: center center;
+    scroll-snap-stop: always;
   }
 }


### PR DESCRIPTION
Adding the `scroll-snap-stop` property makes the CSS Swiper behaves much more like the JS Version. Especially on Android the Swiper skips some slides when `cssMode` is enabled. By adding `scroll-snap-stop`, the Swiper stops after one slide. Also tested with vertical slides.

| No Scroll Snap Stop      | Scroll Snap Stop |
| ----------- | ----------- |
| <video src="https://user-images.githubusercontent.com/39862171/209677646-3343270e-1822-4525-8754-369121ba6bcd.mp4"></video>  | <video src="https://user-images.githubusercontent.com/39862171/209677748-88f3e3c0-e1c8-45fe-85cc-47111b714c72.mp4"></video>  |