### PR TITLE
fix(core): guard against stale event listeners in onTouchEnd and onTouchMove

### DIFF
--- a/src/core/events/onTouchEnd.mjs
+++ b/src/core/events/onTouchEnd.mjs
@@ -3,6 +3,8 @@ import { now, nextTick } from '../../shared/utils.mjs';
 export default function onTouchEnd(event) {
   const swiper = this;
   const data = swiper.touchEventsData;
+  // stale listener: re-init via connectedCallback replaces swiper.onTouchEnd (fn2) but fn1 stays on document
+  if (!data) return;
 
   let e = event;
   if (e.originalEvent) e = e.originalEvent;

--- a/src/core/events/onTouchEnd.mjs
+++ b/src/core/events/onTouchEnd.mjs
@@ -3,7 +3,6 @@ import { now, nextTick } from '../../shared/utils.mjs';
 export default function onTouchEnd(event) {
   const swiper = this;
   const data = swiper.touchEventsData;
-  // stale listener: re-init via connectedCallback replaces swiper.onTouchEnd (fn2) but fn1 stays on document
   if (!data) return;
 
   let e = event;

--- a/src/core/events/onTouchMove.mjs
+++ b/src/core/events/onTouchMove.mjs
@@ -5,6 +5,8 @@ export default function onTouchMove(event) {
   const document = getDocument();
   const swiper = this;
   const data = swiper.touchEventsData;
+  // stale listener: re-init via connectedCallback replaces swiper.onTouchEnd (fn2) but fn1 stays on document
+  if (!data) return;
   const { params, touches, rtlTranslate: rtl, enabled } = swiper;
   if (!enabled) return;
   if (!params.simulateTouch && event.pointerType === 'mouse') return;

--- a/src/core/events/onTouchMove.mjs
+++ b/src/core/events/onTouchMove.mjs
@@ -5,7 +5,6 @@ export default function onTouchMove(event) {
   const document = getDocument();
   const swiper = this;
   const data = swiper.touchEventsData;
-  // stale listener: re-init via connectedCallback replaces swiper.onTouchEnd (fn2) but fn1 stays on document
   if (!data) return;
   const { params, touches, rtlTranslate: rtl, enabled } = swiper;
   if (!enabled) return;


### PR DESCRIPTION
When a <swiper-container> web component is disconnected and reconnected (e.g. during SPA navigation or a loop DOM move), `connectedCallback` calls `initialize()` which checks `this.swiper && this.swiper.initialized`. After `destroy()` runs `deleteProps()`, `swiper.initialized` is deleted (undefined/falsy) but `this.swiper` still references the old object, so the guard passes and a new SwiperCore is created. `attachEvents()` binds a new handler (fn2) and registers it on the document, overwriting `swiper.onTouchEnd` — but fn1 (from the previous init) is never removed and remains registered on the document. When `detachEvents()` is later called, it removes fn2 (the current `swiper.onTouchEnd` reference) and fn1 stays behind. Once `deleteProps()` runs and wipes `touchEventsData`, any subsequent pointer/touch event triggers fn1, which accesses `swiper.touchEventsData` on the already-destroyed instance — now `undefined` — and throws:
```
  TypeError: Cannot read properties of undefined (reading 'touchId')
```
Observed in production monitoring (Chrome 118, Windows 10). A minimal reproducible example is not available as the issue was captured exclusively through production error tracking and private LogRocket session recordings.

Fix: add an early return guard in `onTouchEnd` and `onTouchMove` when `touchEventsData` is absent, making both handlers safe against stale listener invocations on destroyed swiper instances.
