### PR TITLE
Remove 'Lazy' declaration

### DIFF
--- a/src/types/modules/index.d.ts
+++ b/src/types/modules/index.d.ts
@@ -12,7 +12,6 @@ declare const EffectCards: SwiperModule;
 declare const HashNavigation: SwiperModule;
 declare const History: SwiperModule;
 declare const Keyboard: SwiperModule;
-declare const Lazy: SwiperModule;
 declare const Mousewheel: SwiperModule;
 declare const Navigation: SwiperModule;
 declare const Pagination: SwiperModule;
@@ -38,7 +37,6 @@ export {
   HashNavigation,
   History,
   Keyboard,
-  Lazy,
   Mousewheel,
   Navigation,
   Pagination,


### PR DESCRIPTION
`Lazy` is no longer exported since [9.0.0](https://github.com/nolimits4web/Swiper/compare/v8.4.7...v9.0.0), 2023-02-01
But it still exists in the d.ts file. This can be confusing.


