### PR TITLE
feat: add param to disable wrapper live region in a11y module

### DIFF
--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -25,6 +25,7 @@ export default function A11y({ swiper, extendParams, on }) {
       slideRole: 'group',
       id: null,
       scrollOnFocus: true,
+      wrapperLiveRegion: true,
     },
   });
 
@@ -318,9 +319,11 @@ export default function A11y({ swiper, extendParams, on }) {
     const wrapperEl = swiper.wrapperEl;
     const wrapperId =
       params.id || wrapperEl.getAttribute('id') || `swiper-wrapper-${getRandomNumber(16)}`;
-    const live = swiper.params.autoplay && swiper.params.autoplay.enabled ? 'off' : 'polite';
     addElId(wrapperEl, wrapperId);
-    addElLive(wrapperEl, live);
+    if (params.wrapperLiveRegion) {
+      const live = swiper.params.autoplay && swiper.params.autoplay.enabled ? 'off' : 'polite';
+      addElLive(wrapperEl, live);
+    }
 
     // Slide
     initSlides();

--- a/src/types/modules/a11y.d.ts
+++ b/src/types/modules/a11y.d.ts
@@ -107,4 +107,11 @@ export interface A11yOptions {
    * @default true
    */
   scrollOnFocus?: boolean;
+  /**
+   * Whether or not the swiper-wrapper should have the `aria-live` attribute applied to it.
+   * If true, the value will be `off` when autoplay is enabled, otherwise it will be `polite`
+   *
+   * @default true
+   */
+  wrapperLiveRegion?: boolean;
 }


### PR DESCRIPTION
closes #8060

This adds a `wrapperLiveRegion` option to the A11y module params to enable/disable if the `aria-live` attribute should be added to the swiper-wrapper element. The default is `true` so as to prevent breaking existing behaviour