### PR TITLE
fix(thumbs): bind Thumbs tap handler when thumbs swiper is set after init

### DIFF
--- a/src/components-shared/update-swiper.ts
+++ b/src/components-shared/update-swiper.ts
@@ -49,7 +49,7 @@ export function updateSwiper(args: UpdateSwiperArgs): void {
   if (
     changedParams.includes('thumbs') &&
     isObject(passedThumbs) &&
-    isObject(passedThumbs.swiper) &&
+    passedThumbs.swiper &&
     !(passedThumbs.swiper as Swiper).destroyed &&
     isObject(currentThumbs) &&
     (!currentThumbs.swiper || (currentThumbs.swiper as Swiper).destroyed)


### PR DESCRIPTION
## What

Fixes #8198.

With `swiper/react`, clicking a thumbnail does not navigate the main Swiper in v14 when the thumbs Swiper is provided **after** the main Swiper has initialized (the standard `useState` + `onSwiper` pattern). Thumbnails render, but clicking one does nothing and the active-thumbnail highlight is never applied. Arrow navigation and programmatic `slideTo` / `slideNext` keep working. This worked in v12.2.0 and regressed in v14.0.0 (still present in v14.0.1).

## Root cause

Because the thumbs instance is supplied after init, `beforeInit` runs while `thumbs.swiper` is still `null`, so `swiper.thumbs.init()` has to run later from `updateSwiper()` when the `thumbs` param changes. In `src/components-shared/update-swiper.ts`, that late-init gate validates the instance with `isObject(passedThumbs.swiper)`:

```ts
isObject(passedThumbs) &&
isObject(passedThumbs.swiper) &&   // <-- instance checked with isObject
!(passedThumbs.swiper as Swiper).destroyed &&
```

But `isObject` (`src/components-shared/utils.ts`) intentionally **rejects Swiper instances** via the `__swiper__` marker (it ends with `&& !obj.__swiper__`), and instances are created with `__swiper__ = true`. So `isObject(passedThumbs.swiper)` is always `false`: `needThumbsInit` is never set, `swiper.thumbs.init()` never runs, and the thumbnail `tap` handler is never attached. Since `swiper.thumbs.swiper` also stays unset, the module's `update()` early-returns, which is why the active-thumbnail highlight is not applied either.

The adjacent `controller` branch validates its instance with a plain truthiness check (`passedController.control`), which is why controllers are unaffected.

In v12.2.0 this thumbs gate also used a truthiness check on the instance, so late initialization worked.

## Change

Validate `passedThumbs.swiper` with a truthiness check instead of `isObject`, matching the `controller` branch and restoring the v12.2.0 behavior:

```diff
     changedParams.includes('thumbs') &&
     isObject(passedThumbs) &&
-    isObject(passedThumbs.swiper) &&
+    passedThumbs.swiper &&
     !(passedThumbs.swiper as Swiper).destroyed &&
```

## Verification

- Applied this change locally and confirmed the thumbnail click navigates the main Swiper again; reverting the line reproduces the bug.

This only relaxes the gate to accept a valid, non-destroyed Swiper instance (restoring prior behavior). The change is in the shared `update-swiper` used by all framework wrappers; I verified the React wrapper but have not tested Vue / Svelte / Solid — please double-check those.
