### PR TITLE
fix(core): add React as optional peer dependency to fix monorepo resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,17 @@
     "terser": "^5.22.0",
     "vite": "^4.5.0",
     "vue": "^3.3.6"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds React and React DOM as optional peer dependencies to enable proper dependency resolution in monorepo environments with multiple React versions.

## Why?

We had an issue when using the same version of `swiper` in a monorepo with different React versions. When rendering server-side, we'd get a hook warning with the wrong version of React resolved. `pnpm` wasn't linking the correct version of React because it doesn't know `swiper` depends on it. 

In our project, I've used a bit of middleware in `.pnpmfile.cjs` to add `react` + `react-dom` to the peer dependencies inside `swiper`. This has let `pnpm` know that it needs to link the right version of React rather than just resolving the nearest version:

<details>

<summary>(Our project's .pnpmfile.cjs)</summary>

```js
module.exports = {
  hooks: {
    readPackage(pkg) {
      if (pkg.name === 'swiper') {
        pkg.peerDependencies = {
          ...pkg.peerDependencies,
          react: '>=16.8.0',
          'react-dom': '>=16.8.0',
        };
        pkg.peerDependenciesMeta = {
          ...pkg.peerDependenciesMeta,
          react: { optional: true },
          'react-dom': { optional: true },
        };
      }
      return pkg;
    },
  },
};


```

</details>

Thought it might be useful for others so I thought I'd open this PR! 🙂