### PR TITLE
Support boolean as a11y type

### DIFF
--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -892,7 +892,7 @@ export interface SwiperOptions {
    * });
    * ```
    */
-  a11y?: A11yOptions;
+  a11y?: A11yOptions | boolean;
 
   /**
    * Object with autoplay parameters or boolean `true` to enable with default settings


### PR DESCRIPTION
The `a11y` documentation says that it accepts a boolean,

https://swiperjs.com/swiper-api#param-a11y
> Object with a11y parameters or boolean true to enable with default settings.

but the type definition does not support this.

https://github.com/nolimits4web/swiper/blob/3a1777aa7aefe168eac330f308cedd8c3f4a81e4/src/types/swiper-options.d.ts#L895

This PR adds it, mirroring the behaviour of `autoplay`
https://github.com/nolimits4web/swiper/blob/3a1777aa7aefe168eac330f308cedd8c3f4a81e4/src/types/swiper-options.d.ts#L898-L909