### PR TITLE
fix(core): Don't use `data-swiper-slide-index` for `realIndex` when virtual module is enabled

### DIFF
--- a/src/core/update/updateActiveIndex.mjs
+++ b/src/core/update/updateActiveIndex.mjs
@@ -83,8 +83,12 @@ export default function updateActiveIndex(newActiveIndex) {
 
   // Get real index
   let realIndex;
-  if (swiper.virtual && params.virtual.enabled && params.loop) {
-    realIndex = getVirtualRealIndex(activeIndex);
+  if (swiper.virtual && params.virtual.enabled) {
+    if (params.loop) {
+      realIndex = getVirtualRealIndex(activeIndex);
+    } else {
+      realIndex = activeIndex;
+    }
   } else if (gridEnabled) {
     const firstSlideInColumn = swiper.slides.find((slideEl) => slideEl.column === activeIndex);
     let activeSlideIndex = parseInt(firstSlideInColumn.getAttribute('data-swiper-slide-index'), 10);


### PR DESCRIPTION
Swiper has virtual and thumbnail modules, which can be used to create an image carousel with thumbnails.

# Issue

When both modules are enabled:

1. thumbnail carousel loads with active slide = 1
2. click on slide 9.
   Image carousel scrolls to slide 9.
   Thumbnail carousel scrolls to slide 9
3. click on slide 2.
   Image carousel scrolls to slide 2.
   _Currently:_ Thumbnail carousel scrolls back to slide 9.
   _Expected:_ Thumbnail carousel scrolls to slide 2.

The issue occurs only on the first set of slides.
Slides 6 and after work as expected.

https://github.com/user-attachments/assets/77962817-44f2-466f-9b0f-3475c666fe3b

<details>

<summary>Html playground</summary>

Copy to `playground/core/index.html`

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <title>Swiper Playground</title>
    <meta name="viewport" content="width=device-width" />
    <style>
      html,
      body {
        position: relative;
        height: 100%;
      }

      body {
        background: #eee;
        font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
        font-size: 16px;
        color: #000;
        margin: 0;
        padding: 0;

        box-sizing: border-box;
        display: flex;
        flex-flow: column;
        padding: 1rem;
        height: 100dvh;
        gap: 2rem;
      }

      .swiper {
        width: 100%;
        height: 100%;
      }

      .swiper.thumbs {
        box-sizing: border-box;
        padding: 0 calc(var(--swiper-navigation-size) + 1rem);
        height: 30%;
      }

      .image-slide {
        display: flex !important;
        align-items: center;
        justify-content: center;
        background: #fff;
        text-align: center;
        font-size: 18px;
      }

      .thumb-slide.swiper-slide {
        display: flex;
        align-items: center;
        justify-content: center;
        background: #d3d3d3;
      }

      .thumb-slide.swiper-slide-thumb-active {
        background: #76ff8d;
      }
    </style>
  </head>

  <body>
    <div class="images swiper">
      <div class="swiper-wrapper">
        <!-- <div class="swiper-slide image-slide">Slide 1</div> -->
      </div>

      <div class="swiper-button-next"></div>
      <div class="swiper-button-prev"></div>
    </div>

    <div class="thumbs swiper">
      <div class="swiper-wrapper">
        <!-- <div class="swiper-slide thumb-slide">Thumbnail 1</div>  -->
      </div>
      <div class="swiper-button-next"></div>
      <div class="swiper-button-prev"></div>
    </div>

    <script type="module">
      // eslint-disable-next-line
      import "swiper/swiper-bundle.css";

      // eslint-disable-next-line
      import Swiper from "swiper/swiper-bundle.mjs";

      window.swiperThumbs = new Swiper(".thumbs", {
        slidesPerView: 4,
        spaceBetween: 10,
        navigation: {
          nextEl: ".swiper-button-next",
          prevEl: ".swiper-button-prev",
        },
        mousewheel: true,
        freeMode: true,
        virtual: {
          slidesPerView: 7,
          slides: (function () {
            const slides = [];
            for (var i = 0; i < 50; i += 1) {
              slides.push(`Thumbnail ${i + 1}`);
            }
            return slides;
          })(),
          renderSlide: (slide, index) => {
            let e = document.createElement("div");
            e.classList.add("thumb-slide", "swiper-slide");
            e.innerText = slide;
            return e;
          },
          cache: false,
        },
        watchSlidesProgress: true,
      });

      window.swiperImages = new Swiper(".images", {
        slidesPerView: 1,
        spaceBetween: 10,
        thumbs: {
          swiper: window.swiperThumbs,
        },
        navigation: {
          nextEl: ".swiper-button-next",
          prevEl: ".swiper-button-prev",
        },
        virtual: {
          slides: (function () {
            const slides = [];
            for (var i = 0; i < 50; i += 1) {
              slides.push(`Slide ${i + 1}`);
            }
            return slides;
          })(),
          renderSlide: (slide, index) => {
            let e = document.createElement("div");
            e.classList.add("image-slide", "swiper-slide");
            e.innerText = slide;
            return e;
          },
        },
      });
    </script>
  </body>
</html>
```

</details>

# Stack trace

When viewing slide 9. Then clicking on slide 2, which has an index of 1:

1. [onThumbClick](https://github.com/nolimits4web/swiper/blob/975277111b73f389043cb0ed19feee0244a80f57/src/modules/thumbs/thumbs.mjs#L29): `slideToIndex` = 1

   1. [swiper.slideTo()](https://github.com/nolimits4web/swiper/blob/975277111b73f389043cb0ed19feee0244a80f57/src/modules/thumbs/thumbs.mjs#L50) `skip` = 0, `snapIndex` = 1, `snapGrid.length` = 50

2. [slideTo](https://github.com/nolimits4web/swiper/blob/975277111b73f389043cb0ed19feee0244a80f57/src/core/slide/slideTo.mjs#L85): slideIndex = 1

   1. `swiper.setTranslate(translate)` -> emits `setTranslate`

3. `setTranslate` listener in [virtual.mjs](https://github.com/nolimits4web/swiper/blob/975277111b73f389043cb0ed19feee0244a80f57/src/modules/virtual/virtual.mjs#L375):

   1. update()
   2. [swiper.updateActiveIndex()](https://github.com/nolimits4web/swiper/blob/975277111b73f389043cb0ed19feee0244a80f57/src/modules/virtual/virtual.mjs#L87)

   3. [updateActiveIndex](https://github.com/nolimits4web/swiper/blob/975277111b73f389043cb0ed19feee0244a80f57/src/core/update/updateActiveIndex.mjs#L96): (in `else if (swiper.slides[activeIndex]) {`)

      - `activeIndex` = 1
      - `swiper.slides[activeIndex]` = `<div class="image-slide swiper-slide swiper-slide-active" data-swiper-slide-index="8" style="left: 5460px; width: 770px; margin-right: 10px;">`
      - `slideIndex` = 8.

   4. `realIndex` = 8, from `data-swiper-slide-index`
      🔵 Slide dom node and `data-swiper-slide-index` haven't been updated yet in dom.
      User clicked on slide 2, not 8

   5. `updateActiveIndex` [emits `slideChange`](https://github.com/nolimits4web/swiper/blob/975277111b73f389043cb0ed19feee0244a80f57/src/core/update/updateActiveIndex.mjs#L125)

4. `thumbs.mjs` scrolls the thumbnails carousel to slide with index = 8:
   1. [on('slideChange')](https://github.com/nolimits4web/swiper/blob/975277111b73f389043cb0ed19feee0244a80f57/src/modules/thumbs/thumbs.mjs#L228) calls `update()`
   2. [update()](https://github.com/nolimits4web/swiper/blob/975277111b73f389043cb0ed19feee0244a80f57/src/modules/thumbs/thumbs.mjs#L119): `swiper.realIndex` = 8, `thumbsToActivate` = 1
   3. [autoScroll()](https://github.com/nolimits4web/swiper/blob/975277111b73f389043cb0ed19feee0244a80f57/src/modules/thumbs/thumbs.mjs#L183): `newThumbsIndex` = 8

Swiper reads `data-swiper-slide-index` after commit [f5a0ba8a](https://github.com/nolimits4web/swiper/commit/f5a0ba8a18590eb0b9b02acc0ea9d7610a02ac8d#diff-0d9831186d10e5d16dbdd39995b1f5379f76cbda462c031918f85bbcb0d922a2R35).

After commit [d23e8094](https://github.com/nolimits4web/swiper/commit/d23e809461f30475985d244726f440d2192625fe#diff-668d783b24b9f12691b9f311a38c6898505f0dff6ebad56e3ce69a9867c50a74R68) in `updateActiveIndex()` swiper handles virtual module's loop mode as a special case.

# In this PR

In `updateActiveIndex` set `realIndex = activeIndex` if virtual module is enabled.

Index in `data-swiper-slide-index` isn't up to date
