### PR TITLE
Fix initial slide index shift with centeredSlides and slidesPerView auto

### DIFF
--- a/src/core/loop/loopFix.mjs
+++ b/src/core/loop/loopFix.mjs
@@ -158,7 +158,7 @@ export default function loopFix({
         if (byMousewheel) {
           swiper.setTranslate(swiper.translate - diff);
         } else {
-          swiper.slideTo(activeIndex + slidesPrepended, 0, false, true);
+          swiper.slideTo(activeIndex + Math.ceil(slidesPrepended), 0, false, true);
           if (setTranslate) {
             swiper.touchEventsData.startTranslate = swiper.touchEventsData.startTranslate - diff;
             swiper.touchEventsData.currentTranslate =


### PR DESCRIPTION
- Originally observed issue when initialSlide was 0 but reproduced in other cases(#7228 )
- Investigation found activeColIndexWithShift calculation in loopFix.mjs was adding 0.5 when centeredSlides true, causing slidesPrepended to be decimal number in some cases
- Non-integer slidesPrepended value then gets rounded down in snapIndex calculation in slideTo.mjs, causing initial slide index to be less than intended
- Fix by using Math.ceil to round up the slide index variable passed to the slideTo method as argument in loopFix.mjs, ensuring an integer index value is passed to slideTo