### PR TITLE
Parse breakpoints JSON if passed in `breakpoints` attribute

### DIFF
--- a/playground/element/index.html
+++ b/playground/element/index.html
@@ -3,12 +3,24 @@
 
 <head>
   <meta charset="UTF-8" />
-  <title>Swiper Playground</title>
+  <title>Swiper Playground - Element</title>
   <meta name="viewport" content="width=device-width" />
 </head>
 
 <body>
-  <swiper-container>
+<swiper-container class="content-page-grid-carousel" class navigation="true" pagination="true" scrollbar="false" loop="true" breakpoints='{
+        "576": {
+            "slidesPerView": 1
+        },
+        "768": { 
+            "slidesPerView": 2,
+            "spaceBetween":30
+        },
+        "1200": { 
+            "slidesPerView": 3,
+            "spaceBetween":20
+        }
+    }'>  
     <swiper-slide>Slide 1</swiper-slide>
     <swiper-slide>Slide 2</swiper-slide>
     <swiper-slide>Slide 3</swiper-slide>

--- a/src/core/breakpoints/getBreakpoint.js
+++ b/src/core/breakpoints/getBreakpoint.js
@@ -1,6 +1,9 @@
 import { getWindow } from 'ssr-window';
 
 export default function getBreakpoint(breakpoints, base = 'window', containerEl) {
+  if ( typeof breakpoints == 'string' ) {
+    breakpoints = JSON.parse(breakpoints);
+  }
   if (!breakpoints || (base === 'container' && !containerEl)) return undefined;
   let breakpoint = false;
 

--- a/src/core/breakpoints/setBreakpoint.js
+++ b/src/core/breakpoints/setBreakpoint.js
@@ -7,7 +7,10 @@ const isGridEnabled = (swiper, params) => {
 export default function setBreakpoint() {
   const swiper = this;
   const { realIndex, initialized, params, el } = swiper;
-  const breakpoints = params.breakpoints;
+  let breakpoints = params.breakpoints;
+  if ( typeof breakpoints == 'string' ) {
+    breakpoints = JSON.parse(breakpoints);
+  }
   if (!breakpoints || (breakpoints && Object.keys(breakpoints).length === 0)) return;
 
   // Get breakpoint for window width and update parameters


### PR DESCRIPTION
Provides support for a JSON string to be passed as the `breakpoints` attribute on the Swiper element:

```
<swiper-container navigation="true" pagination="true" scrollbar="true" breakpoints='{"600": {"slidesPerView": 3},"900": {
"slidesPerView": 4}}'>
```