### PR TITLE
fix: remove infinite preloader in loop

### DIFF
--- a/src/core/loop/loopFix.mjs
+++ b/src/core/loop/loopFix.mjs
@@ -122,7 +122,6 @@ export default function loopFix({
   if (isPrev) {
     prependSlidesIndexes.forEach((index) => {
       slides[index].swiperLoopMoveDOM = true;
-
       slidesEl.prepend(slides[index]);
       slides[index].swiperLoopMoveDOM = false;
     });

--- a/src/swiper-element.mjs
+++ b/src/swiper-element.mjs
@@ -299,6 +299,10 @@ class SwiperSlide extends ClassToExtend {
   }
 
   connectedCallback() {
+    if (this.swiperLoopMoveDOM) {
+      return;
+    }
+
     this.initialize();
   }
 }


### PR DESCRIPTION
If approved, this PR:

- Add a condition to check if the swiper-slide flag `swiperLoopMoveDOM`, avoiding calling the render method again, which was generating the infinite pre-loader injection.


Fixes: #7233 