### PR TITLE
Split classes in createElement util by space

### DIFF
--- a/src/shared/utils.mjs
+++ b/src/shared/utils.mjs
@@ -207,7 +207,7 @@ function elementChildren(element, selector = '') {
 
 function createElement(tag, classes = []) {
   const el = document.createElement(tag);
-  el.classList.add(...(Array.isArray(classes) ? classes : [classes]));
+  el.classList.add(...(Array.isArray(classes) ? classes : classes.split(' '));
   return el;
 }
 function elementOffset(el) {


### PR DESCRIPTION
I am using this change locally to fix #7096 via patch-package. It will ensure multiple space-separated classes are supported when creating elements.
