### PR TITLE
fix: avoid duplicate css type resolutions

### DIFF
--- a/scripts/build-types.js
+++ b/scripts/build-types.js
@@ -130,5 +130,27 @@ export default async function buildTypes() {
       return fs.writeFile(destPath, fileContent);
     }),
   );
+
+  const packageJson = await fs.readJson(path.resolve(__dirname, `../${outputDir}/package.json`));
+  const cssTypingFiles = new Set();
+  Object.values(packageJson.exports).forEach((entry) => {
+    if (
+      entry &&
+      typeof entry === 'object' &&
+      typeof entry.default === 'string' &&
+      entry.default.endsWith('.css') &&
+      typeof entry.types === 'string'
+    ) {
+      cssTypingFiles.add(entry.types);
+    }
+  });
+  await Promise.all(
+    Array.from(cssTypingFiles).map(async (file) => {
+      const destPath = path.resolve(__dirname, `../${outputDir}`, file);
+      if (await fs.pathExists(destPath)) return;
+      await fs.ensureDir(path.dirname(destPath));
+      await fs.writeFile(destPath, 'export {};\n');
+    }),
+  );
   elapsed.end('types', chalk.green('Types build completed!'));
 }

--- a/src/copy/package.json
+++ b/src/copy/package.json
@@ -32,103 +32,103 @@
       "default": "./swiper.css"
     },
     "./css/bundle": {
-      "types": "./swiper.css.d.ts",
+      "types": "./swiper-bundle.css.d.ts",
       "default": "./swiper-bundle.css"
     },
     "./swiper-bundle.css": {
-      "types": "./swiper.css.d.ts",
+      "types": "./swiper-bundle.css.d.ts",
       "default": "./swiper-bundle.css"
     },
     "./css/a11y": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/a11y.css.d.ts",
       "default": "./modules/a11y.css"
     },
     "./css/autoplay": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/autoplay.css.d.ts",
       "default": "./modules/autoplay.css"
     },
     "./css/controller": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/controller.css.d.ts",
       "default": "./modules/controller.css"
     },
     "./css/effect-coverflow": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-coverflow.css.d.ts",
       "default": "./modules/effect-coverflow.css"
     },
     "./css/effect-cube": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-cube.css.d.ts",
       "default": "./modules/effect-cube.css"
     },
     "./css/effect-fade": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-fade.css.d.ts",
       "default": "./modules/effect-fade.css"
     },
     "./css/effect-flip": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-flip.css.d.ts",
       "default": "./modules/effect-flip.css"
     },
     "./css/effect-creative": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-creative.css.d.ts",
       "default": "./modules/effect-creative.css"
     },
     "./css/effect-cards": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-cards.css.d.ts",
       "default": "./modules/effect-cards.css"
     },
     "./css/free-mode": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/free-mode.css.d.ts",
       "default": "./modules/free-mode.css"
     },
     "./css/grid": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/grid.css.d.ts",
       "default": "./modules/grid.css"
     },
     "./css/hash-navigation": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/hash-navigation.css.d.ts",
       "default": "./modules/hash-navigation.css"
     },
     "./css/history": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/history.css.d.ts",
       "default": "./modules/history.css"
     },
     "./css/keyboard": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/keyboard.css.d.ts",
       "default": "./modules/keyboard.css"
     },
     "./css/manipulation": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/manipulation.css.d.ts",
       "default": "./modules/manipulation.css"
     },
     "./css/mousewheel": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/mousewheel.css.d.ts",
       "default": "./modules/mousewheel.css"
     },
     "./css/navigation": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/navigation.css.d.ts",
       "default": "./modules/navigation.css"
     },
     "./css/pagination": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/pagination.css.d.ts",
       "default": "./modules/pagination.css"
     },
     "./css/parallax": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/parallax.css.d.ts",
       "default": "./modules/parallax.css"
     },
     "./css/scrollbar": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/scrollbar.css.d.ts",
       "default": "./modules/scrollbar.css"
     },
     "./css/thumbs": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/thumbs.css.d.ts",
       "default": "./modules/thumbs.css"
     },
     "./css/virtual": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/virtual.css.d.ts",
       "default": "./modules/virtual.css"
     },
     "./css/zoom": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/zoom.css.d.ts",
       "default": "./modules/zoom.css"
     },
     "./element": {
@@ -144,95 +144,95 @@
       "default": "./swiper-element-bundle.mjs"
     },
     "./element/css/a11y": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/a11y-element.css.d.ts",
       "default": "./modules/a11y-element.css"
     },
     "./element/css/autoplay": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/autoplay-element.css.d.ts",
       "default": "./modules/autoplay-element.css"
     },
     "./element/css/controller": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/controller-element.css.d.ts",
       "default": "./modules/controller-element.css"
     },
     "./element/css/effect-coverflow": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-coverflow-element.css.d.ts",
       "default": "./modules/effect-coverflow-element.css"
     },
     "./element/css/effect-cube": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-cube-element.css.d.ts",
       "default": "./modules/effect-cube-element.css"
     },
     "./element/css/effect-fade": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-fade-element.css.d.ts",
       "default": "./modules/effect-fade-element.css"
     },
     "./element/css/effect-flip": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-flip-element.css.d.ts",
       "default": "./modules/effect-flip-element.css"
     },
     "./element/css/effect-creative": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-creative-element.css.d.ts",
       "default": "./modules/effect-creative-element.css"
     },
     "./element/css/effect-cards": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/effect-cards-element.css.d.ts",
       "default": "./modules/effect-cards-element.css"
     },
     "./element/css/free-mode": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/free-mode-element.css.d.ts",
       "default": "./modules/free-mode-element.css"
     },
     "./element/css/grid": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/grid-element.css.d.ts",
       "default": "./modules/grid-element.css"
     },
     "./element/css/hash-navigation": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/hash-navigation-element.css.d.ts",
       "default": "./modules/hash-navigation-element.css"
     },
     "./element/css/history": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/history-element.css.d.ts",
       "default": "./modules/history-element.css"
     },
     "./element/css/keyboard": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/keyboard-element.css.d.ts",
       "default": "./modules/keyboard-element.css"
     },
     "./element/css/manipulation": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/manipulation-element.css.d.ts",
       "default": "./modules/manipulation-element.css"
     },
     "./element/css/mousewheel": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/mousewheel-element.css.d.ts",
       "default": "./modules/mousewheel-element.css"
     },
     "./element/css/navigation": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/navigation-element.css.d.ts",
       "default": "./modules/navigation-element.css"
     },
     "./element/css/pagination": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/pagination-element.css.d.ts",
       "default": "./modules/pagination-element.css"
     },
     "./element/css/parallax": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/parallax-element.css.d.ts",
       "default": "./modules/parallax-element.css"
     },
     "./element/css/scrollbar": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/scrollbar-element.css.d.ts",
       "default": "./modules/scrollbar-element.css"
     },
     "./element/css/thumbs": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/thumbs-element.css.d.ts",
       "default": "./modules/thumbs-element.css"
     },
     "./element/css/virtual": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/virtual-element.css.d.ts",
       "default": "./modules/virtual-element.css"
     },
     "./element/css/zoom": {
-      "types": "./swiper.css.d.ts",
+      "types": "./modules/zoom-element.css.d.ts",
       "default": "./modules/zoom-element.css"
     },
     "./react": {


### PR DESCRIPTION
## Summary
- point each CSS export at a declaration file matching its emitted CSS file
- generate side-effect-only CSS declaration files during the type build
- preserve shared declarations only for true CSS aliases

## Problem

Currently all imports are duplicated via side effects on the consumer side, causing lint issues

## Verification
- npm run check-format -- scripts/build-types.js src/copy/package.json
- npm run lint
- npm run build:prod
- reproduced and verified import-x/no-duplicates with eslint-plugin-import-x + eslint-import-resolver-typescript