### PR TITLE
fix(pagination): divide fraction/progressbar total by grid rows

### DIFF
--- a/src/modules/pagination/pagination.ts
+++ b/src/modules/pagination/pagination.ts
@@ -491,9 +491,12 @@ const Pagination: SwiperModule = ({ swiper, extendParams, on, emit }) => {
     // Current/Total
     let current: number;
     let previousIndex: number | undefined;
+    const gridParams = swiper.params.grid as { rows?: number } | undefined;
     const slidesLength = isVirtualEnabled(swiper)
       ? swiper.virtual.slides.length
-      : swiper.slides.length;
+      : swiper.grid && gridParams?.rows && gridParams.rows > 1
+        ? swiper.slides.length / Math.ceil(gridParams.rows)
+        : swiper.slides.length;
     const total = swiper.params.loop
       ? Math.ceil(slidesLength / (swiper.params.slidesPerGroup ?? 1))
       : swiper.snapGrid.length;


### PR DESCRIPTION
With `loop: true` and `grid: { rows: N }` (N greater than 1), the `fraction` and `progressbar` pagination `total` is multiplied by `grid.rows`.

For a 12-slide slider with `grid: { rows: 2 }`, `slidesPerView: 1`, `slidesPerGroup: 2`, `loop: true` there are 3 reachable snap positions. The bullets pagination correctly shows 3 bullets, but the fraction shows "1 / 6", "2 / 6", "3 / 6" and then wraps back to "1 / 6", so the current index never reaches the stated total and the two pagination types disagree. The progressbar fills to only 1/3 at the last group instead of full. The error factor equals `grid.rows`.

## Cause

In `src/modules/pagination/pagination.ts`, the Current/Total block computes `slidesLength` from `swiper.slides.length` without dividing by `grid.rows`. In the loop branch `total = ceil(slidesLength / slidesPerGroup)`, so the denominator counts every slide element even though `grid.rows` slides share one column and one snap position. The non-loop branch reads `swiper.snapGrid.length` (already collapsed) and is correct, and the bullets `render()` in the same file already applies the grid-rows adjustment.

## Fix

Apply the same grid-rows branch the bullets renderer already uses, so both pagination types compute the same length. The non-grid, `rows: 1`, non-loop and virtual paths are unaffected (guarded by `swiper.grid && rows > 1`). `tsc --noEmit` is clean.

## Verification

Drove a real Swiper instance (built from `src/`) with the repro config above and used the bullets count as the oracle. Before the change the fraction total is 6 while the bullets count is 3 (also 3x for `rows: 3`, 4x for `rows: 4`); after the change the fraction and progressbar totals equal the bullets count across `rows` 2/3/4 and `slidesPerGroup` 1/2/3/4, with no change to non-grid, `rows: 1`, non-loop or virtual pagination.
