### PR TITLE
fix(core): centerInsuffientSlides takes offsets into account

### DIFF
--- a/src/core/update/updateSlides.mjs
+++ b/src/core/update/updateSlides.mjs
@@ -269,8 +269,9 @@ export default function updateSlides() {
       allSlidesSize += slideSizeValue + (spaceBetween || 0);
     });
     allSlidesSize -= spaceBetween;
-    if (allSlidesSize < swiperSize) {
-      const allSlidesOffset = (swiperSize - allSlidesSize) / 2;
+    const offsetSize = (params.slidesOffsetBefore || 0) + (params.slidesOffsetAfter || 0);
+    if (allSlidesSize + offsetSize < swiperSize) {
+      const allSlidesOffset = (swiperSize - allSlidesSize - offsetSize) / 2;
       snapGrid.forEach((snap, snapIndex) => {
         snapGrid[snapIndex] = snap - allSlidesOffset;
       });


### PR DESCRIPTION
When using centerInsufficientSlides together with slidesOffsetBefore and slidesOffsetAfter, the slides won’t be centered correctly. Apparently slidesOffsetBefore and  slidesOffsetAfter are not taken into account in the calculation of the offset for centerInsufficientSlides.

[Codesandbox](https://codesandbox.io/p/sandbox/swiper-center-insufficient-slides-bug-98rqzr?file=%2Fsrc%2Findex.js)

Resolves https://github.com/nolimits4web/swiper/issues/5436 (was closed already due to lacking information / activity, but issue still remains)