### PR TITLE
fix(core): set isElement on swiper-containers only

### DIFF
--- a/src/core/core.mjs
+++ b/src/core/core.mjs
@@ -485,7 +485,7 @@ class Swiper {
     }
 
     el.swiper = swiper;
-    if (el.parentNode && el.parentNode.host) {
+    if (el.parentNode && el.parentNode.host && el.parentNode.host.nodeName === 'SWIPER-CONTAINER') {
       swiper.isElement = true;
     }
 


### PR DESCRIPTION
Hi @nolimits4web!

I think you introduced a subtle bug with the swiper web component.

In the core you expect the swiper to be a swiper webcomponent whenever it's parentNode has a host, but you forget that the swiper might be a direct child to another (non-swiper) webcomponent.

When that is the case (which happened to me), you assign this other web-component as "slidesEl" to the swiper object.

I noticed that when using the manipulation module's "appendChild" method which now assigned new slides as children to my own web-component.

I suggest to add another condition to the isElement check (see commit).
