### PR TITLE
Change Overflow to Clip

### DIFF
--- a/src/core/core.less
+++ b/src/core/core.less
@@ -10,7 +10,7 @@ swiper-container {
   margin-left: auto;
   margin-right: auto;
   position: relative;
-  overflow: hidden;
+  overflow: clip;
   list-style: none;
   padding: 0;
   /* Fix of Webkit flickering */

--- a/src/core/core.scss
+++ b/src/core/core.scss
@@ -12,7 +12,7 @@ swiper-container {
   margin-left: auto;
   margin-right: auto;
   position: relative;
-  overflow: hidden;
+  overflow: clip;
   list-style: none;
   padding: 0;
   /* Fix of Webkit flickering */


### PR DESCRIPTION
Consider the following situation

Suppose that there is a swiping element horizontally with a few elements, which grown when hovered. When it grows, it exeeds the Y axis overflow. 
With overflow hidden, setting `overflow-y` to "visible" does nothing. However setting overflow to clip allows y-overflow to be visible.
This is as per the [W3 Specification](https://www.w3.org/TR/css-overflow-3/#overflow-control):
> The visible/clip values of overflow compute to auto/hidden (respectively) if one of overflow-x or overflow-y is neither visible nor clip.
