### PR TITLE
'releaseOnEdges' option doesn't work #6770

### DIFF
--- a/src/modules/mousewheel/mousewheel.js
+++ b/src/modules/mousewheel/mousewheel.js
@@ -386,7 +386,11 @@ export default function Mousewheel({ swiper, extendParams, on, emit }) {
         if (swiper.params.autoplay && swiper.params.autoplayDisableOnInteraction)
           swiper.autoplay.stop();
         // Return page scroll on edge positions
-        if (position === swiper.minTranslate() || position === swiper.maxTranslate()) return true;
+        if (
+          params.releaseOnEdges &&
+          (position === swiper.minTranslate() || position === swiper.maxTranslate())
+        )
+          return true;
       }
     }
 


### PR DESCRIPTION
This PR aims to address the issue where the `releaseonEdges` option is not functioning as expected. 

The `releaseonEdges` option is intended to control the release behavior when the user reaches the edge of the swiper container. However, in its current state, the functionality is not working correctly.