### PR TITLE
Fix: types of breakpointsBase & effect

### DIFF
--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -210,7 +210,7 @@ export interface SwiperOptions {
    *
    * @default 'slide'
    */
-  effect?: 'slide' | 'fade' | 'cube' | 'coverflow' | 'flip' | 'creative' | 'cards';
+  effect?: 'slide' | 'fade' | 'cube' | 'coverflow' | 'flip' | 'creative' | 'cards' | string;
 
   /**
    * Fire Transition/SlideChange/Start/End events on swiper initialization.

--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -206,11 +206,11 @@ export interface SwiperOptions {
   uniqueNavElements?: boolean;
 
   /**
-   * Transition effect. Can be `'slide'`, `'fade'`, `'cube'`, `'coverflow'`, `'flip'` or `'creative'`
+   * Transition effect. Can be `'slide'`, `'fade'`, `'cube'`, `'coverflow'`, `'flip'`, `'creative'` or `'cards'`
    *
    * @default 'slide'
    */
-  effect?: 'slide' | 'fade' | 'cube' | 'coverflow' | 'flip' | 'creative' | 'cards' | string;
+  effect?: 'slide' | 'fade' | 'cube' | 'coverflow' | 'flip' | 'creative' | 'cards';
 
   /**
    * Fire Transition/SlideChange/Start/End events on swiper initialization.
@@ -741,7 +741,7 @@ export interface SwiperOptions {
    *
    * @default 'window'
    */
-  breakpointsBase?: string;
+  breakpointsBase?: 'window' | 'container';
 
   // Observer
   /**


### PR DESCRIPTION
This pull request includes updates to the type annotations in `swiper-options.d.ts` of the Swiper package. The changes are as follows:

1. **effect:** The `| string` part of the type has been removed. This enhances the IntelliSense experience by providing more precise suggestions.

![Screenshot 2024-03-11 092210](https://github.com/nolimits4web/swiper/assets/62181905/124b6427-6e68-402b-bc61-a87dca56cac9)
![Screenshot 2024-03-11 092150](https://github.com/nolimits4web/swiper/assets/62181905/f98e84d9-8849-4e3d-a29f-e731cbd4365c)



3. **breakpointsBase:** The type for `breakpointsBase` has been updated from `string` to more explicit `'window' | 'container'`. 

![Screenshot 2024-03-11 092104](https://github.com/nolimits4web/swiper/assets/62181905/70cc9cc2-cd78-4c0a-83ea-527dcf83be17)
![Screenshot 2024-03-11 092133](https://github.com/nolimits4web/swiper/assets/62181905/fc977e88-b26f-41d6-9333-f812fafdad13)

