### PR TITLE
Type definitions for `enabled` on Swiper

### DIFF
--- a/src/types/swiper-class.d.ts
+++ b/src/types/swiper-class.d.ts
@@ -204,6 +204,11 @@ interface Swiper extends SwiperClass<SwiperEvents> {
   rtlTranslate: boolean;
 
   /**
+   * `true` if Swiper is enabled, `false` otherwise
+   */
+  enabled: boolean;
+
+  /**
    * Disable Swiper (if it was enabled). When Swiper is disabled, it will hide all navigation elements and won't respond to any events and interactions
    *
    */


### PR DESCRIPTION
The types for `enabled` have been defined, allowing for proper access to these properties in a TypeScript environment.

Issue: https://github.com/nolimits4web/swiper/issues/7971