### PR TITLE
Allow using a CSS selector as breakpointsBase

### DIFF
--- a/src/core/breakpoints/setBreakpoint.mjs
+++ b/src/core/breakpoints/setBreakpoint.mjs
@@ -10,8 +10,10 @@ export default function setBreakpoint() {
   const breakpoints = params.breakpoints;
   if (!breakpoints || (breakpoints && Object.keys(breakpoints).length === 0)) return;
 
-  // Get breakpoint for window width and update parameters
-  const breakpoint = swiper.getBreakpoint(breakpoints, swiper.params.breakpointsBase, swiper.el);
+  // Get breakpoint for window/container width and update parameters
+  const breakpointsBase = params.breakpointsBase === 'window' || !params.breakpointsBase ? params.breakpointsBase : 'container';
+  const breakpointContainer = params.breakpointsBase === 'window' || !params.breakpointsBase ? el : el.closest(params.breakpointsBase);
+  const breakpoint = swiper.getBreakpoint(breakpoints, breakpointsBase, breakpointContainer);
 
   if (!breakpoint || swiper.currentBreakpoint === breakpoint) return;
 

--- a/src/core/breakpoints/setBreakpoint.mjs
+++ b/src/core/breakpoints/setBreakpoint.mjs
@@ -12,7 +12,7 @@ export default function setBreakpoint() {
 
   // Get breakpoint for window/container width and update parameters
   const breakpointsBase = params.breakpointsBase === 'window' || !params.breakpointsBase ? params.breakpointsBase : 'container';
-  const breakpointContainer = params.breakpointsBase === 'window' || !params.breakpointsBase ? el : el.closest(params.breakpointsBase);
+  const breakpointContainer = ['window', 'container'].includes(params.breakpointsBase) || !params.breakpointsBase ? params.el : document.querySelector(params.breakpointsBase);
   const breakpoint = swiper.getBreakpoint(breakpoints, breakpointsBase, breakpointContainer);
 
   if (!breakpoint || swiper.currentBreakpoint === breakpoint) return;

--- a/src/core/breakpoints/setBreakpoint.mjs
+++ b/src/core/breakpoints/setBreakpoint.mjs
@@ -1,3 +1,4 @@
+import { getDocument } from 'ssr-window';
 import { extend } from '../../shared/utils.mjs';
 
 const isGridEnabled = (swiper, params) => {
@@ -9,10 +10,18 @@ export default function setBreakpoint() {
   const { realIndex, initialized, params, el } = swiper;
   const breakpoints = params.breakpoints;
   if (!breakpoints || (breakpoints && Object.keys(breakpoints).length === 0)) return;
+  const document = getDocument();
 
   // Get breakpoint for window/container width and update parameters
-  const breakpointsBase = params.breakpointsBase === 'window' || !params.breakpointsBase ? params.breakpointsBase : 'container';
-  const breakpointContainer = ['window', 'container'].includes(params.breakpointsBase) || !params.breakpointsBase ? params.el : document.querySelector(params.breakpointsBase);
+  const breakpointsBase =
+    params.breakpointsBase === 'window' || !params.breakpointsBase
+      ? params.breakpointsBase
+      : 'container';
+  const breakpointContainer =
+    ['window', 'container'].includes(params.breakpointsBase) || !params.breakpointsBase
+      ? swiper.el
+      : document.querySelector(params.breakpointsBase);
+
   const breakpoint = swiper.getBreakpoint(breakpoints, breakpointsBase, breakpointContainer);
 
   if (!breakpoint || swiper.currentBreakpoint === breakpoint) return;

--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -741,7 +741,7 @@ export interface SwiperOptions {
    *
    * @default 'window'
    */
-  breakpointsBase?: 'window' | 'container';
+  breakpointsBase?: 'window' | 'container' | CSSSelector;
 
   // Observer
   /**


### PR DESCRIPTION
Fixes #7816 

Allows specifying a CSS selector for the breakpoints base so that not only the container can be referenced but also elements higher up the DOM tree.

I've tested the solution and it works well. Let me know if the solution looks good or whether any changes are needed.