### PR TITLE
fix(lazyPreloadPrevNext): lazyPreloadPrevNext not working with loop mode #6724

### DIFF
--- a/src/shared/process-lazy-preloader.js
+++ b/src/shared/process-lazy-preloader.js
@@ -26,10 +26,10 @@ export const preload = (swiper) => {
       : Math.ceil(swiper.params.slidesPerView);
   const activeIndex = swiper.activeIndex;
   const slideIndexLastInView = activeIndex + slidesPerView - 1;
-  if (swiper.params.rewind) {
+  if (swiper.params.rewind || swiper.params.loop) {
     for (let i = activeIndex - amount; i <= slideIndexLastInView + amount; i += 1) {
       const realIndex = ((i % len) + len) % len;
-      if (realIndex !== activeIndex && realIndex > slideIndexLastInView) unlazy(swiper, realIndex);
+      if (realIndex < activeIndex || realIndex > slideIndexLastInView) unlazy(swiper, realIndex);
     }
   } else {
     for (


### PR DESCRIPTION
Fixes #6724.

The lazyPreloadPrevNext was not working correctly if the loop mode was also enabled.

It also seems that in the part of code for the "rewind" mode, it wasn’t possible to preload slides with an index inferior than the active slide index. Which can happen if initialSlide > 0. It's also the case in the `else` part of the `if(swiper.params.rewind)` condition (src/shared/process-lazy-preloader.js l34), #6684, but I preferred to do a PR for only one issue at a time.



Shouldn’t we just remove that part `(realIndex <= activeIndex || realIndex > slideIndexLastInView)` and just preload the active slide/visible slides?
