### PR TITLE
feat(core): add `alignSlides` option to keep minimum full slides visi…

### DIFF
--- a/src/core/defaults.mjs
+++ b/src/core/defaults.mjs
@@ -58,6 +58,7 @@ export default {
   slidesOffsetAfter: 0, // in px
   normalizeSlideIndex: true,
   centerInsufficientSlides: false,
+  alignSlides: false,
 
   // Disable swiper and hide navigation when container not overflow
   watchOverflow: true,

--- a/src/core/update/updateSlides.mjs
+++ b/src/core/update/updateSlides.mjs
@@ -195,21 +195,27 @@ export default function updateSlides() {
 
   // Remove last grid elements depending on width
   if (!params.centeredSlides) {
+    const minVisible = Math.floor(params.slidesPerView);
+    const lastAllowedSnapIndex = Math.max(slidesLength - minVisible, 0);
+
     const newSlidesGrid = [];
     for (let i = 0; i < snapGrid.length; i += 1) {
       let slidesGridItem = snapGrid[i];
       if (params.roundLengths) slidesGridItem = Math.floor(slidesGridItem);
-      if (snapGrid[i] <= swiper.virtualSize - swiperSize) {
+
+      /* keep this snap iff its *slide index* ≤ lastAllowedSnapIndex */
+      if (i <= lastAllowedSnapIndex && params.alignSlides) {
+        newSlidesGrid.push(slidesGridItem);
+      }
+      else if (snapGrid[i] <= swiper.virtualSize - swiperSize) {
         newSlidesGrid.push(slidesGridItem);
       }
     }
     snapGrid = newSlidesGrid;
 
-    if (
-      Math.floor(swiper.virtualSize - swiperSize) - Math.floor(snapGrid[snapGrid.length - 1]) >
-      1
-    ) {
-      snapGrid.push(swiper.virtualSize - swiperSize);
+    if ((Math.floor(swiper.virtualSize - swiperSize) - Math.floor(snapGrid[snapGrid.length - 1]) > 1) 
+      && !params.alignSlides) {
+        snapGrid.push(swiper.virtualSize - swiperSize);
     }
   }
   if (isVirtual && params.loop) {


### PR DESCRIPTION
Fixes: https://github.com/nolimits4web/swiper/discussions/4780

Currently it's possible for the swiper to fall out of alignment if a fractional value is set for `slidesPerView` and the user reaches the end of the swiper (as show below). The PR Introduces a new boolean param `alignSlides` (default `false`) in core defaults and when set to `true` ensures all sides are always aligned in their original place.

<img width="434" alt="Screenshot 2025-06-16 at 01 02 18" src="https://github.com/user-attachments/assets/007ede92-eeea-4f98-a40f-12fcb8e55fcc" />

- Introduce new boolean param `alignSlides` (default `false`) in core defaults
- Trim `snapGrid` so that only snaps leaving ≥ floor(slidesPerView) slides fully visible remain
- Preserve original “right-flush” fallback only when `alignSlides` is disabled

