### PR TITLE
fix(types): detection of custom html tags

### DIFF
--- a/src/swiper-element.d.ts
+++ b/src/swiper-element.d.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { SwiperOptions, Swiper } from './types/index.d.ts';
+import { Swiper, SwiperOptions } from './types/index.d.ts';
 
 declare const register: () => void;
 
@@ -43,4 +43,12 @@ interface SwiperSlide extends HTMLElement {
   lazy: string | boolean;
 }
 
-export { register, SwiperContainer, SwiperSlide };
+declare global {
+  interface HTMLElementTagNameMap {
+    'swiper-container': SwiperContainer;
+    'swiper-slide': SwiperSlide;
+  }
+}
+
+export { SwiperContainer, SwiperSlide, register };
+


### PR DESCRIPTION

**Before**: Detects custom tags as HTMLElement.

![image](https://github.com/nolimits4web/swiper/assets/1318648/6a32c2b0-9266-4cdf-b947-3c4d748a4927)

**After**: Detects tags as Swiper's custom element.
![image](https://github.com/nolimits4web/swiper/assets/1318648/fea35c8b-542e-4cc8-a0f0-c37ade839828)

https://github.com/nolimits4web/swiper/issues/6466