### PR TITLE
feat(toggle-preloading): add param to disable preloading

### DIFF
--- a/src/components-shared/params-list.mjs
+++ b/src/components-shared/params-list.mjs
@@ -90,6 +90,7 @@ const paramsList = [
   'slidePrevClass',
   'slideBlankClass',
   'wrapperClass',
+  'lazyPreload',
   'lazyPreloaderClass',
   'lazyPreloadPrevNext',
   'runCallbacksOnInit',

--- a/src/core/core.mjs
+++ b/src/core/core.mjs
@@ -405,11 +405,13 @@ class Swiper {
       swiper.setBreakpoint();
     }
 
-    [...swiper.el.querySelectorAll('[loading="lazy"]')].forEach((imageEl) => {
-      if (imageEl.complete) {
-        processLazyPreloader(swiper, imageEl);
-      }
-    });
+    if (swiper.params.lazyPreload) {
+      [...swiper.el.querySelectorAll('[loading="lazy"]')].forEach((imageEl) => {
+        if (imageEl.complete) {
+          processLazyPreloader(swiper, imageEl);
+        }
+      });
+    }
 
     swiper.updateSize();
     swiper.updateSlides();
@@ -617,19 +619,23 @@ class Swiper {
 
     // Attach events
     swiper.attachEvents();
-    const lazyElements = [...swiper.el.querySelectorAll('[loading="lazy"]')];
-    if (swiper.isElement) {
-      lazyElements.push(...swiper.hostEl.querySelectorAll('[loading="lazy"]'));
-    }
-    lazyElements.forEach((imageEl) => {
-      if (imageEl.complete) {
-        processLazyPreloader(swiper, imageEl);
-      } else {
-        imageEl.addEventListener('load', (e) => {
-          processLazyPreloader(swiper, e.target);
-        });
+
+    if (swiper.params.lazyPreload) {
+      const lazyElements = [...swiper.el.querySelectorAll('[loading="lazy"]')];
+      if (swiper.isElement) {
+        lazyElements.push(...swiper.hostEl.querySelectorAll('[loading="lazy"]'));
       }
-    });
+      lazyElements.forEach((imageEl) => {
+        if (imageEl.complete) {
+          processLazyPreloader(swiper, imageEl);
+        } else {
+          imageEl.addEventListener('load', (e) => {
+            processLazyPreloader(swiper, e.target);
+          });
+        }
+      });
+    }
+
     preload(swiper);
 
     // Init Flag

--- a/src/core/defaults.mjs
+++ b/src/core/defaults.mjs
@@ -132,6 +132,9 @@ export default {
   slideNextClass: 'swiper-slide-next',
   slidePrevClass: 'swiper-slide-prev',
   wrapperClass: 'swiper-wrapper',
+
+  // Lazy Preload
+  lazyPreload: true,
   lazyPreloaderClass: 'swiper-lazy-preloader',
   lazyPreloadPrevNext: 0,
 

--- a/src/core/events/index.mjs
+++ b/src/core/events/index.mjs
@@ -53,7 +53,9 @@ const events = (swiper, method) => {
   }
 
   // Images loader
-  el[domMethod]('load', swiper.onLoad, { capture: true });
+  if (params.lazyPreload) {
+    el[domMethod]('load', swiper.onLoad, { capture: true });
+  }
 };
 
 function attachEvents() {

--- a/src/shared/process-lazy-preloader.mjs
+++ b/src/shared/process-lazy-preloader.mjs
@@ -1,5 +1,5 @@
 export const processLazyPreloader = (swiper, imageEl) => {
-  if (!swiper || swiper.destroyed || !swiper.params) return;
+  if (!swiper || swiper.destroyed || !swiper.params || !swiper.params.lazyPreload) return;
   const slideSelector = () => (swiper.isElement ? `swiper-slide` : `.${swiper.params.slideClass}`);
   const slideEl = imageEl.closest(slideSelector());
   if (slideEl) {
@@ -29,7 +29,7 @@ const unlazy = (swiper, index) => {
 };
 
 export const preload = (swiper) => {
-  if (!swiper || swiper.destroyed || !swiper.params) return;
+  if (!swiper || swiper.destroyed || !swiper.params || !swiper.params.lazyPreload) return;
   let amount = swiper.params.lazyPreloadPrevNext;
   const len = swiper.slides.length;
   if (!len || !amount || amount < 0) return;

--- a/src/swiper-vue.d.ts
+++ b/src/swiper-vue.d.ts
@@ -331,6 +331,10 @@ declare const Swiper: DefineComponent<
       type: StringConstructor;
       default: undefined;
     };
+    lazyPreload: {
+      type: BooleanConstructor;
+      default: undefined;
+    };
     lazyPreloaderClass: {
       type: StringConstructor;
       default: undefined;

--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -866,6 +866,18 @@ export interface SwiperOptions {
   wrapperClass?: string;
 
   /**
+   * When enabled, Swiper attaches `load` listeners to lazy images (`loading="lazy"`),
+   * removes the lazy preloader element once they load, and preloads adjacent slides.
+   *
+   * Set to `false` if you manage lazy loading yourself — Swiper will not attach any
+   * image `load` listeners (including the capture-phase listener on the root element),
+   * avoiding the layout reflows that `swiper.update()` triggers on every image load.
+   *
+   * @default true
+   */
+  lazyPreload?: boolean;
+
+  /**
    * CSS class name of lazy preloader
    *
    * @default 'swiper-lazy-preloader'

--- a/src/vue/swiper.mjs
+++ b/src/vue/swiper.mjs
@@ -111,6 +111,7 @@ const Swiper = {
     slideNextClass: { type: String, default: undefined },
     slidePrevClass: { type: String, default: undefined },
     wrapperClass: { type: String, default: undefined },
+    lazyPreload: { type: Boolean, default: undefined },
     lazyPreloaderClass: { type: String, default: undefined },
     lazyPreloadPrevNext: { type: Number, default: undefined },
     runCallbacksOnInit: { type: Boolean, default: undefined },


### PR DESCRIPTION
Add ability to toggle preloading of images. If the user doesn't want to rely on the swiper implementation the user is unable to opt out of it and infers huge performance penalties.
More in https://github.com/nolimits4web/swiper/issues/7570