### PR TITLE
Declare enabled option in mousewheel.d.ts

### DIFF
--- a/src/types/modules/mousewheel.d.ts
+++ b/src/types/modules/mousewheel.d.ts
@@ -27,15 +27,19 @@ export interface MousewheelEvents {
 
 export interface MousewheelOptions {
   /**
+   * Set to `true` to enable mousewheel control
+   *
+   * @default false
+   */
+  enabled?: boolean;
+  /**
    * Set to `true` to force mousewheel swipes to axis. So in horizontal mode mousewheel will work only with horizontal mousewheel scrolling, and only with vertical scrolling in vertical mode.
-
    *
    * @default false
    */
   forceToAxis?: boolean;
   /**
    * Set to `true` and swiper will release mousewheel event and allow page scrolling when swiper is on edge positions (in the beginning or in the end)
-
    *
    * @default false
    */


### PR DESCRIPTION
Declare `enabled` option for the Mousewheel options, to prevent the type check errors.

Currently TS build raise a (non-blocking) error on build:
error TS2353: Object literal may only specify known properties, and 'enabled' does not exist in type 'MousewheelOptions', using the following declaration:

```
<swiper
    :mousewheel="{
      enabled: true
    }"
  >
  ...
```
