### PR TITLE
Restore compatibility with ES2019 #7891

### DIFF
--- a/src/shared/utils.mjs
+++ b/src/shared/utils.mjs
@@ -223,9 +223,9 @@ function elementIsChildOfSlot(el, slot) {
       return true;
     }
     elementsQueue.push(
-      ...elementToCheck.children,
-      ...(elementToCheck.shadowRoot?.children || []),
-      ...(elementToCheck.assignedElements?.() || []),
+      ...Array.from(elementToCheck.children),
+      ...(elementToCheck.shadowRoot ? Array.from(elementToCheck.shadowRoot.children) : []),
+      ...(elementToCheck.assignedElements ? Array.from(elementToCheck.assignedElements()) : []),
     );
   }
 }

--- a/src/shared/utils.mjs
+++ b/src/shared/utils.mjs
@@ -223,9 +223,9 @@ function elementIsChildOfSlot(el, slot) {
       return true;
     }
     elementsQueue.push(
-      ...Array.from(elementToCheck.children),
-      ...(elementToCheck.shadowRoot ? Array.from(elementToCheck.shadowRoot.children) : []),
-      ...(elementToCheck.assignedElements ? Array.from(elementToCheck.assignedElements()) : []),
+      ...elementToCheck.children,
+      ...(elementToCheck.shadowRoot ? elementToCheck.shadowRoot.children : []),
+      ...(elementToCheck.assignedElements ? elementToCheck.assignedElements() : []),
     );
   }
 }


### PR DESCRIPTION
This PR will enable projects that are compiled with a version of JavaScript prior to ES2020 to use Swiper V11.2.0 or above.