### PR TITLE
added new prop for a11y module - scrollOnFocus

### DIFF
--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -18,6 +18,7 @@ export default function A11y({ swiper, extendParams, on }) {
       itemRoleDescriptionMessage: null,
       slideRole: 'group',
       id: null,
+      scrollOnFocus: true
     },
   });
 

--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -237,7 +237,7 @@ export default function A11y({ swiper, extendParams, on }) {
   };
 
   const handleFocus = (e) => {
-    if (swiper.a11y.clicked) return;
+    if (swiper.a11y.clicked || !swiper.params.a11y.scrollOnFocus) return;
     if (new Date().getTime() - visibilityChangedTimestamp < 100) return;
 
     const slideEl = e.target.closest(`.${swiper.params.slideClass}, swiper-slide`);

--- a/src/types/modules/a11y.d.ts
+++ b/src/types/modules/a11y.d.ts
@@ -93,4 +93,11 @@ export interface A11yOptions {
    * @default null
    */
   id?: string | number | null;
+
+  /**
+   * Enables scrolling to the slide that has been focused
+   *
+   * @default true
+   */
+  scrollOnFocus?: boolean;
 }


### PR DESCRIPTION
Added the 'scrollOnFocus' property with a zero value, which will prevent scrolling to the element that was focused. At the same time, the default value will be 'true', which will avoid backward compatibility issues.