### PR TITLE
fix: use find where possible instead of filter

### DIFF
--- a/src/components-shared/get-element-params.mjs
+++ b/src/components-shared/get-element-params.mjs
@@ -69,9 +69,7 @@ function getParams(element, propName, propValue) {
     attrsList.push({ name: propName, value: isObject(propValue) ? { ...propValue } : propValue });
   }
   attrsList.forEach((attr) => {
-    const moduleParam = modulesParamsList.filter(
-      (mParam) => attr.name.indexOf(`${mParam}-`) === 0,
-    )[0];
+    const moduleParam = modulesParamsList.find((mParam) => attr.name.startsWith(`${mParam}-`));
     if (moduleParam) {
       const parentObjName = attrToProp(moduleParam);
       const subObjName = attrToProp(attr.name.split(`${moduleParam}-`)[1]);

--- a/src/core/core.mjs
+++ b/src/core/core.mjs
@@ -254,9 +254,9 @@ class Swiper {
 
   getSlideIndexByData(index) {
     return this.getSlideIndex(
-      this.slides.filter(
-        (slideEl) => slideEl.getAttribute('data-swiper-slide-index') * 1 === index,
-      )[0],
+      this.slides.find(
+        (slideEl) => slideEl.getAttribute('data-swiper-slide-index') * 1 === index
+      ),
     );
   }
 

--- a/src/core/events/onTouchEnd.mjs
+++ b/src/core/events/onTouchEnd.mjs
@@ -13,7 +13,7 @@ export default function onTouchEnd(event) {
     if (e.pointerId !== data.pointerId) return;
     targetTouch = e;
   } else {
-    targetTouch = [...e.changedTouches].filter((t) => t.identifier === data.touchId)[0];
+    targetTouch = [...e.changedTouches].find((t) => t.identifier === data.touchId);
     if (!targetTouch || targetTouch.identifier !== data.touchId) return;
   }
 

--- a/src/core/events/onTouchMove.mjs
+++ b/src/core/events/onTouchMove.mjs
@@ -20,7 +20,7 @@ export default function onTouchMove(event) {
 
   let targetTouch;
   if (e.type === 'touchmove') {
-    targetTouch = [...e.changedTouches].filter((t) => t.identifier === data.touchId)[0];
+    targetTouch = [...e.changedTouches].find((t) => t.identifier === data.touchId);
     if (!targetTouch || targetTouch.identifier !== data.touchId) return;
   } else {
     targetTouch = e;

--- a/src/core/loop/loopFix.mjs
+++ b/src/core/loop/loopFix.mjs
@@ -68,7 +68,7 @@ export default function loopFix({
 
   if (typeof activeSlideIndex === 'undefined') {
     activeSlideIndex = swiper.getSlideIndex(
-      slides.filter((el) => el.classList.contains(params.slideActiveClass))[0],
+      slides.find((el) => el.classList.contains(params.slideActiveClass)),
     );
   } else {
     activeIndex = activeSlideIndex;

--- a/src/core/slide/slideToLoop.mjs
+++ b/src/core/slide/slideToLoop.mjs
@@ -21,9 +21,9 @@ export default function slideToLoop(index = 0, speed, runCallbacks = true, inter
       let targetSlideIndex;
       if (gridEnabled) {
         const slideIndex = newIndex * swiper.params.grid.rows;
-        targetSlideIndex = swiper.slides.filter(
+        targetSlideIndex = swiper.slides.find(
           (slideEl) => slideEl.getAttribute('data-swiper-slide-index') * 1 === slideIndex,
-        )[0].column;
+        ).column;
       } else {
         targetSlideIndex = swiper.getSlideIndexByData(newIndex);
       }
@@ -70,9 +70,9 @@ export default function slideToLoop(index = 0, speed, runCallbacks = true, inter
 
       if (gridEnabled) {
         const slideIndex = newIndex * swiper.params.grid.rows;
-        newIndex = swiper.slides.filter(
+        newIndex = swiper.slides.find(
           (slideEl) => slideEl.getAttribute('data-swiper-slide-index') * 1 === slideIndex,
-        )[0].column;
+        ).column;
       } else {
         newIndex = swiper.getSlideIndexByData(newIndex);
       }

--- a/src/core/update/updateActiveIndex.mjs
+++ b/src/core/update/updateActiveIndex.mjs
@@ -86,7 +86,7 @@ export default function updateActiveIndex(newActiveIndex) {
   if (swiper.virtual && params.virtual.enabled && params.loop) {
     realIndex = getVirtualRealIndex(activeIndex);
   } else if (gridEnabled) {
-    const firstSlideInColumn = swiper.slides.filter((slideEl) => slideEl.column === activeIndex)[0];
+    const firstSlideInColumn = swiper.slides.find((slideEl) => slideEl.column === activeIndex);
     let activeSlideIndex = parseInt(firstSlideInColumn.getAttribute('data-swiper-slide-index'), 10);
     if (Number.isNaN(activeSlideIndex)) {
       activeSlideIndex = Math.max(swiper.slides.indexOf(firstSlideInColumn), 0);

--- a/src/core/update/updateSlidesClasses.mjs
+++ b/src/core/update/updateSlidesClasses.mjs
@@ -36,9 +36,9 @@ export default function updateSlidesClasses() {
     }
   } else {
     if (gridEnabled) {
-      activeSlide = slides.filter((slideEl) => slideEl.column === activeIndex)[0];
-      nextSlide = slides.filter((slideEl) => slideEl.column === activeIndex + 1)[0];
-      prevSlide = slides.filter((slideEl) => slideEl.column === activeIndex - 1)[0];
+      activeSlide = slides.find((slideEl) => slideEl.column === activeIndex);
+      nextSlide = slides.find((slideEl) => slideEl.column === activeIndex + 1);
+      prevSlide = slides.find((slideEl) => slideEl.column === activeIndex - 1);
     } else {
       activeSlide = slides[activeIndex];
     }

--- a/src/modules/autoplay/autoplay.mjs
+++ b/src/modules/autoplay/autoplay.mjs
@@ -66,9 +66,9 @@ export default function Autoplay({ swiper, extendParams, on, emit, params }) {
   const getSlideDelay = () => {
     let activeSlideEl;
     if (swiper.virtual && swiper.params.virtual.enabled) {
-      activeSlideEl = swiper.slides.filter((slideEl) =>
+      activeSlideEl = swiper.slides.find((slideEl) =>
         slideEl.classList.contains('swiper-slide-active'),
-      )[0];
+      );
     } else {
       activeSlideEl = swiper.slides[swiper.activeIndex];
     }

--- a/src/modules/hash-navigation/hash-navigation.mjs
+++ b/src/modules/hash-navigation/hash-navigation.mjs
@@ -12,9 +12,9 @@ export default function HashNavigation({ swiper, extendParams, emit, on }) {
       watchState: false,
       getSlideIndex(_s, hash) {
         if (swiper.virtual && swiper.params.virtual.enabled) {
-          const slideWithHash = swiper.slides.filter(
+          const slideWithHash = swiper.slides.find(
             (slideEl) => slideEl.getAttribute('data-hash') === hash,
-          )[0];
+          );
           if (!slideWithHash) return 0;
           const index = parseInt(slideWithHash.getAttribute('data-swiper-slide-index'), 10);
           return index;

--- a/src/modules/pagination/pagination.mjs
+++ b/src/modules/pagination/pagination.mjs
@@ -365,10 +365,10 @@ export default function Pagination({ swiper, extendParams, on, emit }) {
       el = [...swiper.el.querySelectorAll(params.el)];
       // check if it belongs to another nested Swiper
       if (el.length > 1) {
-        el = el.filter((subEl) => {
+        el = el.find((subEl) => {
           if (elementParents(subEl, '.swiper')[0] !== swiper.el) return false;
           return true;
-        })[0];
+        });
       }
     }
     if (Array.isArray(el) && el.length === 1) el = el[0];

--- a/src/modules/thumbs/thumbs.mjs
+++ b/src/modules/thumbs/thumbs.mjs
@@ -125,9 +125,9 @@ export default function Thumb({ swiper, extendParams, on }) {
       let newThumbsIndex;
       let direction;
       if (thumbsSwiper.params.loop) {
-        const newThumbsSlide = thumbsSwiper.slides.filter(
+        const newThumbsSlide = thumbsSwiper.slides.find(
           (slideEl) => slideEl.getAttribute('data-swiper-slide-index') === `${swiper.realIndex}`,
-        )[0];
+        );
         newThumbsIndex = thumbsSwiper.slides.indexOf(newThumbsSlide);
 
         direction = swiper.activeIndex > swiper.previousIndex ? 'next' : 'prev';

--- a/src/shared/effect-virtual-transition-end.mjs
+++ b/src/shared/effect-virtual-transition-end.mjs
@@ -10,9 +10,9 @@ export default function effectVirtualTransitionEnd({
   const getSlide = (el) => {
     if (!el.parentElement) {
       // assume shadow root
-      const slide = swiper.slides.filter(
+      const slide = swiper.slides.find(
         (slideEl) => slideEl.shadowRoot && slideEl.shadowRoot === el.parentNode,
-      )[0];
+      );
       return slide;
     }
     return el.parentElement;


### PR DESCRIPTION
I love swiper! This project is super fast. I'm using this in a calendar project which has multiple swipers on one page. I'm facing some performance issues on slow mobile phones and I'm trying to figure out ways to help out and make this library even more performant.

I found this previous [similar PR](https://github.com/nolimits4web/swiper/pull/7235) which was not merged. I guess it had too many changes. I tried to keep this small and concise as possible so it's easy to see what changed.

I think swapping [filter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) out for [find](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) should bring some performance gains and is quite safe thing to do. 

I will keep looking for ways to increase performance of this awesome project.
