### PR TITLE
fix(core): use virtual slides count in onResize when virtual mode is enabled 

### DIFF
--- a/src/core/events/onResize.mjs
+++ b/src/core/events/onResize.mjs
@@ -32,7 +32,7 @@ export default function onResize() {
     !isVirtualLoop
   ) {
     const slides = isVirtual ? swiper.virtual.slides : swiper.slides;
-+   swiper.slideTo(slides.length - 1, 0, false, true);
+    swiper.slideTo(slides.length - 1, 0, false, true);
   } else {
     if (swiper.params.loop && !isVirtual) {
       swiper.slideToLoop(swiper.realIndex, 0, false, true);


### PR DESCRIPTION
## Summary                                                                                                       
  - https://github.com/nolimits4web/swiper/issues/8162
  - Fix `onResize()` to use `swiper.virtual.slides` instead of `swiper.slides` (DOM elements) when Virtual mode is 
  enabled
  - This aligns `onResize()` with the existing correct implementation in `update()`

  ## Problem

  When using Virtual mode with `slidesPerView > 1`, `onResize()` incorrectly uses `swiper.slides.length` (rendered
  DOM elements, typically ~4-6) instead of the full virtual slides count (e.g., ~10). This causes `slideTo()` to
  navigate to a wrong position when the swiper is at the end and a resize event occurs.

  For example, with 10 virtual slides and `slidesPerGroup: 2`:
  - `swiper.slides.length` = 4 (DOM elements)
  - `slideTo(3)` → `snapIndex = Math.floor(3/2) = 1` → jumps to slide index 2
  - **Expected**: stay at the last slide (index 8)

  ## Root cause

  `onResize()` enters this branch when `slidesPerView > 1` and `isEnd === true`:

  ```js
  // onResize() - BUG
  if ((params.slidesPerView === 'auto' || params.slidesPerView > 1)
      && swiper.isEnd && !swiper.isBeginning
      && !swiper.params.centeredSlides && !isVirtualLoop) {
    swiper.slideTo(swiper.slides.length - 1, 0, false, true);
    //             ^^^^^^^^^^^^^^^^^^^^^^ DOM count (~4), not virtual count (~10)
  }

  The update() method already handles this correctly:

  // update() - CORRECT
  const slides = swiper.virtual && params.virtual.enabled ? swiper.virtual.slides : swiper.slides;
  translated = swiper.slideTo(slides.length - 1, 0, false, true);

  Fix

  Apply the same virtual-aware pattern from update() to onResize():

  + const slides = isVirtual ? swiper.virtual.slides : swiper.slides;
  - swiper.slideTo(swiper.slides.length - 1, 0, false, true);
  + swiper.slideTo(slides.length - 1, 0, false, true);

  Note: isVirtual is already defined earlier in onResize():
  const isVirtual = swiper.virtual && swiper.params.virtual.enabled;