### PR TITLE
Add containerRole parameter to a11y module

### DIFF
--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -15,6 +15,7 @@ export default function A11y({ swiper, extendParams, on }) {
       slideLabelMessage: '{{index}} / {{slidesLength}}',
       containerMessage: null,
       containerRoleDescriptionMessage: null,
+      containerRole: null,
       itemRoleDescriptionMessage: null,
       slideRole: 'group',
       id: null,
@@ -301,6 +302,9 @@ export default function A11y({ swiper, extendParams, on }) {
     }
     if (params.containerMessage) {
       addElLabel(containerEl, params.containerMessage);
+    }
+    if (params.containerRole) {
+      addElRole(containerEl, params.containerRole);
     }
 
     // Wrapper

--- a/src/types/modules/a11y.d.ts
+++ b/src/types/modules/a11y.d.ts
@@ -67,6 +67,13 @@ export interface A11yOptions {
   containerRoleDescriptionMessage?: string | null;
 
   /**
+   * Value of the "role" attribute to be set on the swiper container
+   *
+   * @default null
+   */
+  containerRole?: string | null;
+
+  /**
    * Message for screen readers describing the role of slide element
    *
    * @default null


### PR DESCRIPTION
To fix accessibility error related to aria-roledescription by adding an additional role parameter to the a11y module.

Fixes #7707