### PR TITLE
Make activeSlides a public property

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -140,6 +140,7 @@ class Swiper {
       slidesGrid: [],
       snapGrid: [],
       slidesSizesGrid: [],
+      activeSlides: [],
 
       // isDirection
       isHorizontal() {

--- a/src/core/update/updateAutoHeight.js
+++ b/src/core/update/updateAutoHeight.js
@@ -33,6 +33,10 @@ export default function updateAutoHeight(speed) {
     activeSlides.push(getSlideByIndex(swiper.activeIndex));
   }
 
+  Object.assign(swiper, {
+    activeSlides,
+  });
+
   // Find new height from highest slide in view
   for (i = 0; i < activeSlides.length; i += 1) {
     if (typeof activeSlides[i] !== 'undefined') {


### PR DESCRIPTION
Make `activeSlides` a publicly accessible property of the swiper. Usage example: `swiper.activeSlides`.