### PR TITLE
Make VirtualOptions generic

### DIFF
--- a/src/types/modules/virtual.d.ts
+++ b/src/types/modules/virtual.d.ts
@@ -1,4 +1,4 @@
-export interface VirtualMethods {
+export interface VirtualMethods<T = any> {
   /**
    * Object with cached slides HTML elements
    */
@@ -17,7 +17,7 @@ export interface VirtualMethods {
   /**
    * Array with slide items passed by `virtual.slides` parameter
    */
-  slides: any[];
+  slides: T[];
 
   /*
    * Methods
@@ -59,7 +59,7 @@ export interface VirtualMethods {
 
 export interface VirtualEvents {}
 
-export interface VirtualData {
+export interface VirtualData<T> {
   /**
    * slides left/top offset in px
    */
@@ -75,10 +75,10 @@ export interface VirtualData {
   /**
    * array with slide items to be rendered
    */
-  slides: any[];
+  slides: T[];
 }
 
-export interface VirtualOptions {
+export interface VirtualOptions<T = any> {
   /**
    * Whether the virtual slides are enabled
    *
@@ -90,7 +90,7 @@ export interface VirtualOptions {
    *
    * @default []
    */
-  slides?: any[];
+  slides?: T[];
   /**
    * Enables DOM cache of rendering slides html elements. Once they are rendered they will be saved to cache and reused from it.
    *
@@ -114,7 +114,7 @@ export interface VirtualOptions {
    *
    * @default null
    */
-  renderSlide?: (slide: any, index: any) => any | null;
+  renderSlide?: (slide: T, index: any) => any | null;
   /**
    * Function for external rendering (e.g. using some other library to handle DOM manipulations and state like React.js or Vue.js). As an argument it accepts `data` object with the following properties:
    *
@@ -125,7 +125,7 @@ export interface VirtualOptions {
    *
    * @default null
    */
-  renderExternal?: (data: VirtualData) => any | null;
+  renderExternal?: (data: VirtualData<T>) => any | null;
   /**
    * When enabled (by default) it will update Swiper layout right after renderExternal called. Useful to disable and update swiper manually when used with render libraries that renders asynchronously
    *


### PR DESCRIPTION
I made `VirtualOptions` interface generic to be able to specify what is the type of item in `slides` array. By default item type is set to `any` to maintain compatibility.