### PR TITLE
7771: [hotfix] Dart Sass 3.0.0 compatibility

### DIFF
--- a/scripts/build-styles.js
+++ b/scripts/build-styles.js
@@ -97,6 +97,26 @@ export default async function buildStyles() {
             .replace(/modules\/([a-zA-Z0-9-]*)/, 'modules')
             .replace(/modules\\([a-zA-Z0-9-]*)/, 'modules');
         }
+
+        const extension = file.split('.').pop();
+        if (extension === 'scss') {
+          if (file === 'swiper.scss') {
+            //root file
+            distFileContent = distFileContent.replace(
+              `@import 'swiper-vars.scss';`,
+              `@use 'swiper-vars.scss' as vars;`,
+            );
+            distFileContent = distFileContent.replace(`#{$themeColor}`, `#{vars.$themeColor}`);
+          } else {
+            //modules files
+            distFileContent = distFileContent.replace(
+              `@import '../swiper-vars.scss';`,
+              `@use '../swiper-vars.scss' as vars;`,
+            );
+            distFileContent = distFileContent.replace(`#{$themeColor}`, `#{vars.$themeColor}`);
+          }
+        }
+
         await fs.ensureDir(path.dirname(distFilePath));
         await fs.writeFile(distFilePath, distFileContent);
       }),


### PR DESCRIPTION
PR connected with [issue 7771](https://github.com/nolimits4web/swiper/issues/7771)

Added string replacement in `build-styles.js` file to make compatibility with Dart Sass 3.0 ([breaking changes in @import and global built-in functions](https://sass-lang.com/documentation/breaking-changes/import/)).

- `@import` statement is replaced with `@use` with namespace `vars`
- `#{$themeColor}` replaced `#{vars.$themeColor}`to work with `@use` statement

