### PR TITLE
Add sanity check before allowTouchMove call in timeout

### DIFF
--- a/src/modules/zoom/zoom.mjs
+++ b/src/modules/zoom/zoom.mjs
@@ -247,6 +247,7 @@ export default function Zoom({ swiper, extendParams, on, emit }) {
     clearTimeout(allowTouchMoveTimeout);
     swiper.touchEventsData.preventTouchMoveFromPointerMove = true;
     allowTouchMoveTimeout = setTimeout(() => {
+      if (swiper.destroyed) return;
       allowTouchMove();
     });
   }


### PR DESCRIPTION
This PR adds a check if Swiper instance has been destroyed before the `allowTouchMove` call in the `setTimeout` callback happens.

Issue: #7722 
