### PR TITLE
Fix React strict mode double initialization errors for thumbs

### DIFF
--- a/src/components-shared/update-swiper.mjs
+++ b/src/components-shared/update-swiper.mjs
@@ -26,8 +26,9 @@ function updateSwiper({
     changedParams.includes('thumbs') &&
     passedParams.thumbs &&
     passedParams.thumbs.swiper &&
+    !passedParams.thumbs.swiper.destroyed &&
     currentParams.thumbs &&
-    !currentParams.thumbs.swiper
+    (!currentParams.thumbs.swiper || currentParams.thumbs.swiper.destroyed)
   ) {
     needThumbsInit = true;
   }


### PR DESCRIPTION
The same issue we fixed in #7293 is causing #7565.

This patch would handle thumbs inits more gracefully in strict mode.