### PR TITLE
Fixing autoplay undefined error

### DIFF
--- a/src/modules/autoplay/autoplay.js
+++ b/src/modules/autoplay/autoplay.js
@@ -93,6 +93,7 @@ export default function Autoplay({ swiper, extendParams, on, emit, params }) {
     autoplayTimeLeft = delay;
     const speed = swiper.params.speed;
     const proceed = () => {
+      if(!swiper || swiper.destroyed) return;
       if (swiper.params.autoplay.reverseDirection) {
         if (!swiper.isBeginning || swiper.params.loop || swiper.params.rewind) {
           swiper.slidePrev(speed, true, true);


### PR DESCRIPTION
Added a null check to "proceed" function so it doesn't run when the swiper doesn't exist used the logic in "onTransitionEnd" for consistancy purposes, tested the fix on my project and it works correctly now...
The problem is described in this issue: https://github.com/nolimits4web/swiper/issues/6261
and this: https://github.com/nolimits4web/swiper/issues/5244
It probably has some specific trigger conditions but it doesn't matter on this fix because it's adding null checks which are never a bad thing.