### PR TITLE
dont let autoplay module slide when its time over

### DIFF
--- a/src/modules/autoplay/autoplay.mjs
+++ b/src/modules/autoplay/autoplay.mjs
@@ -18,6 +18,7 @@ export default function Autoplay({ swiper, extendParams, on, emit, params }) {
       stopOnLastSlide: false,
       reverseDirection: false,
       pauseOnMouseEnter: false,
+      disableAutoSlide: false,
     },
   });
   let timeout;
@@ -98,7 +99,10 @@ export default function Autoplay({ swiper, extendParams, on, emit, params }) {
     const speed = swiper.params.speed;
     const proceed = () => {
       if (!swiper || swiper.destroyed) return;
-      if (swiper.params.autoplay.reverseDirection) {
+      if(swiper.params.autoplay.disableAutoSlide){
+        stop()
+      }
+      else if (swiper.params.autoplay.reverseDirection) {
         if (!swiper.isBeginning || swiper.params.loop || swiper.params.rewind) {
           swiper.slidePrev(speed, true, true);
           emit('autoplay');
@@ -323,6 +327,9 @@ export default function Autoplay({ swiper, extendParams, on, emit, params }) {
   });
 
   on('slideChange', () => {
+    if(swiper.params.autoplay.enabled && swiper.params.autoplay.disableAutoSlide && !swiper.autoplay.running){
+      start()
+    }
     if (swiper.destroyed || !swiper.autoplay.running) return;
     slideChanged = true;
   });


### PR DESCRIPTION
Hello, when I was working on a project, I encountered a problem. Swiper doesn't provide a method for disabling slide movement when the time is over. In my project, I needed to animate elements on the slide when it disappears and appears, and it must also slide to the next after a certain period of time. Here, a problem arises: Swiper's Autoplay module moves slides automatically and doesn't provide any methods for disabling this. This is a problem because I needed to hide elements on the slide before the next slide appears. When i added disableAutoSlide to autoplay params, this parameter makes autoplay frezee then its time over, and unfreeze then slide changed by hand or programaticaly. I will be very glad, if you find this feature useful and merge this pull request