### PR TITLE
Add vertical navigation button styles

### DIFF
--- a/demos/090-vertical.html
+++ b/demos/090-vertical.html
@@ -24,6 +24,9 @@
     </div>
     <!-- Add Pagination -->
     <div class="swiper-pagination"></div>
+    <!-- Add Navigation -->
+    <div class="swiper-button-next"></div>
+    <div class="swiper-button-prev"></div>
   </div>
 
 
@@ -37,6 +40,10 @@
       pagination: {
         el: '.swiper-pagination',
         clickable: true,
+      },
+      navigation: {
+        nextEl: ".swiper-button-next",
+        prevEl: ".swiper-button-prev",
       },
     });
   </script>

--- a/src/modules/navigation/navigation.less
+++ b/src/modules/navigation/navigation.less
@@ -82,3 +82,17 @@
   left: auto;
 }
 /* Navigation font end */
+.swiper-vertical {
+  :is(.swiper-button-next, .swiper-button-prev) {
+    left: 50%;
+    transform: rotate(90deg);
+    transform-origin: left center;
+  }
+  .swiper-button-prev {
+    top: calc(var(--swiper-navigation-size) / 2);
+  }
+  .swiper-button-next {
+    top: auto;
+    bottom: calc(var(--swiper-navigation-size) / 2);
+  }
+}

--- a/src/modules/navigation/navigation.scss
+++ b/src/modules/navigation/navigation.scss
@@ -85,3 +85,17 @@
   left: auto;
 }
 /* Navigation font end */
+.swiper-vertical {
+  :is(.swiper-button-next, .swiper-button-prev) {
+    left: 50%;
+    transform: rotate(90deg);
+    transform-origin: left center;
+  }
+  .swiper-button-prev {
+    top: calc(var(--swiper-navigation-size) / 2);
+  }
+  .swiper-button-next {
+    top: auto;
+    bottom: calc(var(--swiper-navigation-size) / 2);
+  }
+}


### PR DESCRIPTION
This PR adds styles (to SCSS and LESS) for visually adjusting the vertical swiper navigation buttons.
It also adds navigation buttons to the vertical swiper demo page.

Closes https://github.com/nolimits4web/swiper/issues/3592 (was automatically closed due to staleness).