### PR TITLE
fix(swiper): reset initialized flag on disconnectedCallback

### DIFF
--- a/src/element/swiper-element.js
+++ b/src/element/swiper-element.js
@@ -142,6 +142,7 @@ class SwiperContainer extends ClassToExtend {
     if (this.swiper && this.swiper.destroy) {
       this.swiper.destroy();
     }
+    this.initialized = false;
   }
 
   updateSwiperOnPropChange(propName) {


### PR DESCRIPTION
resolves https://github.com/nolimits4web/swiper/issues/6473

This PR updates the `disconnectedCallback` function to set `this.initialized = false`. That way the `initialize` function will not return early when it is called from `connectedCallback`.

I could not find where the E2E are in `master`. I see there are Cypress E2E tests in the `v8` branch: https://github.com/nolimits4web/swiper/tree/v8/cypress/e2e/modules But it looks like they were moved/removed for v9. Happy to write a test if someone could point me in the direction of the tests.