### PR TITLE
Also do an early return on a NaN value

### DIFF
--- a/src/modules/hash-navigation/hash-navigation.js
+++ b/src/modules/hash-navigation/hash-navigation.js
@@ -37,8 +37,7 @@ export default function HashNavigation({ swiper, extendParams, emit, on }) {
     const activeSlideHash = activeSlideEl ? activeSlideEl.getAttribute('data-hash') : '';
     if (newHash !== activeSlideHash) {
       const newIndex = swiper.params.hashNavigation.getSlideIndex(swiper, newHash);
-      console.log(newIndex);
-      if (typeof newIndex === 'undefined' || isNaN(newIndex)) return;
+      if (typeof newIndex === 'undefined' || Number.isNaN(newIndex)) return;
       swiper.slideTo(newIndex);
     }
   };

--- a/src/modules/hash-navigation/hash-navigation.js
+++ b/src/modules/hash-navigation/hash-navigation.js
@@ -38,7 +38,7 @@ export default function HashNavigation({ swiper, extendParams, emit, on }) {
     if (newHash !== activeSlideHash) {
       const newIndex = swiper.params.hashNavigation.getSlideIndex(swiper, newHash);
       console.log(newIndex);
-      if (typeof newIndex === 'undefined') return;
+      if (typeof newIndex === 'undefined' || isNaN(newIndex)) return;
       swiper.slideTo(newIndex);
     }
   };


### PR DESCRIPTION
Workaround for issue https://github.com/nolimits4web/swiper/issues/6680. Instead of only checking for a type of `undefined` we also explicitly check for NaN values.
