### PR TITLE
fix: 6915

### DIFF
--- a/src/core/slide/slideTo.mjs
+++ b/src/core/slide/slideTo.mjs
@@ -166,6 +166,11 @@ export default function slideTo(
         swiper.onSlideToWrapperTransitionEnd = null;
         delete swiper.onSlideToWrapperTransitionEnd;
         swiper.transitionEnd(runCallbacks, direction);
+
+        // Fix the loop if we're in loop mode
+        if (swiper.params.loop) {
+          swiper.loopFix();
+        }
       };
     }
     swiper.wrapperEl.addEventListener('transitionend', swiper.onSlideToWrapperTransitionEnd);


### PR DESCRIPTION
The issue is that `swiper.loopFix()` doesn't run when the `slideToLoop` is called, so it gets stuck and doesn't loop. I added `swiper.loopFix()` to the underlying `slideTo` function after the transition to fix this.