### PR TITLE
fix(modules/a11y): filter out falsy pagination elems

### DIFF
--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -297,9 +297,7 @@ export default function A11y({ swiper, extendParams, on }) {
 
     // Pagination
     if (hasClickablePagination()) {
-      const paginationEl = Array.isArray(swiper.pagination.el)
-        ? swiper.pagination.el
-        : [swiper.pagination.el];
+      const paginationEl = makeElementsArray(swiper.pagination.el)
       paginationEl.forEach((el) => {
         el.addEventListener('keydown', onEnterOrSpaceKey);
       });
@@ -324,9 +322,7 @@ export default function A11y({ swiper, extendParams, on }) {
 
     // Pagination
     if (hasClickablePagination()) {
-      const paginationEl = Array.isArray(swiper.pagination.el)
-        ? swiper.pagination.el
-        : [swiper.pagination.el];
+      const paginationEl = makeElementsArray(swiper.pagination.el)
       paginationEl.forEach((el) => {
         el.removeEventListener('keydown', onEnterOrSpaceKey);
       });


### PR DESCRIPTION
Similar to #6823 I am noticing intermittent exceptions generated in the `destroy()` method of the `a11y` module, in this case where the `el` argument to the callback passed to `paginationEl.forEach` is `undefined` and so the attempt to `.removeEventListener` is a `TypeError`. As in the previous case, because these exceptions are thrown from within an event handler they are uncatchable and crash the entire page.

It looks like the use of `makeElementsArray`, which filters out such falsy elements (and should otherwise behave identically to the existing code), is also required with the pagination element.