### PR TITLE
add types for minTranslate and maxTranslate functions

### DIFF
--- a/src/types/swiper-class.d.ts
+++ b/src/types/swiper-class.d.ts
@@ -386,6 +386,16 @@ interface Swiper extends SwiperClass<SwiperEvents> {
   ): any;
 
   /**
+   * Get current minimal translate value
+   */
+  minTranslate(): number;
+
+  /**
+   * Get current maximal translate value
+   */
+  maxTranslate(): number;
+
+  /**
    * Unset grab cursor
    */
   unsetGrabCursor(): void;


### PR DESCRIPTION
I only extended the types for the `maxTranslate` and `minTranslate` functions.