### PR TITLE
fix: detect contenteditable element in keyboard module

### DIFF
--- a/src/modules/keyboard/keyboard.mjs
+++ b/src/modules/keyboard/keyboard.mjs
@@ -50,9 +50,10 @@ export default function Keyboard({ swiper, extendParams, on, emit }) {
     }
     if (
       document.activeElement &&
-      document.activeElement.nodeName &&
-      (document.activeElement.nodeName.toLowerCase() === 'input' ||
-        document.activeElement.nodeName.toLowerCase() === 'textarea')
+      (document.activeElement.isContentEditable ||
+        (document.activeElement.nodeName &&
+          (document.activeElement.nodeName.toLowerCase() === 'input' ||
+            document.activeElement.nodeName.toLowerCase() === 'textarea')))
     ) {
       return undefined;
     }


### PR DESCRIPTION
Fixes an issue where Swiper responds to arrow key presses even when a `contenteditable` element is focused. This prevents users from moving the caret inside editable text.

This PR adds a check to ignore keyboard navigation when a `contenteditable` element is active.

Closes #7665 
