### PR TITLE
Fix: Typo in autoplay param check

### DIFF
--- a/src/modules/mousewheel/mousewheel.mjs
+++ b/src/modules/mousewheel/mousewheel.mjs
@@ -385,7 +385,7 @@ export default function Mousewheel({ swiper, extendParams, on, emit }) {
         if (!ignoreWheelEvents) emit('scroll', e);
 
         // Stop autoplay
-        if (swiper.params.autoplay && swiper.params.autoplayDisableOnInteraction)
+        if (swiper.params.autoplay && swiper.params.autoplay.disableOnInteraction)
           swiper.autoplay.stop();
         // Return page scroll on edge positions
         if (


### PR DESCRIPTION
There seems to be a typo in Mousewheel module, where it checks for an autoplay param
```js
 // Stop autoplay
        if (swiper.params.autoplay && swiper.params.autoplayDisableOnInteraction)
```
by which i believe
```js
swiper.params.autoplay.disableOnInteraction
```
is meant.