### PR TITLE
fix: loopAddBlankSlides incorrect documentation

### DIFF
--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -643,7 +643,7 @@ export interface SwiperOptions {
    * Automatically adds blank slides if you use Grid or `slidesPerGroup` and the total amount of slides is not even to `slidesPerGroup` or to `grid.rows`
    *
    *
-   * @default false
+   * @default true
    *
    */
   loopAddBlankSlides?: boolean;


### PR DESCRIPTION
The `SwiperOptions` type definitions, which I believe is used to auto-generate the api website (https://swiperjs.com/swiper-api#param-loopAddBlankSlides), has incorrect information.

The API documentation states that `loopAddBlankSlides` defaults to `false`,  but it actually defaults to `true`. This drove me crazy for some time (my implementation was broken), until I decided to take a look at the source code.


```
src/core/defaults.mjs - line 103
```

https://github.com/nolimits4web/swiper/blob/76355b81e0a7378a10f4e23af36e83f7d9b8ae98/src/core/defaults.mjs#L101-L105