### PR TITLE
add a conditional to early return if the swiper controller is destroyed

### DIFF
--- a/src/modules/controller/controller.js
+++ b/src/modules/controller/controller.js
@@ -179,11 +179,11 @@ export default function Controller({ swiper, extendParams, on }) {
     removeSpline();
   });
   on('setTranslate', (_s, translate, byController) => {
-    if (!swiper.controller.control) return;
+    if (!swiper.controller.control || swiper.controller.control.destroyed) return;
     swiper.controller.setTranslate(translate, byController);
   });
   on('setTransition', (_s, duration, byController) => {
-    if (!swiper.controller.control) return;
+    if (!swiper.controller.control || swiper.controller.control.destroyed) return;
     swiper.controller.setTransition(duration, byController);
   });
 


### PR DESCRIPTION
Fixes to address this issue [#6552](https://github.com/nolimits4web/swiper/issues/6552)
I did some debugging to fix this bug and found a solution.

Check if the swiper controller is destroyed before the `setTranslate`, `setTransition` functions run.

[In other PR](https://github.com/nolimits4web/swiper/pull/6501), the above two functions are executed and checked for destruction within the setControlledTranslate and setControlledTransition functions, but I think it would be nice to check for this in advance to avoid running unnecessary logic.

This is my first open source PR. Feedback is always welcome.