### PR TITLE
fix: prevent blank slide when loop enabled with next navigation

### DIFF
--- a/src/core/loop/loopFix.mjs
+++ b/src/core/loop/loopFix.mjs
@@ -97,7 +97,7 @@ export default function loopFix({
     activeColIndex +
     (bothDirections && typeof setTranslate === 'undefined' ? -slidesPerView / 2 + 0.5 : 0);
   // prepend last slides before start
-  if (activeColIndexWithShift < loopedSlides) {
+  if (activeColIndexWithShift < loopedSlides && !isNext) {
     slidesPrepended = Math.max(loopedSlides - activeColIndexWithShift, slidesPerGroup);
     for (let i = 0; i < loopedSlides - activeColIndexWithShift; i += 1) {
       const index = i - Math.floor(i / cols) * cols;


### PR DESCRIPTION
## Description

Fixes #8137

When loop is enabled with `slidesPerView: 3` and 4 total slides, navigating to the next slide causes a blank space to appear.

## Root Cause

The prepend operation in `loopFix.mjs` was triggered regardless of navigation direction. This caused slides to be prepended even when moving forward (`isNext`), which is unnecessary and creates blank spaces.

## Solution

Added `!isNext` condition to line 100 to ensure prepend only occurs when moving backward (`isPrev`). This prevents the blank slide issue while maintaining proper loop behavior for backward navigation.

## Changes

- Modified `src/core/loop/loopFix.mjs` line 100
- Changed: `if (activeColIndexWithShift < loopedSlides)`
- To: `if (activeColIndexWithShift < loopedSlides && !isNext)`

## Testing

Tested with the reproduction case from #8137:
- `loop: true`
- `slidesPerView: 3`
- 4 total slides

Result: No blank slide appears when navigating forward.

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=162055292