### PR TITLE
fix: remove redundant aria-disabled=false from swiper nav button

### DIFF
--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -214,7 +214,6 @@ export default function A11y({ swiper, extendParams, on }) {
       el.addEventListener('keydown', onEnterOrSpaceKey);
     }
     addElLabel(el, message);
-    addElControls(el, wrapperId);
   };
 
   const handlePointerDown = (e) => {

--- a/src/modules/a11y/a11y.mjs
+++ b/src/modules/a11y/a11y.mjs
@@ -105,7 +105,7 @@ export default function A11y({ swiper, extendParams, on }) {
   function enableEl(el) {
     el = makeElementsArray(el);
     el.forEach((subEl) => {
-      subEl.setAttribute('aria-disabled', false);
+      subEl.removeAttribute('aria-disabled');
     });
   }
 


### PR DESCRIPTION
Fixes #7975

## Problem
Two invalid ARIA attributes on the swiper nav buttons were flagged by accessibility checkers (e.g. Eye-Able, axe-core):

1. `aria-disabled="false"` is an invalid ARIA value. When a button is not disabled, the correct approach is to omit the attribute entirely.

2. `aria-controls` references an ID that is only set inside the Shadow DOM. ARIA ID references do not work across Shadow DOM boundaries and are therefore invisible to assistive technologies — making the attribute misleading and ineffective.

## Changes
- Removed `aria-disabled="false"` from next/prev buttons — the buttons remain fully functional and accessible without it.
- Removed `aria-controls` from next/prev buttons — `aria-label` already communicates the button's purpose clearly.