### PR TITLE
Fix: Add Optional `swiperElementNodeName` Prop for (non swiper-element) Web Component Usage

### DIFF
--- a/src/components-shared/params-list.mjs
+++ b/src/components-shared/params-list.mjs
@@ -7,6 +7,7 @@ const paramsList = [
   'init',
   '_direction',
   'oneWayMovement',
+  'swiperElementNodeName',
   'touchEventsTarget',
   'initialSlide',
   '_speed',

--- a/src/core/core.mjs
+++ b/src/core/core.mjs
@@ -504,7 +504,7 @@ class Swiper {
     }
 
     el.swiper = swiper;
-    if (el.parentNode && el.parentNode.host && el.parentNode.host.nodeName === 'SWIPER-CONTAINER') {
+    if (el.parentNode && el.parentNode.host && el.parentNode.host.nodeName === swiper.params.swiperElementNodeName.toUpperCase()) {
       swiper.isElement = true;
     }
 

--- a/src/core/defaults.mjs
+++ b/src/core/defaults.mjs
@@ -2,6 +2,7 @@ export default {
   init: true,
   direction: 'horizontal',
   oneWayMovement: false,
+  swiperElementNodeName: 'SWIPER-CONTAINER',
   touchEventsTarget: 'wrapper',
   initialSlide: 0,
   speed: 300,

--- a/src/swiper-vue.d.ts
+++ b/src/swiper-vue.d.ts
@@ -51,6 +51,10 @@ declare const Swiper: DefineComponent<
       type: PropType<SwiperOptions['oneWayMovement']>;
       default: SwiperOptions['oneWayMovement'];
     };
+    swiperElementNodeName: {
+      type: PropType<SwiperOptions['swiperElementNodeName']>;
+      default: SwiperOptions['swiperElementNodeName'];
+    };
     touchEventsTarget: {
       type: PropType<SwiperOptions['touchEventsTarget']>;
       default: undefined;

--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -101,6 +101,13 @@ export interface SwiperOptions {
   oneWayMovement?: boolean;
 
   /**
+   * The name of the swiper element node name; used for detecting web component rendering
+   *
+   * @default 'SWIPER-CONTAINER'
+   */
+  swiperElementNodeName?: string;
+
+  /**
    * Duration of transition between slides (in ms)
    *
    * @default 300

--- a/src/vue/swiper.mjs
+++ b/src/vue/swiper.mjs
@@ -31,6 +31,7 @@ const Swiper = {
     init: { type: Boolean, default: undefined },
     direction: { type: String, default: undefined },
     oneWayMovement: { type: Boolean, default: undefined },
+    swiperElementNodeName: { type: String, default: 'SWIPER-CONTAINER' },
     touchEventsTarget: { type: String, default: undefined },
     initialSlide: { type: Number, default: undefined },
     speed: { type: Number, default: undefined },


### PR DESCRIPTION
Our design system team recently ran into some major rendering issues using Swiper internally with some of our LitElement based web components (slotted children slides aren't detected). 

After doing some digging, I stumbled across the change added in #6870 which uses a hard-coded nodeName to ultimately determine if a particular swiper instance is rendering as a web component or not.

This PR should allow continued Swiper usage (as-is) via the `swiper-container` custom element, yet also help other folks with customized web component usage by using this new `swiperElementNodeName` parameter to define the custom element tag name being used in their implementation.