### PR TITLE
Fixes #7298 #7956 #6916 bugs when slidesOffsetBefore & slidesOffsetAfter are combinated with centeredSlides, slidesPerView & loop

### DIFF
--- a/src/core/loop/loopCreate.mjs
+++ b/src/core/loop/loopCreate.mjs
@@ -73,9 +73,10 @@ export default function loopCreate(slideRealIndex, initial) {
     initSlides();
   }
 
+  const bothDirections = (params.centeredSlides || !!params.slidesOffsetBefore || !!params.slidesOffsetAfter);
   swiper.loopFix({
     slideRealIndex,
-    direction: params.centeredSlides ? undefined : 'next',
+    direction: bothDirections ? undefined : 'next',
     initial,
   });
 }

--- a/src/core/loop/loopFix.mjs
+++ b/src/core/loop/loopFix.mjs
@@ -15,15 +15,17 @@ export default function loopFix({
   if (!swiper.params.loop) return;
   swiper.emit('beforeLoopFix');
   const { slides, allowSlidePrev, allowSlideNext, slidesEl, params } = swiper;
-  const { centeredSlides, initialSlide } = params;
+  const { centeredSlides, slidesOffsetBefore, slidesOffsetAfter, initialSlide } = params;
+  const bothDirections = centeredSlides || !!slidesOffsetBefore || !!slidesOffsetAfter;
+  
   swiper.allowSlidePrev = true;
   swiper.allowSlideNext = true;
 
   if (swiper.virtual && params.virtual.enabled) {
     if (slideTo) {
-      if (!params.centeredSlides && swiper.snapIndex === 0) {
+      if (!bothDirections && swiper.snapIndex === 0) {
         swiper.slideTo(swiper.virtual.slides.length, 0, false, true);
-      } else if (params.centeredSlides && swiper.snapIndex < params.slidesPerView) {
+      } else if (bothDirections && swiper.snapIndex < params.slidesPerView) {
         swiper.slideTo(swiper.virtual.slides.length + swiper.snapIndex, 0, false, true);
       } else if (swiper.snapIndex === swiper.snapGrid.length - 1) {
         swiper.slideTo(swiper.virtual.slidesBefore, 0, false, true);
@@ -39,13 +41,13 @@ export default function loopFix({
     slidesPerView = swiper.slidesPerViewDynamic();
   } else {
     slidesPerView = Math.ceil(parseFloat(params.slidesPerView, 10));
-    if (centeredSlides && slidesPerView % 2 === 0) {
+    if (bothDirections && slidesPerView % 2 === 0) {
       slidesPerView = slidesPerView + 1;
     }
   }
 
   const slidesPerGroup = params.slidesPerGroupAuto ? slidesPerView : params.slidesPerGroup;
-  let loopedSlides = centeredSlides
+  let loopedSlides = bothDirections
     ? Math.max(slidesPerGroup, Math.ceil(slidesPerView / 2))
     : slidesPerGroup;
 
@@ -72,7 +74,7 @@ export default function loopFix({
 
   const cols = gridEnabled ? Math.ceil(slides.length / params.grid.rows) : slides.length;
 
-  const isInitialOverflow = initial && cols - initialSlide < slidesPerView && !centeredSlides;
+  const isInitialOverflow = initial && cols - initialSlide < slidesPerView && !bothDirections;
 
   let activeIndex = isInitialOverflow ? initialSlide : swiper.activeIndex;
 
@@ -93,7 +95,7 @@ export default function loopFix({
   const activeColIndex = gridEnabled ? slides[activeSlideIndex].column : activeSlideIndex;
   const activeColIndexWithShift =
     activeColIndex +
-    (centeredSlides && typeof setTranslate === 'undefined' ? -slidesPerView / 2 + 0.5 : 0);
+    (bothDirections && typeof setTranslate === 'undefined' ? -slidesPerView / 2 + 0.5 : 0);
   // prepend last slides before start
   if (activeColIndexWithShift < loopedSlides) {
     slidesPrepended = Math.max(loopedSlides - activeColIndexWithShift, slidesPerGroup);

--- a/src/core/slide/slideToLoop.mjs
+++ b/src/core/slide/slideToLoop.mjs
@@ -32,27 +32,27 @@ export default function slideToLoop(index = 0, speed, runCallbacks = true, inter
         ? Math.ceil(swiper.slides.length / swiper.params.grid.rows)
         : swiper.slides.length;
 
-      const { centeredSlides } = swiper.params;
+      const { centeredSlides, slidesOffsetBefore, slidesOffsetAfter } = swiper.params;
+      const bothDirections = centeredSlides || !!slidesOffsetBefore || !!slidesOffsetAfter;
       let slidesPerView = swiper.params.slidesPerView;
       if (slidesPerView === 'auto') {
         slidesPerView = swiper.slidesPerViewDynamic();
       } else {
         slidesPerView = Math.ceil(parseFloat(swiper.params.slidesPerView, 10));
-        if (centeredSlides && slidesPerView % 2 === 0) {
+        if (bothDirections && slidesPerView % 2 === 0) {
           slidesPerView = slidesPerView + 1;
         }
       }
       let needLoopFix = cols - targetSlideIndex < slidesPerView;
-
-      if (centeredSlides) {
+      if (bothDirections) {
         needLoopFix = needLoopFix || targetSlideIndex < Math.ceil(slidesPerView / 2);
       }
-      if (internal && centeredSlides && swiper.params.slidesPerView !== 'auto' && !gridEnabled) {
+      if (internal && bothDirections && swiper.params.slidesPerView !== 'auto' && !gridEnabled) {
         needLoopFix = false;
       }
 
       if (needLoopFix) {
-        const direction = centeredSlides
+        const direction = bothDirections
           ? targetSlideIndex < swiper.activeIndex
             ? 'prev'
             : 'next'

--- a/src/core/update/updateSlides.mjs
+++ b/src/core/update/updateSlides.mjs
@@ -14,7 +14,7 @@ export default function updateSlides() {
 
   const params = swiper.params;
 
-  const { wrapperEl, slidesEl, size: swiperSize, rtlTranslate: rtl, wrongRTL } = swiper;
+  const { wrapperEl, slidesEl, rtlTranslate: rtl, wrongRTL } = swiper;
   const isVirtual = swiper.virtual && params.virtual.enabled;
   const previousSlidesLength = isVirtual ? swiper.virtual.slides.length : swiper.slides.length;
   const slides = elementChildren(slidesEl, `.${swiper.params.slideClass}, swiper-slide`);
@@ -36,6 +36,7 @@ export default function updateSlides() {
   const previousSnapGridLength = swiper.snapGrid.length;
   const previousSlidesGridLength = swiper.slidesGrid.length;
 
+  const swiperSize = swiper.size - offsetBefore - offsetAfter;
   let spaceBetween = params.spaceBetween;
   let slidePosition = -offsetBefore;
   let prevSlideSize = 0;
@@ -49,7 +50,7 @@ export default function updateSlides() {
     spaceBetween = parseFloat(spaceBetween);
   }
 
-  swiper.virtualSize = -spaceBetween;
+  swiper.virtualSize = -spaceBetween - offsetBefore - offsetAfter;
 
   // reset margins
   slides.forEach((slideEl) => {
@@ -269,7 +270,7 @@ export default function updateSlides() {
       allSlidesSize += slideSizeValue + (spaceBetween || 0);
     });
     allSlidesSize -= spaceBetween;
-    const offsetSize = (params.slidesOffsetBefore || 0) + (params.slidesOffsetAfter || 0);
+    const offsetSize = (offsetBefore || 0) + (offsetAfter || 0);
     if (allSlidesSize + offsetSize < swiperSize) {
       const allSlidesOffset = (swiperSize - allSlidesSize - offsetSize) / 2;
       snapGrid.forEach((snap, snapIndex) => {


### PR DESCRIPTION
This PR fixes several bugs when slidesOffsetBefore & slidesOffsetAfter are combined with other settings. 
Like in #7298 , #7956 and #6916

> Note that the offset's are required to display a fadeout-overlay without obscuring the first/last slides. A margin/padding on the scrollable element would not work in this case, because it would hide the slides behind the fadeout-overlay.

For all the below examples the base config contains:
```
slidesPerView: 2,
slidesOffsetBefore: 100,
slidesOffsetAfter: 200,
```

**1. Less than 2 slides were visible within the fading offsets**
Before PR:

https://github.com/user-attachments/assets/779e2552-63ca-4128-84f1-9dea1f86ec30

After PR:

https://github.com/user-attachments/assets/a1140163-3fb1-4f21-8af0-e251429fb86f

2. With `loop: true` the previous slides in the loop was missing
Before PR:

https://github.com/user-attachments/assets/a145a565-702b-48cb-b9a6-4cf4d798e65e

After PR:

https://github.com/user-attachments/assets/6d2fd790-f4fd-4848-bcf1-85b023ddcf65

3. With `centeredSlides: true` the current slide is not centered within the offsets:

Before PR:

https://github.com/user-attachments/assets/224848d2-291c-43f0-9110-4edeae407f68

After PR:

https://github.com/user-attachments/assets/d406898c-94bc-486a-8ef4-21bf6bf5a097

4. With `centeredSlides: true, loop: true` (all configuration options and bugs combined):

Before PR:

https://github.com/user-attachments/assets/7635eb6e-462b-4a08-8c1e-3d649e804b83

After PR:

https://github.com/user-attachments/assets/ff950e0f-e47e-4e65-8234-c5bfc7a41832