### PR TITLE
feat: check if slidesEl is defined in loopDestroy

### DIFF
--- a/src/core/loop/loopDestroy.mjs
+++ b/src/core/loop/loopDestroy.mjs
@@ -1,7 +1,7 @@
 export default function loopDestroy() {
   const swiper = this;
   const { params, slidesEl } = swiper;
-  if (!params.loop || (swiper.virtual && swiper.params.virtual.enabled)) return;
+  if ((!params.loop || !slidesEl) || (swiper.virtual && swiper.params.virtual.enabled)) return;
   swiper.recalcSlides();
 
   const newSlidesOrder = [];

--- a/src/core/loop/loopDestroy.mjs
+++ b/src/core/loop/loopDestroy.mjs
@@ -1,7 +1,7 @@
 export default function loopDestroy() {
   const swiper = this;
   const { params, slidesEl } = swiper;
-  if ((!params.loop || !slidesEl) || (swiper.virtual && swiper.params.virtual.enabled)) return;
+  if (!params.loop || !slidesEl || (swiper.virtual && swiper.params.virtual.enabled)) return;
   swiper.recalcSlides();
 
   const newSlidesOrder = [];


### PR DESCRIPTION
If approved, this PR:

- Checks if `slidesEl` is defined on `loopDestroy`, avoiding cases where components can be unmounted too soon to complete render.

This is a specific case, more information is provided in the related issue.

Fixes: #7881 