### PR TITLE
fix(types): :rotating_light: added an event fallback for when prefixe…

### DIFF
--- a/src/swiper-element.d.ts
+++ b/src/swiper-element.d.ts
@@ -8,6 +8,10 @@ interface SwiperContainerEventMap extends Omit<HTMLElementEventMap, 'click' | 'p
   // CORE_EVENTS
 
   // MODULES_EVENTS
+
+   // TODO: With custom eventsPrefix can't listen to events
+  // Using that as fallback
+  [key: string]: CustomEvent<[swiper: Swiper, ...additionalData: any[]]>;
 }
 
 interface SwiperContainer extends HTMLElement {}


### PR DESCRIPTION
When a prefix is added (now defaulting to 'swiper'), the CustomEvent<[swiper: Swiper]> is not detected in the typing for the swiper-element.
