### PR TITLE
fix(a11y): notifications not working on click events

### DIFF
--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -110,7 +110,6 @@ export default function A11y({ swiper, extendParams, on }) {
 
   function onEnterOrSpaceKey(e) {
     if (e.keyCode !== 13 && e.keyCode !== 32) return;
-    const params = swiper.params.a11y;
     const targetEl = e.target;
     if (
       swiper.pagination &&
@@ -126,20 +125,10 @@ export default function A11y({ swiper, extendParams, on }) {
         if (!(swiper.isEnd && !swiper.params.loop)) {
           swiper.slideNext();
         }
-        if (swiper.isEnd) {
-          notify(params.lastSlideMessage);
-        } else {
-          notify(params.nextSlideMessage);
-        }
       }
       if (prevEls.includes(targetEl)) {
         if (!(swiper.isBeginning && !swiper.params.loop)) {
           swiper.slidePrev();
-        }
-        if (swiper.isBeginning) {
-          notify(params.firstSlideMessage);
-        } else {
-          notify(params.prevSlideMessage);
         }
       }
     }
@@ -405,5 +394,23 @@ export default function A11y({ swiper, extendParams, on }) {
   on('destroy', () => {
     if (!swiper.params.a11y.enabled) return;
     destroy();
+  });
+  on('navigationNext', () => {
+    if (!swiper.params.a11y.enabled) return;
+    const params = swiper.params.a11y;
+    if (swiper.isEnd) {
+      notify(params.lastSlideMessage);
+    } else {
+      notify(params.nextSlideMessage);
+    }
+  });
+  on('navigationPrev', () => {
+    if (!swiper.params.a11y.enabled) return;
+    const params = swiper.params.a11y;
+    if (swiper.isBeginning) {
+      notify(params.firstSlideMessage);
+    } else {
+      notify(params.prevSlideMessage);
+    }
   });
 }


### PR DESCRIPTION
Closes #8016 

This change enhances screen reader support for touch devices. Currently, notifications work only on desktop by firing a notification for space or enter keystrokes. This should change the behavior to notify on the event rather than a specific input type.
