### PR TITLE
get active slide element using the old method if Virtual is not being…

### DIFF
--- a/src/modules/hash-navigation/hash-navigation.js
+++ b/src/modules/hash-navigation/hash-navigation.js
@@ -31,15 +31,11 @@ export default function HashNavigation({ swiper, extendParams, emit, on }) {
   const onHashChange = () => {
     emit('hashChange');
     const newHash = document.location.hash.replace('#', '');
-    let activeSlideHash;
-    if (swiper.virtual && swiper.params.virtual.enabled) {
-      const activeSlideEl = swiper.slidesEl.querySelector(
-        `[data-swiper-slide-index="${swiper.activeIndex}"]`,
-      );
-      activeSlideHash = activeSlideEl ? activeSlideEl.getAttribute('data-hash') : '';
-    } else {
-      activeSlideHash = swiper.slides[swiper.activeIndex].getAttribute('data-hash');
-    }
+    const activeSlideEl =
+      swiper.virtual && swiper.params.virtual.enabled
+        ? swiper.slidesEl.querySelector(`[data-swiper-slide-index="${swiper.activeIndex}"]`)
+        : swiper.slides[swiper.activeIndex];
+    const activeSlideHash = activeSlideEl ? activeSlideEl.getAttribute('data-hash') : '';
     if (newHash !== activeSlideHash) {
       const newIndex = swiper.params.hashNavigation.getSlideIndex(swiper, newHash);
       if (typeof newIndex === 'undefined' || Number.isNaN(newIndex)) return;
@@ -48,17 +44,13 @@ export default function HashNavigation({ swiper, extendParams, emit, on }) {
   };
   const setHash = () => {
     if (!initialized || !swiper.params.hashNavigation.enabled) return;
-    let activeSlideHash;
-    if (swiper.virtual && swiper.params.virtual.enabled) {
-      const activeSlideEl = swiper.slidesEl.querySelector(
-        `[data-swiper-slide-index="${swiper.activeIndex}"]`,
-      );
-      activeSlideHash = activeSlideEl
-        ? activeSlideEl.getAttribute('data-hash') || activeSlideEl.getAttribute('data-history')
-        : '';
-    } else {
-      activeSlideHash = swiper.slides[swiper.activeIndex].getAttribute('data-hash');
-    }
+    const activeSlideEl =
+      swiper.virtual && swiper.params.virtual.enabled
+        ? swiper.slidesEl.querySelector(`[data-swiper-slide-index="${swiper.activeIndex}"]`)
+        : swiper.slides[swiper.activeIndex];
+    const activeSlideHash = activeSlideEl
+      ? activeSlideEl.getAttribute('data-hash') || activeSlideEl.getAttribute('data-history')
+      : '';
     if (
       swiper.params.hashNavigation.replaceState &&
       window.history &&

--- a/src/modules/hash-navigation/hash-navigation.js
+++ b/src/modules/hash-navigation/hash-navigation.js
@@ -31,10 +31,13 @@ export default function HashNavigation({ swiper, extendParams, emit, on }) {
   const onHashChange = () => {
     emit('hashChange');
     const newHash = document.location.hash.replace('#', '');
-    const activeSlideEl = swiper.slidesEl.querySelector(
-      `[data-swiper-slide-index="${swiper.activeIndex}"]`,
-    );
-    const activeSlideHash = activeSlideEl ? activeSlideEl.getAttribute('data-hash') : '';
+    let activeSlideHash;
+    if (swiper.virtual && swiper.params.virtual.enabled) {
+        const activeSlideEl = swiper.slidesEl.querySelector(`[data-swiper-slide-index="${swiper.activeIndex}"]`);
+        activeSlideHash = activeSlideEl ? activeSlideEl.getAttribute('data-hash') : '';
+    } else {
+        activeSlideHash = swiper.slides[swiper.activeIndex].getAttribute('data-hash');
+    }
     if (newHash !== activeSlideHash) {
       const newIndex = swiper.params.hashNavigation.getSlideIndex(swiper, newHash);
       if (typeof newIndex === 'undefined' || Number.isNaN(newIndex)) return;
@@ -43,12 +46,13 @@ export default function HashNavigation({ swiper, extendParams, emit, on }) {
   };
   const setHash = () => {
     if (!initialized || !swiper.params.hashNavigation.enabled) return;
-    const activeSlideEl = swiper.slidesEl.querySelector(
-      `[data-swiper-slide-index="${swiper.activeIndex}"]`,
-    );
-    const activeSlideHash = activeSlideEl
-      ? activeSlideEl.getAttribute('data-hash') || activeSlideEl.getAttribute('data-history')
-      : '';
+    let activeSlideHash;
+    if (swiper.virtual && swiper.params.virtual.enabled) {
+        const activeSlideEl = swiper.slidesEl.querySelector(`[data-swiper-slide-index="${swiper.activeIndex}"]`);
+        activeSlideHash = activeSlideEl ? activeSlideEl.getAttribute('data-hash') || activeSlideEl.getAttribute('data-history') : '';
+    } else {
+        activeSlideHash = swiper.slides[swiper.activeIndex].getAttribute('data-hash');
+    }
     if (
       swiper.params.hashNavigation.replaceState &&
       window.history &&

--- a/src/modules/hash-navigation/hash-navigation.js
+++ b/src/modules/hash-navigation/hash-navigation.js
@@ -33,10 +33,12 @@ export default function HashNavigation({ swiper, extendParams, emit, on }) {
     const newHash = document.location.hash.replace('#', '');
     let activeSlideHash;
     if (swiper.virtual && swiper.params.virtual.enabled) {
-        const activeSlideEl = swiper.slidesEl.querySelector(`[data-swiper-slide-index="${swiper.activeIndex}"]`);
-        activeSlideHash = activeSlideEl ? activeSlideEl.getAttribute('data-hash') : '';
+      const activeSlideEl = swiper.slidesEl.querySelector(
+        `[data-swiper-slide-index="${swiper.activeIndex}"]`,
+      );
+      activeSlideHash = activeSlideEl ? activeSlideEl.getAttribute('data-hash') : '';
     } else {
-        activeSlideHash = swiper.slides[swiper.activeIndex].getAttribute('data-hash');
+      activeSlideHash = swiper.slides[swiper.activeIndex].getAttribute('data-hash');
     }
     if (newHash !== activeSlideHash) {
       const newIndex = swiper.params.hashNavigation.getSlideIndex(swiper, newHash);
@@ -48,10 +50,14 @@ export default function HashNavigation({ swiper, extendParams, emit, on }) {
     if (!initialized || !swiper.params.hashNavigation.enabled) return;
     let activeSlideHash;
     if (swiper.virtual && swiper.params.virtual.enabled) {
-        const activeSlideEl = swiper.slidesEl.querySelector(`[data-swiper-slide-index="${swiper.activeIndex}"]`);
-        activeSlideHash = activeSlideEl ? activeSlideEl.getAttribute('data-hash') || activeSlideEl.getAttribute('data-history') : '';
+      const activeSlideEl = swiper.slidesEl.querySelector(
+        `[data-swiper-slide-index="${swiper.activeIndex}"]`,
+      );
+      activeSlideHash = activeSlideEl
+        ? activeSlideEl.getAttribute('data-hash') || activeSlideEl.getAttribute('data-history')
+        : '';
     } else {
-        activeSlideHash = swiper.slides[swiper.activeIndex].getAttribute('data-hash');
+      activeSlideHash = swiper.slides[swiper.activeIndex].getAttribute('data-hash');
     }
     if (
       swiper.params.hashNavigation.replaceState &&


### PR DESCRIPTION
Ensures the old method of getting the active slide is being used when the Virtual module is not being used. Resolves https://github.com/nolimits4web/swiper/issues/6703. It might be nice to just make a `swiper.getActiveSlideEl` function that abstracts the implementation away and implements the logic.
