### PR TITLE
fix types of swiper-effect-utils.d.ts

### DIFF
--- a/src/swiper-effect-utils.d.ts
+++ b/src/swiper-effect-utils.d.ts
@@ -1,6 +1,6 @@
-import { Swiper, SwiperOptions } from './types/index.d.ts';
+import type { Swiper, SwiperOptions } from './types/index.d.ts';
 
-declare const createShadow: (suffix?: string, slideEl: HTMLElement, side?: string) => HTMLElement;
+declare const createShadow: (suffix: string, slideEl: HTMLElement, side?: string) => HTMLElement;
 
 declare const effectInit: (params: {
   effect: string;


### PR DESCRIPTION
This PR fix two type issues of `swiper-effect-utils.d.ts`.

#### 1. change `import` of .d.ts file to `import type`

related: https://github.com/nolimits4web/Swiper/commit/30ce8e0c9c7ce32025275469e9480ca8c81f30a7

> A declaration file cannot be imported without 'import type'. Did you mean to import an implementation file './types/index.ts' instead?

![fix_types_of_effect_utils_01](https://github.com/user-attachments/assets/20b5c13b-8120-4cf1-8881-b48e70a3b4c6)

#### 2. Fix invalid optional parameter declaration of `createShadow`.

In making this correction, I checked that `suffix` parameter is specified at all places in this repo where `createShadow` is called.

> A required parameter cannot follow an optional parameter.

![fix_types_of_effect_utils_02](https://github.com/user-attachments/assets/2b232122-2a72-41ee-bff4-41755b3a8723)
