### PR TITLE
Type definitions for `slidesEl`, `slidesGrid`, and `slidesSizesGrid`

### DIFF
--- a/src/types/swiper-class.d.ts
+++ b/src/types/swiper-class.d.ts
@@ -60,6 +60,11 @@ interface Swiper extends SwiperClass<SwiperEvents> {
   wrapperEl: HTMLElement;
 
   /**
+   * Wrapper HTML element
+   */
+  slidesEl: HTMLElement;
+
+  /**
    * Array of slides HTML elements. To get specific slide HTMLElement use `swiper.slides[1]`
    */
   slides: HTMLElement[];
@@ -115,6 +120,16 @@ interface Swiper extends SwiperClass<SwiperEvents> {
    * Slides snap grid
    */
   snapGrid: number[];
+
+  /**
+   * Slides grid
+   */
+  slidesGrid: number[];
+
+  /**
+   * Array of widths for slides
+   */
+  slidesSizesGrid: number[];
 
   /**
    * `true` if slider on most "left"/"top" position


### PR DESCRIPTION
The types for `slidesEl`, `slidesGrid`, and `slidesSizesGrid` have been defined, allowing for proper access to these properties in a TypeScript environment.

Issue: https://github.com/nolimits4web/swiper/issues/7767 https://github.com/nolimits4web/swiper/issues/7605