### PR TITLE
feat(react): expose isFullyVisible in SwiperSlide render props

### DIFF
--- a/src/react/swiper-slide.mjs
+++ b/src/react/swiper-slide.mjs
@@ -58,6 +58,7 @@ const SwiperSlide = forwardRef(
     const slideData = {
       isActive: slideClasses.indexOf('swiper-slide-active') >= 0,
       isVisible: slideClasses.indexOf('swiper-slide-visible') >= 0,
+      isFullyVisible: slideClasses.indexOf('swiper-slide-fully-visible') >= 0,
       isPrev: slideClasses.indexOf('swiper-slide-prev') >= 0,
       isNext: slideClasses.indexOf('swiper-slide-next') >= 0,
     };

--- a/src/swiper-react.d.ts
+++ b/src/swiper-react.d.ts
@@ -42,6 +42,7 @@ type SwiperProps = Omit<
 interface SlideData {
   isActive: boolean;
   isVisible: boolean;
+  isFullyVisible: boolean;
   isPrev: boolean;
   isNext: boolean;
 }


### PR DESCRIPTION
## Summary

Expose `isFullyVisible` in `SwiperSlide` render props for React.

## Changes

- add `isFullyVisible` to the `slideData` object passed to `SwiperSlide` render props
- add `isFullyVisible` to the React `SlideData` TypeScript definition

## Motivation

Swiper already tracks the `swiper-slide-fully-visible` state internally, but that state is not currently exposed through `SwiperSlide` render props.

Exposing it makes the React API more complete and lets consumers implement UI logic based on full visibility without relying on class name parsing or DOM workarounds.

## Example

```tsx
<SwiperSlide>
  {({ isFullyVisible }) => (
    <div>{isFullyVisible ? 'fully visible' : 'not fully visible'}</div>
  )}
</SwiperSlide>
```

## Validation

- `eslint src/react/swiper-slide.mjs`
- `npm run build:prod`

## Notes

- additive change only
- no existing behavior removed or changed
- Closes #8174 