### PR TITLE
fix(vue): added missing props

### DIFF
--- a/src/vue/swiper.mjs
+++ b/src/vue/swiper.mjs
@@ -92,6 +92,8 @@ const Swiper = {
     loop: { type: Boolean, default: undefined },
     loopedSlides: { type: Number, default: undefined },
     loopPreventsSliding: { type: Boolean, default: undefined },
+    loopAdditionalSlides: { type: Number, default: undefined },
+    loopAddBlankSlides: { type: Boolean, default: undefined },
     rewind: { type: Boolean, default: undefined },
     allowSlidePrev: { type: Boolean, default: undefined },
     allowSlideNext: { type: Boolean, default: undefined },


### PR DESCRIPTION
Added missing `loopAdditionalSlides` and `loopAddBlankSlides` props to Vue `Swiper` component.
They are listed in `swiper-vue.d.ts`  typings, but not in props: https://github.com/nolimits4web/swiper/blob/10084e3c605dad488ff2d517f872d3b23763a581/src/swiper-vue.d.ts#L259-L263