### PR TITLE
Avoid rendering same slide vnode twice for small amount of slides in loop + virtual mode

### DIFF
--- a/src/vue/virtual.mjs
+++ b/src/vue/virtual.mjs
@@ -24,7 +24,7 @@ function renderVirtual(swiperRef, slides, virtualData) {
   const loopTo = swiperRef.value.params.loop ? slides.length * 2 : slides.length;
   const slidesToRender = [];
   for (let i = loopFrom; i < loopTo; i += 1) {
-    if (i >= from && i <= to) {
+    if (i >= from && i <= to && slidesToRender.length < slides.length) {
       slidesToRender.push(slides[getSlideIndex(i)]);
     }
   }


### PR DESCRIPTION
This fix adds one extra logical check in order to avoid pushing more elements to `slidesToRender` that we have slides, i.e. we avoid duplicates. 

Refers to #7557 

Cases with 4+ slides work as before