### PR TITLE
centeredSlides with centeredSlidesBounds don't work correct when slidesPerView: 'auto' and width of the swiper bigger then width of slides

### DIFF
--- a/src/core/update/updateSlides.mjs
+++ b/src/core/update/updateSlides.mjs
@@ -255,7 +255,7 @@ export default function updateSlides() {
       allSlidesSize += slideSizeValue + (spaceBetween || 0);
     });
     allSlidesSize -= spaceBetween;
-    const maxSnap = allSlidesSize - swiperSize;
+    const maxSnap = allSlidesSize > swiperSize ? allSlidesSize - swiperSize : 0;
     snapGrid = snapGrid.map((snap) => {
       if (snap <= 0) return -offsetBefore;
       if (snap > maxSnap) return maxSnap + offsetAfter;


### PR DESCRIPTION
Demo here https://jsfiddle.net/pbL17azg/
Try run demo and resize window to breakpoin to 800px or bigger and click to (Slide arrow) to reproduce bug
Added video for visuality bug.
https://github.com/user-attachments/assets/f93246c5-50d9-4bdf-9a98-83300189418d

Bug reproduction if the swiper width bigger then the total width of slides and has option slidesPerView with value 'auto' .


