### PR TITLE
fix(types): coverflow effect can be number or string with percentage

### DIFF
--- a/src/types/modules/effect-coverflow.d.ts
+++ b/src/types/modules/effect-coverflow.d.ts
@@ -16,11 +16,14 @@ export interface CoverflowEffectOptions {
    */
   rotate?: number;
   /**
-   * Stretch space between slides (in px)
+   * Stretch space between slides
+   *
+   * - a number is interpreted as pixels (e.g., `20` for 20px).
+   * - a string with a percentage (e.g., `"50%"`).
    *
    * @default 0
    */
-  stretch?: number;
+  stretch?: number | `${number}%`;
   /**
    * Depth offset in px (slides translate in Z axis)
    *


### PR DESCRIPTION
Updated the JSDoc for the `stretch` prop to clarify that it accepts both  
a number (interpreted as pixels) and a percentage string (e.g., `"50%"`).  

This improves readability, helps developers understand the expected values,  
and ensures correct TypeScript type inference, preventing errors when using percentage values.  

Relevant code handling percentage values in `stretch`:

```
let stretch = params.stretch;
// Allow percentage to make a relative stretch for responsive sliders
if (typeof stretch === 'string' && stretch.indexOf('%') !== -1) {
  stretch = (parseFloat(params.stretch) / 100) * slideSize;
}
let translateY = isHorizontal ? 0 : stretch * offsetMultiplier;
let translateX = isHorizontal ? stretch * offsetMultiplier : 0;
```


