### PR TITLE
fix(core): prevent duplicate module initialization in constructor

### DIFF
--- a/src/core/core.mjs
+++ b/src/core/core.mjs
@@ -93,7 +93,11 @@ class Swiper {
     swiper.eventsAnyListeners = [];
     swiper.modules = [...swiper.__modules__];
     if (params.modules && Array.isArray(params.modules)) {
-      swiper.modules.push(...params.modules);
+      params.modules.forEach((mod) => {
+        if (typeof mod === 'function' && swiper.modules.indexOf(mod) < 0) {
+          swiper.modules.push(mod);
+        }
+      });
     }
 
     const allModulesParams = {};


### PR DESCRIPTION
## issues

resolve #8155 

## Description

Prevents duplicate module initialization when modules are specified in both `Swiper.use()` and constructor options.

## Changes

Added duplicate check in constructor's module initialization to match `Swiper.installModule()` behavior. Modules now initialize only once regardless of registration method.

https://github.com/nolimits4web/swiper/blob/3a1777aa7aefe168eac330f308cedd8c3f4a81e4/src/core/core.mjs#L718-L725