### PR TITLE
fix: initialSlide #7216

### DIFF
--- a/src/core/core.mjs
+++ b/src/core/core.mjs
@@ -337,7 +337,6 @@ class Swiper {
   }
 
   slidesPerViewDynamic(view = 'current', exact = false) {
-    console.log('debug');
     const swiper = this;
     const { params, slides, slidesGrid, slidesSizesGrid, size: swiperSize, activeIndex } = swiper;
     let spv = 1;

--- a/src/core/core.mjs
+++ b/src/core/core.mjs
@@ -337,17 +337,18 @@ class Swiper {
   }
 
   slidesPerViewDynamic(view = 'current', exact = false) {
+    console.log('debug');
     const swiper = this;
     const { params, slides, slidesGrid, slidesSizesGrid, size: swiperSize, activeIndex } = swiper;
     let spv = 1;
     if (typeof params.slidesPerView === 'number') return params.slidesPerView;
 
     if (params.centeredSlides) {
-      let slideSize = slides[activeIndex] ? slides[activeIndex].swiperSlideSize : 0;
+      let slideSize = slides[activeIndex] ? Math.ceil(slides[activeIndex].swiperSlideSize) : 0;
       let breakLoop;
       for (let i = activeIndex + 1; i < slides.length; i += 1) {
         if (slides[i] && !breakLoop) {
-          slideSize += slides[i].swiperSlideSize;
+          slideSize += Math.ceil(slides[i].swiperSlideSize);
           spv += 1;
           if (slideSize > swiperSize) breakLoop = true;
         }


### PR DESCRIPTION
Fixed behavior where the combination of 'initialSlide:0' and 'slidesPerView:auto' would shift the first slide position

- getPropertyValue has an error when getting a decimal point value.
- 'slidesPerView:auto' caused an error in the actual number of slides displayed and the calculated number of slides displayed due to the error.