### PR TITLE
fix(core): avoid double-subtracting offsets in centerInsufficientSlides

### DIFF
--- a/src/core/update/updateSlides.mjs
+++ b/src/core/update/updateSlides.mjs
@@ -327,9 +327,8 @@ export default function updateSlides() {
       allSlidesSize += slideSizeValue + (spaceBetween || 0);
     });
     allSlidesSize -= spaceBetween;
-    const offsetSize = (offsetBefore || 0) + (offsetAfter || 0);
-    if (allSlidesSize + offsetSize < swiperSize) {
-      const allSlidesOffset = (swiperSize - allSlidesSize - offsetSize) / 2;
+    if (allSlidesSize < swiperSize) {
+      const allSlidesOffset = (swiperSize - allSlidesSize) / 2;
       snapGrid.forEach((snap, snapIndex) => {
         snapGrid[snapIndex] = snap - allSlidesOffset;
       });


### PR DESCRIPTION
Fix `centerInsufficientSlides` with `slidesOffsetBefore/After` in v12

## Summary

In Swiper v12.0.0+, `centerInsufficientSlides` under-centers slides when `slidesOffsetBefore` and/or `slidesOffsetAfter` are set. The wrapper ends up shifted by `(offsetBefore + offsetAfter) / 2` compared to v11 behavior. This PR fixes the centering math so offsets are applied exactly once.

## Root cause

Starting in v12 (commit [`74cc297`](https://github.com/nolimits4web/swiper/commit/74cc297)), `updateSlides()` computes:

- `swiperSize = swiper.size - offsetBefore - offsetAfter`

But the `centerInsufficientSlides` block still treated offsets as not accounted for and subtracted them again via `offsetSize`, effectively shrinking the available size by `2 * (offsetBefore + offsetAfter)`.

## Reproduction

Minimal config:

```js
new Swiper('.swiper', {
  slidesPerView: 'auto',
  spaceBetween: 12,
  centerInsufficientSlides: true,
  slidesOffsetBefore: 48,
  slidesOffsetAfter: 48,
});
```

## Verification

- With fewer slides than needed to fill the container, v12 now centers the same as v11 when offsets are configured.
- No behavior change when offsets are `0` / unset.