### PR TITLE
fix(autoplay): broken custom delay percentages with pause/resume

### DIFF
--- a/src/modules/autoplay/autoplay.mjs
+++ b/src/modules/autoplay/autoplay.mjs
@@ -77,24 +77,27 @@ export default function Autoplay({ swiper, extendParams, on, emit, params }) {
     return currentSlideDelay;
   };
 
+  const getTotalDelay = () => {
+    let totalDelay = swiper.params.autoplay.delay;
+    const currentSlideDelay = getSlideDelay();
+    if (!Number.isNaN(currentSlideDelay) && currentSlideDelay > 0) {
+      totalDelay = currentSlideDelay;
+    }
+    return totalDelay;
+  };
+
   const run = (delayForce) => {
     if (swiper.destroyed || !swiper.autoplay.running) return;
     cancelAnimationFrame(raf);
     calcTimeLeft();
 
-    let delay = typeof delayForce === 'undefined' ? swiper.params.autoplay.delay : delayForce;
-    autoplayDelayTotal = swiper.params.autoplay.delay;
-    autoplayDelayCurrent = swiper.params.autoplay.delay;
-    const currentSlideDelay = getSlideDelay();
-    if (
-      !Number.isNaN(currentSlideDelay) &&
-      currentSlideDelay > 0 &&
-      typeof delayForce === 'undefined'
-    ) {
-      delay = currentSlideDelay;
-      autoplayDelayTotal = currentSlideDelay;
-      autoplayDelayCurrent = currentSlideDelay;
+    let delay = delayForce;
+    if (typeof delay === 'undefined') {
+      delay = getTotalDelay();
+      autoplayDelayTotal = delay;
+      autoplayDelayCurrent = delay;
     }
+
     autoplayTimeLeft = delay;
     const speed = swiper.params.speed;
     const proceed = () => {
@@ -170,9 +173,6 @@ export default function Autoplay({ swiper, extendParams, on, emit, params }) {
 
     swiper.autoplay.paused = true;
     if (reset) {
-      if (slideChanged) {
-        autoplayTimeLeft = swiper.params.autoplay.delay;
-      }
       slideChanged = false;
       proceed();
       return;
@@ -328,6 +328,11 @@ export default function Autoplay({ swiper, extendParams, on, emit, params }) {
   on('slideChange', () => {
     if (swiper.destroyed || !swiper.autoplay.running) return;
     slideChanged = true;
+
+    if (swiper.autoplay.paused) {
+      autoplayTimeLeft = getTotalDelay();
+      autoplayDelayTotal = getTotalDelay();
+    }
   });
 
   Object.assign(swiper.autoplay, {


### PR DESCRIPTION
fixes #8132

-  **incorrect autoplay % returned by `autoplayTimeLeft` on `autoplay.resume()`**
When a slide uses a `data-swiper-autoplay` attribute (custom delay), pausing and then resuming autoplay causes the percentage value emitted via `autoplayTimeLeft` to be incorrectly calculated. This was because `autoplayDelayTotal` was reset to the default delay value of `swiper.params.autoplay.delay` inside the `run` function during a resume operation, instead of retaining the custom delay value.

- **incorrect autoplay % returned by `autoplayTimeLeft` after manual slide change while `swiper.autoplay.paused`**
When autoplay was paused and the user manually navigated to the next slide (`swiper.slideNext()`), resuming autoplay caused the new slide's timer to start at the position the previous slide was paused at. Again, the incorrect value of `swiper.params.autoplay.delay` was being used inside the `pause` function instead of looking for the current slide's custom delay value.

both fixes use a new `getTotalDelay()` helper function that looks for the current slide's `data-swiper-autoplay` value and `swiper.params.autoplay.delay` as a fallback. 