### PR TITLE
feat(keyboard): add support for custom speed parameter in keyboard navigation

### DIFF
--- a/src/modules/keyboard/keyboard.mjs
+++ b/src/modules/keyboard/keyboard.mjs
@@ -13,6 +13,7 @@ export default function Keyboard({ swiper, extendParams, on, emit }) {
       enabled: false,
       onlyInViewport: true,
       pageUpDown: true,
+      speed: undefined,
     },
   });
 
@@ -92,22 +93,23 @@ export default function Keyboard({ swiper, extendParams, on, emit }) {
       }
       if (!inView) return undefined;
     }
+    const speed = swiper.params.keyboard.speed;
     if (swiper.isHorizontal()) {
       if (isPageUp || isPageDown || isArrowLeft || isArrowRight) {
         if (e.preventDefault) e.preventDefault();
         else e.returnValue = false;
       }
       if (((isPageDown || isArrowRight) && !rtl) || ((isPageUp || isArrowLeft) && rtl))
-        swiper.slideNext();
+        swiper.slideNext(speed);
       if (((isPageUp || isArrowLeft) && !rtl) || ((isPageDown || isArrowRight) && rtl))
-        swiper.slidePrev();
+        swiper.slidePrev(speed);
     } else {
       if (isPageUp || isPageDown || isArrowUp || isArrowDown) {
         if (e.preventDefault) e.preventDefault();
         else e.returnValue = false;
       }
-      if (isPageDown || isArrowDown) swiper.slideNext();
-      if (isPageUp || isArrowUp) swiper.slidePrev();
+      if (isPageDown || isArrowDown) swiper.slideNext(speed);
+      if (isPageUp || isArrowUp) swiper.slidePrev(speed);
     }
     emit('keyPress', kc);
     return undefined;

--- a/src/types/modules/keyboard.d.ts
+++ b/src/types/modules/keyboard.d.ts
@@ -43,4 +43,10 @@ export interface KeyboardOptions {
    * @default true
    */
   pageUpDown?: boolean;
+  /**
+   * Set the speed of keyboard navigation transitions (in ms)
+   *
+   * @default undefined
+   */
+  speed?: number;
 }


### PR DESCRIPTION
## Summary

This PR introduces a new `speed` parameter to the Swiper keyboard module, allowing users to customize the slide transition speed when navigating with keyboard controls (Arrow keys, PageUp/PageDown).

## Details

- Extended Swiper’s keyboard parameters to include an optional `speed` property.
- When navigating with the keyboard, the `slideNext()`/`slidePrev()` functions now use the specified `keyboard.speed` value if provided; otherwise, they fallback to the global Swiper speed.
- Updated the TypeScript type definitions (`KeyboardOptions`) to include the new parameter.

## Motivation

Previously, keyboard navigation always used the default Swiper speed. This feature allows for more granular control, enabling smoother or faster transitions specifically when using keyboard controls.


## Breaking changes

None. If keyboard.speed is not set, Swiper behavior remains unchanged.
