### PR TITLE
Initialize lastClickTime to very old time

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -182,7 +182,7 @@ class Swiper {
         // Form elements to match
         focusableElements: swiper.params.focusableElements,
         // Last click time
-        lastClickTime: now(),
+        lastClickTime: 0,
         clickTimeout: undefined,
         // Velocities
         velocities: [],


### PR DESCRIPTION
Related to: https://github.com/nolimits4web/swiper/issues/6496

This way we avoid Swiper to think a single tap is a double tap when we do it very fast, for example at Cypress tests.
