### PR TITLE
Fix for React strict mode double initialization errors

### DIFF
--- a/src/react/swiper.mjs
+++ b/src/react/swiper.mjs
@@ -138,7 +138,7 @@ const Swiper = forwardRef(
         swiperParams,
       );
 
-      if (onSwiper) onSwiper(swiperRef.current);
+      if (onSwiper && !swiperRef.current.destroyed) onSwiper(swiperRef.current);
       // eslint-disable-next-line
       return () => {
         if (swiperRef.current && !swiperRef.current.destroyed) {


### PR DESCRIPTION
React strict mode creates everything two times and destroys one instance again to check for potential leaks in dev move. 
This behaviour causes swiper to potentially handle an already destroyed instance.