### PR TITLE
fix(core): clear blank slides within loopCreate()

### DIFF
--- a/src/core/loop/loopCreate.mjs
+++ b/src/core/loop/loopCreate.mjs
@@ -13,6 +13,18 @@ export default function loopCreate(slideRealIndex, initial) {
     });
   };
 
+  const clearBlankSlides = () => {
+    const slides = elementChildren(slidesEl, `.${params.slideBlankClass}`);
+
+    slides.forEach((el) => {
+      el.remove();
+    });
+  };
+
+  clearBlankSlides();
+  swiper.recalcSlides();
+  swiper.updateSlides();
+
   const gridEnabled = swiper.grid && params.grid && params.grid.rows > 1;
 
   const slidesPerGroup = params.slidesPerGroup * (gridEnabled ? params.grid.rows : 1);

--- a/src/core/loop/loopCreate.mjs
+++ b/src/core/loop/loopCreate.mjs
@@ -19,11 +19,15 @@ export default function loopCreate(slideRealIndex, initial) {
     slides.forEach((el) => {
       el.remove();
     });
+    if (slides.length > 0) {
+      swiper.recalcSlides();
+      swiper.updateSlides();
+    }
   };
 
-  clearBlankSlides();
-  swiper.recalcSlides();
-  swiper.updateSlides();
+  if (params.loopAddBlankSlides && (params.slidesPerGroup > 1 || gridEnabled)) {
+    clearBlankSlides();
+  }
 
   const gridEnabled = swiper.grid && params.grid && params.grid.rows > 1;
 


### PR DESCRIPTION
This PR fixes #8027 .

The issue is that when the `loop` parameter is `true` and the `slidesPerGroup` parameters are set for multiple breakpoints, unnecessary blank slides are created by resizing the `breakpointsBase`.