### PR TITLE
fix #6863, update scripts/utils/minify.js to fix source maps for ES modules.

### DIFF
--- a/scripts/utils/minify.js
+++ b/scripts/utils/minify.js
@@ -10,7 +10,7 @@ export default async (fileName, filePath, bannerName) => {
   const { code, map } = await minify(content, {
     sourceMap: {
       filename: `${fileName}${fileExt}`,
-      url: `${fileName}.map`,
+      url: `${fileName.replace(fileExt, `.min${fileExt}`)}.map`,
     },
     output: {
       preamble: typeof bannerName !== 'undefined' ? banner(bannerName) : '',


### PR DESCRIPTION
Fixes issue #6863 

This commit addresses an issue with the missing ".min" part in the source map URLs, which leads to broken links for .jsm files. The problem is that the URLs are not correctly formed, causing the files to point to non-existing locations.

In this code change, we have rectified this problem by ensuring that the source map URLs now include the ".min" part. This adjustment ensures that the links to .jsm files are correctly directed to the appropriate URLs, resolving the problem of broken links.

With this fix, the source map URLs will now be accurately generated, and the .jsm files will successfully link to their corresponding source maps, resolving the previously broken links.


