### PR TITLE
fix(types): support boolean as controller type

### DIFF
--- a/src/types/swiper-options.d.ts
+++ b/src/types/swiper-options.d.ts
@@ -920,7 +920,7 @@ export interface SwiperOptions {
    * });
    * ```
    */
-  controller?: ControllerOptions;
+  controller?: ControllerOptions | boolean;
 
   /**
    * Object with Coverflow-effect parameters.


### PR DESCRIPTION
## Summary

Allow `controller: true` in `SwiperOptions`. Mirrors #8157, which made the same fix for `a11y`.

## Problem

The JSDoc on `controller` in `src/types/swiper-options.d.ts` explicitly documents both forms:

https://github.com/nolimits4web/swiper/blob/b36e16abeb6a6fa9b6b67c0e10df0bd11252c6f5/src/types/swiper-options.d.ts#L911-L923

> Object with controller parameters or boolean \`true\` to enable with default settings

…but the type only allows `ControllerOptions`:

```ts
controller?: ControllerOptions;
```

So this — which works at runtime — is a TS error today:

```ts
new Swiper('.swiper', { controller: true });
//                     ~~~~~~~~~~~~~~~~~~
// Type 'boolean' is not assignable to type 'ControllerOptions'.
```

## Why it works at runtime

The universal normalizer in `moduleExtendParams.mjs` converts `=== true` to `{ enabled: true }` for every module:

https://github.com/nolimits4web/swiper/blob/b36e16abeb6a6fa9b6b67c0e10df0bd11252c6f5/src/core/moduleExtendParams.mjs#L11-L13

```js
if (params[moduleParamName] === true) {
  params[moduleParamName] = { enabled: true };
}
```

That's the same mechanism every other `Module | boolean` option (a11y, autoplay, keyboard, mousewheel, navigation, pagination, parallax, scrollbar, hashNavigation, history, virtual, zoom, freeMode) already relies on.

## Solution

One-line type widening, matching #8157:

```diff
- controller?: ControllerOptions;
+ controller?: ControllerOptions | boolean;
```

## Out of scope

`thumbs` and `grid` are similarly `Module` only (not `Module | boolean`), but their JSDoc does not promise boolean support, so they're intentionally left alone here.

## Test plan

- [x] `git diff --check` clean.
- [x] Confirmed `moduleExtendParams.mjs` handles `controller === true` identically to the other `Module | boolean` options.
- [ ] CI to confirm.

## Related

- #8157 — prior PR adding boolean to `a11y` type (mirrored).

Made with [Cursor](https://cursor.com)