### PR TITLE
fix(element): attach container shadow DOM on init

### DIFF
--- a/src/swiper-element.mjs
+++ b/src/swiper-element.mjs
@@ -40,8 +40,6 @@ const addStyle = (shadowRoot, styles) => {
 class SwiperContainer extends ClassToExtend {
   constructor() {
     super();
-
-    this.attachShadow({ mode: 'open' });
   }
 
   static get nextButtonSvg() {
@@ -149,6 +147,9 @@ class SwiperContainer extends ClassToExtend {
 
   initialize() {
     if (this.swiper && this.swiper.initialized) return;
+
+    this.attachShadow({ mode: 'open' });
+
     const { params: swiperParams, passedParams } = getParams(this);
     this.swiperParams = swiperParams;
     this.passedParams = passedParams;


### PR DESCRIPTION
This PR addresses the issue I described in https://github.com/nolimits4web/swiper/issues/7983.

It moves the shadow DOM attachment for the `SwiperContainer` element from the `constructor` to the `initialize` function. This makes sure that the elements stay visible all the time as the `render` function is triggered synchronously right after.

The change is not needed for the `SwiperSlide` as it moves its contents immediately anyway.