### PR TITLE
Fix #7003. SwiperProps interface doesn't include SwiperOptions fields on TS4

### DIFF
--- a/src/swiper-react.d.ts
+++ b/src/swiper-react.d.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
-import type { SwiperOptions, Swiper as SwiperClass } from './types/index.d.ts';
+// Importing from index file causes errors in Typescript 4
+import type { SwiperOptions } from './types/swiper-options';
+import type SwiperClass from './types/swiper-class';
 
 interface SwiperProps extends SwiperOptions {
   /**


### PR DESCRIPTION
Fix for #7003 

Looks like Typescript 4 has some bugs related to imports/exports in .d.ts files. If we make direct imports instead of importing from index.d.ts - everything works. Checked on my project

Any idea why it happens? 