### PR TITLE
Allow multiple clickableClass

### DIFF
--- a/src/modules/pagination/pagination.js
+++ b/src/modules/pagination/pagination.js
@@ -371,7 +371,7 @@ export default function Pagination({ swiper, extendParams, on, emit }) {
     el = makeElementsArray(el);
     el.forEach((subEl) => {
       if (params.type === 'bullets' && params.clickable) {
-        subEl.classList.add(params.clickableClass);
+        subEl.classList.add(...params.clickableClass.split(' '));
       }
 
       subEl.classList.add(params.modifierClass + params.type);


### PR DESCRIPTION
We have an error when trying to set a class for the clickableClass props.

The error is : 

```
failed to execute 'add' on 'domtokenlist': the token provided ('relative top-20') contains html space characters, which are not valid in token
```

For example here : 
```tsx
<Swiper
      slidesPerView={1}
      spaceBetween={10}
      pagination={{
        clickable: true,
        bulletActiveClass: '!bg-grey-black !w-6 !rounded-xl opacity-1',
        clickableClass: `!relative !top-20`, // <--- ERROR
        bulletClass: `w-32 h-32 inline-block`,
      }}
      navigation
      breakpoints={{
        640: {
          slidesPerView: 2,
          spaceBetween: 20,
        },
      }}
      className="h-full w-full"
      modules={[Pagination, Navigation]}
    >
      {components.map((component, i) => (
        <SwiperSlide className="!flex !items-center !justify-center" key={i}>
          {component}
        </SwiperSlide>
      ))}
    </Swiper>
    ```

The change fixes this error. 

Thanks !