### PR TITLE
Export swiper-vars.scss for overwriteability

### DIFF
--- a/src/copy/package.json
+++ b/src/copy/package.json
@@ -95,6 +95,7 @@
     "./scss/parallax": "./modules/parallax.scss",
     "./scss/scrollbar": "./modules/scrollbar.scss",
     "./scss/thumbs": "./modules/thumbs.scss",
+    "./scss/vars": "./swiper-vars.scss",
     "./scss/virtual": "./modules/virtual.scss",
     "./scss/zoom": "./modules/zoom.scss",
     "./element": {


### PR DESCRIPTION
Fixes #7882

The [`src/swiper-vars.scss`](https://github.com/nolimits4web/swiper/blob/master/src/swiper-vars.scss) file is now exported in package.json so that developers using Swiper can override the variables it contains.