### PR TITLE
fix(modules/*): filter out falsy elements

### DIFF
--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -33,10 +33,8 @@ export default function A11y({ swiper, extendParams, on }) {
     notification.innerHTML = message;
   }
 
-  const makeElementsArray = (el) => {
-    if (!Array.isArray(el)) el = [el].filter((e) => !!e);
-    return el;
-  };
+  const makeElementsArray = el =>
+    (Array.isArray(el) ? el : [el]).filter((e) => !!e)
 
   function getRandomNumber(size = 16) {
     const randomChar = () => Math.round(16 * Math.random()).toString(16);

--- a/src/modules/navigation/navigation.mjs
+++ b/src/modules/navigation/navigation.mjs
@@ -19,10 +19,8 @@ export default function Navigation({ swiper, extendParams, on, emit }) {
     prevEl: null,
   };
 
-  const makeElementsArray = (el) => {
-    if (!Array.isArray(el)) el = [el].filter((e) => !!e);
-    return el;
-  };
+  const makeElementsArray = el =>
+    (Array.isArray(el) ? el : [el]).filter((e) => !!e)
 
   function getEl(el) {
     let res;

--- a/src/modules/pagination/pagination.mjs
+++ b/src/modules/pagination/pagination.mjs
@@ -44,10 +44,8 @@ export default function Pagination({ swiper, extendParams, on, emit }) {
   let bulletSize;
   let dynamicBulletIndex = 0;
 
-  const makeElementsArray = (el) => {
-    if (!Array.isArray(el)) el = [el].filter((e) => !!e);
-    return el;
-  };
+  const makeElementsArray = el =>
+    (Array.isArray(el) ? el : [el]).filter((e) => !!e)
 
   function isPaginationDisabled() {
     return (


### PR DESCRIPTION
N.B. I have not linked this PR to an issue because I can't provide my employer's application as a demo, and it would take vastly more time to strip it down to a working reproduction that I could get permission to share, than it would for the validity of the code fix to be assessed.

Under some circumstances when the the a11y module calls `destroy()` in response to receiving a `destroy` event, it throws an exception (which can't be easily handled due to the asynchronicity).  

![Screenshot 2023-07-07 at 2 58 47 pm](https://github.com/nolimits4web/swiper/assets/13465236/11469e98-7d1e-402f-894e-e8fcbe559424)

When the elements are retrieved from the swiper instance's navigation property:

`let { nextEl, prevEl } = swiper.navigation ? swiper.navigation : {};`
  
 evidently they are arrays containing `undefined`.
 
The conservative change I have made and which I have validated fixes the problem is to extend the existing truthiness filter in `makeElementsArray` for the single element case to the case when the input is already an array.