### PR TITLE
Fix a crash with resize when the autoplay has gone away during timeout

### DIFF
--- a/src/core/events/onResize.js
+++ b/src/core/events/onResize.js
@@ -44,7 +44,9 @@ export default function onResize() {
   if (swiper.autoplay && swiper.autoplay.running && swiper.autoplay.paused) {
     clearTimeout(timeout);
     timeout = setTimeout(() => {
-      swiper.autoplay.resume();
+      if (swiper.autoplay && swiper.autoplay.running && swiper.autoplay.paused) {
+        swiper.autoplay.resume();
+      }
     }, 500);
   }
   // Return locks after resize


### PR DESCRIPTION
We had a crash this morning that you can see below:

<img width="1189" alt="Screenshot 2023-02-24 at 8 49 24 AM" src="https://user-images.githubusercontent.com/2895/221194649-fba82f89-499d-4625-8617-917db902f400.png">

I think what's happening is that:

* A resize occurs
* This schedules a timeout to resume the autoplay, checking that it should do so before scheduling the timeout
* Before the timeout's callback fires, the autoplay goes away, presumably because the user has moved on to a different page
* The timeout fires and does not check again for the existence of the autoplay, which causes the crash

This just duplicates the check for needing to resume the autoplay within the callback. I debated about whether all three checks were needed but went for the maximal approach just to be sure... happy to tweak that if needed.