### PR TITLE
fix(react): fixes `lazy` prop 

### DIFF
--- a/src/react/swiper-slide.mjs
+++ b/src/react/swiper-slide.mjs
@@ -75,7 +75,6 @@ const SwiperSlide = forwardRef(
         ref={slideElRef}
         className={uniqueClasses(`${slideClasses}${className ? ` ${className}` : ''}`)}
         data-swiper-slide-index={virtualIndex}
-        onLoad={onLoad}
         {...rest}
       >
         {zoom && (
@@ -85,14 +84,14 @@ const SwiperSlide = forwardRef(
               data-swiper-zoom={typeof zoom === 'number' ? zoom : undefined}
             >
               {renderChildren()}
-              {lazy && !lazyLoaded && <div className="swiper-lazy-preloader" />}
+              {lazy && !lazyLoaded && <div className="swiper-lazy-preloader" onLoad={onLoad} />}
             </div>
           </SwiperSlideContext.Provider>
         )}
         {!zoom && (
           <SwiperSlideContext.Provider value={slideData}>
             {renderChildren()}
-            {lazy && !lazyLoaded && <div className="swiper-lazy-preloader" />}
+            {lazy && !lazyLoaded && <div className="swiper-lazy-preloader" onLoad={onLoad} />}
           </SwiperSlideContext.Provider>
         )}
       </Tag>


### PR DESCRIPTION
Corrects the lazy loader never being added into the dom causing removeChild error

Fixes Issue #8149
