### PR TITLE
fix(element): Query the swiper.hostEl for the navigation buttons (#7714)

### DIFF
--- a/src/modules/navigation/navigation.mjs
+++ b/src/modules/navigation/navigation.mjs
@@ -23,7 +23,7 @@ export default function Navigation({ swiper, extendParams, on, emit }) {
   function getEl(el) {
     let res;
     if (el && typeof el === 'string' && swiper.isElement) {
-      res = swiper.el.querySelector(el);
+      res = swiper.el.querySelector(el) || swiper.hostEl.querySelector(el);
       if (res) return res;
     }
     if (el) {


### PR DESCRIPTION
To be able to have more than one Swiper custom element on a page without having to have different CSS selectors for their custom navigation buttons.

A PR for the issue #7714 