### PR TITLE
refactor(element): use swiper state for init/destroy tracking

### DIFF
--- a/src/swiper-element.mjs
+++ b/src/swiper-element.mjs
@@ -147,7 +147,7 @@ class SwiperContainer extends ClassToExtend {
   }
 
   initialize() {
-    if (this.swiper?.initialized) return;
+    if (this.swiper && this.swiper.initialized) return;
     const { params: swiperParams, passedParams } = getParams(this);
     this.swiperParams = swiperParams;
     this.passedParams = passedParams;
@@ -179,7 +179,8 @@ class SwiperContainer extends ClassToExtend {
 
   connectedCallback() {
     if (
-      this.swiper?.initialized &&
+      this.swiper &&
+      this.swiper.initialized &&
       this.nested &&
       this.closest('swiper-slide') &&
       this.closest('swiper-slide').swiperLoopMoveDOM

--- a/src/swiper-element.mjs
+++ b/src/swiper-element.mjs
@@ -237,7 +237,7 @@ class SwiperContainer extends ClassToExtend {
   }
 
   attributeChangedCallback(attr, prevValue, newValue) {
-    if (!this.initialized) return;
+    if (!(this.swiper && this.swiper.initialized)) return;
     if (prevValue === 'true' && newValue === null) {
       newValue = false;
     }
@@ -268,7 +268,7 @@ paramsList.forEach((paramName) => {
     set(value) {
       if (!this.passedParams) this.passedParams = {};
       this.passedParams[paramName] = value;
-      if (!this.initialized) return;
+      if (!(this.swiper && this.swiper.initialized)) return;
       this.updateSwiperOnPropChange(paramName, value);
     },
   });

--- a/src/swiper-element.mjs
+++ b/src/swiper-element.mjs
@@ -147,8 +147,7 @@ class SwiperContainer extends ClassToExtend {
   }
 
   initialize() {
-    if (this.initialized) return;
-    this.initialized = true;
+    if (this.swiper?.initialized) return;
     const { params: swiperParams, passedParams } = getParams(this);
     this.swiperParams = swiperParams;
     this.passedParams = passedParams;
@@ -180,7 +179,7 @@ class SwiperContainer extends ClassToExtend {
 
   connectedCallback() {
     if (
-      this.initialized &&
+      this.swiper?.initialized &&
       this.nested &&
       this.closest('swiper-slide') &&
       this.closest('swiper-slide').swiperLoopMoveDOM
@@ -204,7 +203,6 @@ class SwiperContainer extends ClassToExtend {
     if (this.swiper && this.swiper.destroy) {
       this.swiper.destroy();
     }
-    this.initialized = false;
   }
 
   updateSwiperOnPropChange(propName, propValue) {


### PR DESCRIPTION
If approved, this PR:

- Uses swiper state to define the initialization/destroy behavior. Using the state defined in the web component was not reflected, because the `initialize` and `destroy` methods only update the `swiper` instance state.

In the case of `disconnectedCallback`. Only will it be triggered if the component is removed from the DOM.

Fixes: #7666 