### PR TITLE
7761: Fixed elementIsChildOf returning false for nested web components

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -36,7 +36,7 @@ module.exports = {
     ecmaFeatures: {
       jsx: true,
     },
-    ecmaVersion: 2018,
+    ecmaVersion: 2021,
     sourceType: 'module',
   },
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "element": "npm run build && concurrently --kill-others \"vite ./playground/element\" \"npm run watch\" ",
     "react": "npm run build && concurrently --kill-others \"vite ./playground/react\" \"npm run watch\"",
     "vue": "npm run build && concurrently --kill-others \"vite ./playground/vue\" \"npm run watch\"",
-    "prettier": "prettier \"**/*.+(js|json|scss|css|less|ts|jsx)\"",
+    "prettier": "prettier \"**/*.+(js|json|scss|css|less|ts|jsx|mjs)\"",
     "format": "npm run prettier -- --write",
     "check-format": "npm run prettier -- --list-different",
     "lint": "eslint --ext .js,.jsx .",

--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -19,7 +19,7 @@ export default function A11y({ swiper, extendParams, on }) {
       itemRoleDescriptionMessage: null,
       slideRole: 'group',
       id: null,
-      scrollOnFocus: true
+      scrollOnFocus: true,
     },
   });
 

--- a/src/shared/utils.mjs
+++ b/src/shared/utils.mjs
@@ -213,9 +213,9 @@ function elementChildren(element, selector = '') {
   }
   return children.filter((el) => el.matches(selector));
 }
-function elementIsChildOf(el, parent) {
+function elementIsChildOfSlot(el, slot) {
   // Breadth-first search through all parent's children and assigned elements
-  const elementsQueue = [parent];
+  const elementsQueue = [slot];
   while (elementsQueue.length > 0) {
     const elementToCheck = elementsQueue.shift();
     if (el === elementToCheck) {
@@ -223,11 +223,22 @@ function elementIsChildOf(el, parent) {
     }
     elementsQueue.push(
       ...elementToCheck.children,
-      ...(elementToCheck.shadowRoot?.children ?? []),
-      ...(elementToCheck.assignedElements?.() ?? []),
+      ...(elementToCheck.shadowRoot?.children || []),
+      ...(elementToCheck.assignedElements?.() || []),
     );
   }
-  return false;
+}
+function elementIsChildOf(el, parent) {
+  let isChild = parent.contains(el);
+  if (!isChild && parent instanceof HTMLSlotElement) {
+    const children = [...parent.assignedElements()];
+    isChild = children.includes(el);
+    if (!isChild) {
+      isChild = elementIsChildOfSlot(el, parent);
+    }
+  }
+
+  return isChild;
 }
 function showWarning(text) {
   try {

--- a/src/shared/utils.mjs
+++ b/src/shared/utils.mjs
@@ -214,12 +214,20 @@ function elementChildren(element, selector = '') {
   return children.filter((el) => el.matches(selector));
 }
 function elementIsChildOf(el, parent) {
-  const isChild = parent.contains(el);
-  if (!isChild && parent instanceof HTMLSlotElement) {
-    const children = [...parent.assignedElements()];
-    return children.includes(el);
+  // Breadth-first search through all parent's children and assigned elements
+  const elementsQueue = [parent];
+  while (elementsQueue.length > 0) {
+    const elementToCheck = elementsQueue.shift();
+    if (el === elementToCheck) {
+      return true;
+    }
+    elementsQueue.push(
+      ...elementToCheck.children,
+      ...(elementToCheck.shadowRoot?.children ?? []),
+      ...(elementToCheck.assignedElements?.() ?? []),
+    );
   }
-  return isChild;
+  return false;
 }
 function showWarning(text) {
   try {

--- a/src/vue/get-children.mjs
+++ b/src/vue/get-children.mjs
@@ -18,13 +18,9 @@ function getChildren(originalSlots = {}, slidesRef, oldSlidesRef) {
       if (isFragment && vnode.children) {
         getSlidesFromElements(vnode.children, slotName);
       } else if (
-        (
-          vnode.type &&
-          (vnode.type.name === 'SwiperSlide' || vnode.type.name === 'AsyncComponentWrapper')
-        ) ||
-        (
-          vnode.componentOptions && (vnode.componentOptions.tag === 'SwiperSlide')
-        )
+        (vnode.type &&
+          (vnode.type.name === 'SwiperSlide' || vnode.type.name === 'AsyncComponentWrapper')) ||
+        (vnode.componentOptions && vnode.componentOptions.tag === 'SwiperSlide')
       ) {
         slides.push(vnode);
       } else if (slots[slotName]) {


### PR DESCRIPTION
A fix for #7761.

I basically had to write my own implementation of the standard `element.contains()` method in `elementIsChildOf` function. This implementation takes into account shadow roots and slots, which are commonly used in web components. The standard implementation does not.

I tested the solution in my own project and it fixes the issue. I have also tested it in the provided demos, it didn't seem to break anything.

Also, I've noticed that .mjs files are not included into the prettier job, so I added them and re-ran it. 