### PR TITLE
Bugfix: Fixed typo in utils/elementIsChildOf

### DIFF
--- a/src/shared/utils.mjs
+++ b/src/shared/utils.mjs
@@ -216,7 +216,7 @@ function elementChildren(element, selector = '') {
 function elementIsChildOf(el, parent) {
   const isChild = parent.contains(el);
   if (!isChild && parent instanceof HTMLSlotElement) {
-    const children = [...element.assignedElements()];
+    const children = [...parent.assignedElements()];
     return children.includes(el);
   }
   return isChild;


### PR DESCRIPTION
The current implementation of elementIsChildOf function references a variable 'element', which is not defined in its scope:
```js
function elementIsChildOf(el, parent) {
  const isChild = parent.contains(el);
  if (!isChild && parent instanceof HTMLSlotElement) {
    const children = [...element.assignedElements()];
    return children.includes(el);
  }
  return isChild;
}
```

I believe it should've been 'parent', the current implementation just throws an error if parent is an HTMLSlotElement.
