### PR TITLE
Bug fix for slideResetTransition events

### DIFF
--- a/src/core/transition/transitionEmit.mjs
+++ b/src/core/transition/transitionEmit.mjs
@@ -9,11 +9,9 @@ export default function transitionEmit({ swiper, runCallbacks, direction, step }
 
   swiper.emit(`transition${step}`);
 
-  if (runCallbacks && activeIndex !== previousIndex) {
-    if (dir === 'reset') {
-      swiper.emit(`slideResetTransition${step}`);
-      return;
-    }
+  if (runCallbacks && dir === 'reset') {
+    swiper.emit(`slideResetTransition${step}`);
+  } else if (runCallbacks && activeIndex !== previousIndex) {
     swiper.emit(`slideChangeTransition${step}`);
     if (dir === 'next') {
       swiper.emit(`slideNextTransition${step}`);


### PR DESCRIPTION
slideResetTransitionStart and slideResetTransitionEnd events never trigger b/c the reset event emit is inside a conditional that would never trigger. This moves the reset events to a location that will actually emit.

