### PR TITLE
Add template for CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,15 @@ Swiper is not compatible with all platforms, it is a modern touch slider which i
 - **Accessibility (A11y)**
 - **And many more ...**
 
+### CMS integration
+
+Slideshows are a common feature in e-commerce and marketing sites, whether it's a homepage hero, product highlights, or testimonials.
+In most cases, these are powered by a content management system (CMS), so marketers or content editors can easily update them without deploying code.
+
+Check the template below for CMS integration with a free-forever tier:
+
+[![Use Template](https://croct.com/button?variant=cms)](https://croct.com/templates/interface/section/react-swiper-carousel)
+
 ## Community
 
 The Swiper community can be found on [GitHub Discussions](https://github.com/nolimits4web/swiper/discussions), where you can ask questions, voice ideas, and share your projects


### PR DESCRIPTION
I've helped so many teams integrate React Swiper with a CMS that I decided to turn it into a [template](https://croct.com/templates/interface/section/react-swiper-carousel).

This one shows an example using a slideshow for e-commerce, where content can be updated without touching code:
![image](https://github.com/user-attachments/assets/90c80c5f-6a94-4c39-b04a-71de9f819961)

You get a fully working setup with just one command:

```bash
npx croct@latest use npm://swiper
```

It uses Croct, which has a forever-free plan and works great for managing this kind of dynamic content.

Hopefully it saves someone the time I've spent wiring this up in the past.