### PR TITLE
fix(types): fix `effect` param type

### DIFF
--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -210,7 +210,7 @@ export interface SwiperOptions {
    *
    * @default 'slide'
    */
-  effect?: 'slide' | 'fade' | 'cube' | 'coverflow' | 'flip' | 'creative' | 'cards' | string;
+  effect?: 'slide' | 'fade' | 'cube' | 'coverflow' | 'flip' | 'creative' | 'cards' | (string & {});
 
   /**
    * Fire Transition/SlideChange/Start/End events on swiper initialization.


### PR DESCRIPTION
Fixes #7944

## Type IntelliSense doesn't work properly on the `effect` param

### Expected Behavior
Code completion works properly on the `effect` parameter while allowing an arbitrary `string` value to be passed.
<img width="624" alt="Screenshot 2025-04-02 at 22 43 04" src="https://github.com/user-attachments/assets/582cf9aa-daf0-4d3f-8710-124d23ab96b4" />

### Actual Behavior
Code completion doesn't work as expected because the resulting type of the effect param is `string | undefined`.
<img width="856" alt="Screenshot 2025-04-02 at 22 47 20" src="https://github.com/user-attachments/assets/89ed5f1a-ab19-4464-bd8b-8bd92b3b8b47" />
