### PR TITLE
fix: centeredSlidesBounds don't work when grid.rows > 1

### DIFF
--- a/src/core/update/updateSlides.js
+++ b/src/core/update/updateSlides.js
@@ -260,12 +260,7 @@ export default function updateSlides() {
   }
 
   if (params.centeredSlides && params.centeredSlidesBounds) {
-    let allSlidesSize = 0;
-    slidesSizesGrid.forEach((slideSizeValue) => {
-      allSlidesSize += slideSizeValue + (params.spaceBetween ? params.spaceBetween : 0);
-    });
-    allSlidesSize -= params.spaceBetween;
-    const maxSnap = allSlidesSize - swiperSize;
+    const maxSnap = swiper.virtualSize - swiperSize;
     snapGrid = snapGrid.map((snap) => {
       if (snap < 0) return -offsetBefore;
       if (snap > maxSnap) return maxSnap + offsetAfter;


### PR DESCRIPTION
When I swipe from left to right and use the grid layout and grid.rows > 1, "centeredSlidesBounds" doesn't work at the right。
Replace “allSlidesSize” with "swiper.virtualSize" to calculate whether the slide reaches the boundary，tested the fix on my project and it works correctly now...

**Reproduction link**
https://codesandbox.io/s/beautiful-bassi-xf45wf
