### PR TITLE
fix: Zoom with two fingers not work when document is scrolled

### DIFF
--- a/src/modules/zoom/zoom.mjs
+++ b/src/modules/zoom/zoom.mjs
@@ -91,9 +91,9 @@ export default function Zoom({ swiper, extendParams, on, emit }) {
     if (evCache.length < 2) return { x: null, y: null };
     const box = gesture.imageEl.getBoundingClientRect();
     return [
-      (evCache[0].pageX + (evCache[1].pageX - evCache[0].pageX) / 2 - box.x) / currentScale,
+      (evCache[0].pageX + (evCache[1].pageX - evCache[0].pageX) / 2 - box.x - scrollX) / currentScale,
 
-      (evCache[0].pageY + (evCache[1].pageY - evCache[0].pageY) / 2 - box.y) / currentScale,
+      (evCache[0].pageY + (evCache[1].pageY - evCache[0].pageY) / 2 - box.y - scrollY) / currentScale,
     ];
   }
 


### PR DESCRIPTION
Fix: https://github.com/nolimits4web/swiper/issues/6950

Account for the amount of horizontal and vertical scrolling that has occurred on the document 