### PR TITLE
add 'touch-action: none' to swiper-scrollbar

### DIFF
--- a/src/modules/scrollbar/scrollbar.less
+++ b/src/modules/scrollbar/scrollbar.less
@@ -15,6 +15,7 @@
   border-radius: var(--swiper-scrollbar-border-radius, 10px);
   position: relative;
   -ms-touch-action: none;
+  touch-action: none;
   background: var(--swiper-scrollbar-bg-color, rgba(0, 0, 0, 0.1));
   .swiper-scrollbar-disabled > &,
   &.swiper-scrollbar-disabled {

--- a/src/modules/scrollbar/scrollbar.scss
+++ b/src/modules/scrollbar/scrollbar.scss
@@ -17,6 +17,7 @@
   border-radius: var(--swiper-scrollbar-border-radius, 10px);
   position: relative;
   -ms-touch-action: none;
+  touch-action: none;
   background: var(--swiper-scrollbar-bg-color, rgba(0, 0, 0, 0.1));
   .swiper-scrollbar-disabled > &,
   &.swiper-scrollbar-disabled {


### PR DESCRIPTION
'-ms-touch-action' is not supported by Firefox, Firefox for Android, Safari, Samsung Internet. Add 'touch-action' to support Firefox 52+, Firefox for Android 52+, Safari 13+, Samsung Internet 3.0+.

I discovered issues while using Hint tools to check my website, and some of them were related to Bootstrap so I decided to resolve them in Swiper repository. These changes include properties that allow to support more browsers.

