### PR TITLE
Add check for slot support

### DIFF
--- a/src/shared/utils.mjs
+++ b/src/shared/utils.mjs
@@ -204,7 +204,7 @@ function findElementsInElements(elements = [], selector = '') {
 }
 function elementChildren(element, selector = '') {
   const children = [...element.children];
-  if (element instanceof HTMLSlotElement) {
+  if (window.HTMLSlotElement && element instanceof HTMLSlotElement) {
     children.push(...element.assignedElements());
   }
 
@@ -230,7 +230,7 @@ function elementIsChildOfSlot(el, slot) {
 }
 function elementIsChildOf(el, parent) {
   let isChild = parent.contains(el);
-  if (!isChild && parent instanceof HTMLSlotElement) {
+  if (!isChild && window.HTMLSlotElement && parent instanceof HTMLSlotElement) {
     const children = [...parent.assignedElements()];
     isChild = children.includes(el);
     if (!isChild) {

--- a/src/shared/utils.mjs
+++ b/src/shared/utils.mjs
@@ -203,6 +203,7 @@ function findElementsInElements(elements = [], selector = '') {
   return found;
 }
 function elementChildren(element, selector = '') {
+  const window = getWindow();
   const children = [...element.children];
   if (window.HTMLSlotElement && element instanceof HTMLSlotElement) {
     children.push(...element.assignedElements());
@@ -229,6 +230,7 @@ function elementIsChildOfSlot(el, slot) {
   }
 }
 function elementIsChildOf(el, parent) {
+  const window = getWindow();
   let isChild = parent.contains(el);
   if (!isChild && window.HTMLSlotElement && parent instanceof HTMLSlotElement) {
     const children = [...parent.assignedElements()];


### PR DESCRIPTION
Adds checks for slot support before checking if an element is a `HTMLSlotElement`. This helps prevent crashes in legacy browsers that lack support.

Related to https://github.com/jellyfin/jellyfin-web/issues/5919