### PR TITLE
fix: fix transform origin of `zoom.in()` function

### DIFF
--- a/src/modules/zoom/zoom.mjs
+++ b/src/modules/zoom/zoom.mjs
@@ -494,6 +494,8 @@ export default function Zoom({ swiper, extendParams, on, emit }) {
     mousePanStart.y = e.clientY;
     image.startX = newX;
     image.startY = newY;
+    image.currentX = newX;
+    image.currentY = newY;
   }
 
   function zoomIn(e) {
@@ -560,6 +562,8 @@ export default function Zoom({ swiper, extendParams, on, emit }) {
       touchY = image.touchesStart.y;
     }
 
+    const prevScale = currentScale;
+
     const forceZoomRatio = typeof e === 'number' ? e : null;
     if (currentScale === 1 && forceZoomRatio) {
       touchX = undefined;
@@ -590,8 +594,18 @@ export default function Zoom({ swiper, extendParams, on, emit }) {
       translateMaxX = -translateMinX;
       translateMaxY = -translateMinY;
 
-      translateX = diffX * zoom.scale;
-      translateY = diffY * zoom.scale;
+      if (
+        prevScale > 0 &&
+        forceZoomRatio &&
+        typeof image.currentX === 'number' &&
+        typeof image.currentY === 'number'
+      ) {
+        translateX = (image.currentX * zoom.scale) / prevScale;
+        translateY = (image.currentY * zoom.scale) / prevScale;
+      } else {
+        translateX = diffX * zoom.scale;
+        translateY = diffY * zoom.scale;
+      }
 
       if (translateX < translateMinX) {
         translateX = translateMinX;
@@ -614,6 +628,9 @@ export default function Zoom({ swiper, extendParams, on, emit }) {
       gesture.originX = 0;
       gesture.originY = 0;
     }
+
+    image.currentX = translateX;
+    image.currentY = translateY;
     gesture.imageWrapEl.style.transitionDuration = '300ms';
     gesture.imageWrapEl.style.transform = `translate3d(${translateX}px, ${translateY}px,0)`;
     gesture.imageEl.style.transitionDuration = '300ms';
@@ -647,6 +664,8 @@ export default function Zoom({ swiper, extendParams, on, emit }) {
     }
     zoom.scale = 1;
     currentScale = 1;
+    image.currentX = undefined;
+    image.currentY = undefined;
     image.touchesStart.x = undefined;
     image.touchesStart.y = undefined;
     gesture.imageWrapEl.style.transitionDuration = '300ms';


### PR DESCRIPTION
This PR fixes #7903

- zoom.in function sets an unexpected transform3d value to the .swiper-zoom-container element, if the previous scale value is greater than 1 and the position of the image is not centered.
- The origin of the image should be preserved after zoom.in function is called, as if `transform-origin` was `center`;

## Reproduction
CodeSandbox: https://codesandbox.io/p/sandbox/swiper-zoom-forked-w4jlgg

https://github.com/user-attachments/assets/0a1bef43-dfa1-42d3-bd7c-813a087e65ed

## This PR
This PR fixes the issue.

https://github.com/user-attachments/assets/c0ef4df3-ddfe-4cee-8add-b35a75bdb172