### PR TITLE
Fix: Ensure the Zoom module's  array is cleared onTouchEnd

### DIFF
--- a/src/modules/zoom/zoom.mjs
+++ b/src/modules/zoom/zoom.mjs
@@ -28,7 +28,6 @@ export default function Zoom({ swiper, extendParams, on, emit }) {
   let isScaling = false;
   let fakeGestureTouched;
   let fakeGestureMoved;
-  let preventZoomOut;
   const evCache = [];
   const gesture = {
     originX: 0,
@@ -378,6 +377,7 @@ export default function Zoom({ swiper, extendParams, on, emit }) {
   }
   function onTouchEnd() {
     const zoom = swiper.zoom;
+    evCache.length = 0;
     if (!gesture.imageEl) return;
     if (!image.isTouched || !image.isMoved) {
       image.isTouched = false;


### PR DESCRIPTION
This fixes an issue in which long pressing a slide's image left the zoom module in a bad state.

Closes #7304