### PR TITLE
Remove redundant line in a11y.mjs

### DIFF
--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -352,7 +352,6 @@ export default function A11y({ swiper, extendParams, on }) {
     const document = getDocument();
     document.addEventListener('visibilitychange', onVisibilityChange);
     swiper.el.addEventListener('focus', handleFocus, true);
-    swiper.el.addEventListener('focus', handleFocus, true);
     swiper.el.addEventListener('pointerdown', handlePointerDown, true);
     swiper.el.addEventListener('pointerup', handlePointerUp, true);
   };


### PR DESCRIPTION
There is a duplicate line of code in the a11y module where the same event listener is attached twice to the swiper element. This is redundant and should be cleaned up to avoid unnecessary execution or potential side effects.

Fixes #8139 
