### PR TITLE
fix: made defineProperty configurable as it broke when minified.

### DIFF
--- a/src/element/swiper-element.js
+++ b/src/element/swiper-element.js
@@ -198,6 +198,7 @@ paramsList.forEach((paramName) => {
   if (paramName === 'init') return;
   paramName = paramName.replace('_', '');
   Object.defineProperty(SwiperContainer.prototype, paramName, {
+    configurable: true,
     get() {
       return (this.passedParams || {})[paramName];
     },


### PR DESCRIPTION
To reproduce the bug: Embed into a website.

Fixes the below issue where the build crashes when minified:

<img width="911" alt="image" src="https://user-images.githubusercontent.com/8881382/232129389-edf276e3-1ed9-4aa4-ac7e-3bcde4f769a3.png">
Minified Code Below: 

```
paramsList.forEach((paramName) => {
  if (paramName === 'init') return;
  paramName = paramName.replace('_', '');
  Object.defineProperty(SwiperContainer.prototype, paramName, {
    / / added configurable:true  HERE to fix crash
    get() {
      return (this.passedParams || {})[paramName];
    },
    set(value) {
      if (!this.passedParams) this.passedParams = {};
      this.passedParams[paramName] = value;
      if (!this.initialized) return;
      this.updateSwiperOnPropChange(paramName, value);
    },
  });
});
```


It seems that the property is redefined in a later loop but as it is read only it crashes. Making it configurable fixes this issue.
