### PR TITLE
fix(loop): stop false "not enough slides" warning with auto + centeredSlides

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "consumer-types-test": "node tests/consumer-types/run.mjs",
     "ssr-test": "node tests/ssr/ssr.test.mjs",
     "element-dom-test": "node tests/element-dom/element-dom.test.mjs",
+    "loop-warning-test": "node tests/element-dom/loop-warning.test.mjs",
     "release": "npm run validate && node ./scripts/release",
-    "test": "npm run validate && npm run build:prod && npm run contract-test && npm run dist-types-test && npm run consumer-types-test && npm run ssr-test && npm run element-dom-test && npm run bundle-size",
+    "test": "npm run validate && npm run build:prod && npm run contract-test && npm run dist-types-test && npm run consumer-types-test && npm run ssr-test && npm run element-dom-test && npm run loop-warning-test && npm run bundle-size",
     "changelog": "npx conventional-changelog -p angular -i CHANGELOG.md -u -s",
     "build-sponsors": "node scripts/build-sponsors.js"
   },

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -994,6 +994,16 @@ export class Swiper {
     let spv = 1;
     if (typeof params.slidesPerView === 'number') return params.slidesPerView;
 
+    // swiperSize is only known once updateSize() has measured a non-zero container (see
+    // updateSize.ts, which bails out and leaves `size` unset when clientWidth/clientHeight is 0 -
+    // e.g. the container is hidden or not yet laid out). Without this guard the centered branch
+    // below never finds a slide size that "overflows" an unknown size, so it keeps counting past
+    // the last slide and reports spv ~= slides.length. That inflated count then made loopFix()
+    // think there weren't enough slides for loop mode even when there clearly were
+    // (https://github.com/nolimits4web/swiper/issues/7586). Falling back to 1 here matches what
+    // the non-centered branches below already do implicitly when swiperSize is falsy.
+    if (!swiperSize) return spv;
+
     if (params.centeredSlides) {
       let slideSize = slides[activeIndex] ? Math.ceil(slides[activeIndex].swiperSlideSize ?? 0) : 0;
       let breakLoop = false;

--- a/tests/element-dom/loop-warning.test.mjs
+++ b/tests/element-dom/loop-warning.test.mjs
@@ -1,0 +1,217 @@
+// Real-DOM regression test for https://github.com/nolimits4web/swiper/issues/7586
+//
+// Swiper warned "The number of slides is not enough for loop mode" even when there were
+// clearly enough slides, whenever `slidesPerView: 'auto'` was combined with
+// `centeredSlides: true`. Root cause, traced through src/core/core.ts (slidesPerViewDynamic)
+// and src/core/update/updateSize.ts (updateSize):
+//
+//   - updateSize() bails out and leaves `swiper.size` unset when the container's
+//     clientWidth/clientHeight is 0 (hidden container, not yet laid out, or a DOM
+//     environment - like this one - that doesn't run real layout).
+//   - slidesPerViewDynamic()'s centered-slides branch sums slide sizes going outward from
+//     the active slide until the running total exceeds `swiperSize`. With `swiperSize`
+//     unset (undefined), `slideSize > undefined` is always false, so the loop never
+//     breaks and walks every slide in the array, returning spv ~= slides.length.
+//   - loopFix() then compares `slides.length < slidesPerView + loopedSlides`. With
+//     slidesPerView inflated to roughly the full slide count, that comparison trips even
+//     with plenty of slides, and the warning fires.
+//
+// Fix: slidesPerViewDynamic() now returns the safe default of 1 whenever swiperSize is
+// falsy, matching what the two non-centered branches already do implicitly in that case.
+//
+// happy-dom is used deliberately here (not a browser) because it never performs real
+// layout, so it reproduces the "unmeasured container" condition that triggers the bug on
+// every run, without needing to fake a zero-width container.
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Window } from 'happy-dom';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(__dirname, '..', '..', 'dist');
+const dist = (p) => path.join(distDir, p);
+
+if (!fs.existsSync(distDir)) {
+  console.error('dist/ missing — run `npm run build:prod` first.');
+  process.exit(1);
+}
+
+const win = new Window({ url: 'http://localhost/' });
+const FORCE = new Set(['Event', 'CustomEvent', 'Node', 'Element', 'HTMLElement', 'ShadowRoot']);
+for (const key of Object.getOwnPropertyNames(win)) {
+  if (key in globalThis && key !== 'window' && !FORCE.has(key)) continue;
+  try {
+    globalThis[key] = win[key];
+  } catch {
+    /* read-only global (e.g. navigator) — not needed for this test */
+  }
+}
+globalThis.window = win;
+
+const { default: Swiper } = await import(dist('swiper-bundle.mjs'));
+
+const doc = win.document;
+
+function mountSwiper({ params = {}, slideCount = 8 } = {}) {
+  const el = doc.createElement('div');
+  el.className = 'swiper';
+  const wrapper = doc.createElement('div');
+  wrapper.className = 'swiper-wrapper';
+  for (let i = 1; i <= slideCount; i += 1) {
+    const slide = doc.createElement('div');
+    slide.className = 'swiper-slide';
+    slide.textContent = `Slide ${i}`;
+    wrapper.appendChild(slide);
+  }
+  el.appendChild(wrapper);
+  doc.body.appendChild(el);
+  const swiper = new Swiper(el, params);
+  return { el, swiper };
+}
+
+function withCapturedWarnings(fn) {
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  try {
+    fn();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
+
+let failed = 0;
+let passed = 0;
+async function check(label, fn) {
+  let el;
+  try {
+    el = await fn();
+    passed += 1;
+    console.log(`  ok  ${label}`);
+  } catch (err) {
+    failed += 1;
+    console.log(`  FAIL  ${label}`);
+    console.log(`        ${err.message}`);
+  } finally {
+    if (el && el.remove) el.remove();
+  }
+}
+
+console.log('\nSwiper loop-mode warning regression test (happy-dom, #7586)\n');
+
+await check('slidesPerView: auto + centeredSlides does not warn with 8 slides', () => {
+  let swiper;
+  const warnings = withCapturedWarnings(() => {
+    ({ swiper } = mountSwiper({
+      params: { loop: true, slidesPerView: 'auto', centeredSlides: true },
+      slideCount: 8,
+    }));
+  });
+  assert.equal(swiper.slides.length, 8, 'all 8 slides must be present');
+  assert.equal(
+    warnings.some((w) => w.includes('not enough for loop mode')),
+    false,
+    `expected no "not enough" warning, got: ${JSON.stringify(warnings)}`,
+  );
+  return swiper.el;
+});
+
+await check('centeredSlides alone (fixed slidesPerView) does not warn with 8 slides', () => {
+  let swiper;
+  const warnings = withCapturedWarnings(() => {
+    ({ swiper } = mountSwiper({
+      params: { loop: true, slidesPerView: 1, centeredSlides: true },
+      slideCount: 8,
+    }));
+  });
+  assert.equal(
+    warnings.some((w) => w.includes('not enough for loop mode')),
+    false,
+    `expected no "not enough" warning, got: ${JSON.stringify(warnings)}`,
+  );
+  return swiper.el;
+});
+
+await check('slidesPerView: auto alone (no centeredSlides) does not warn with 8 slides', () => {
+  let swiper;
+  const warnings = withCapturedWarnings(() => {
+    ({ swiper } = mountSwiper({
+      params: { loop: true, slidesPerView: 'auto' },
+      slideCount: 8,
+    }));
+  });
+  assert.equal(
+    warnings.some((w) => w.includes('not enough for loop mode')),
+    false,
+    `expected no "not enough" warning, got: ${JSON.stringify(warnings)}`,
+  );
+  return swiper.el;
+});
+
+await check('breakpoints switching into auto + centeredSlides does not warn with 8 slides', () => {
+  let swiper;
+  const warnings = withCapturedWarnings(() => {
+    ({ swiper } = mountSwiper({
+      params: {
+        loop: true,
+        slidesPerView: 1,
+        breakpoints: {
+          0: { slidesPerView: 'auto', centeredSlides: true },
+        },
+      },
+      slideCount: 8,
+    }));
+  });
+  assert.equal(
+    warnings.some((w) => w.includes('not enough for loop mode')),
+    false,
+    `expected no "not enough" warning, got: ${JSON.stringify(warnings)}`,
+  );
+  return swiper.el;
+});
+
+await check('genuinely too few slides still warns (no false negative introduced)', () => {
+  let swiper;
+  const warnings = withCapturedWarnings(() => {
+    ({ swiper } = mountSwiper({
+      params: { loop: true, slidesPerView: 3, slidesPerGroup: 3 },
+      slideCount: 2,
+    }));
+  });
+  assert.equal(
+    warnings.some((w) => w.includes('not enough for loop mode')),
+    true,
+    'expected the genuine-shortage warning to still fire',
+  );
+  return swiper.el;
+});
+
+await check(
+  'slideToLoop with auto + centeredSlides resolves a real index (not stuck at 0)',
+  async () => {
+    let swiper;
+    withCapturedWarnings(() => {
+      ({ swiper } = mountSwiper({
+        params: { loop: true, slidesPerView: 'auto', centeredSlides: true, speed: 0 },
+        slideCount: 8,
+      }));
+    });
+    swiper.slideToLoop(4, 0);
+    // slideToLoop() defers the actual slideTo() call to a requestAnimationFrame callback;
+    // let happy-dom's task queue drain so it actually runs before we assert.
+    await win.happyDOM.waitUntilComplete();
+    assert.equal(
+      swiper.realIndex,
+      4,
+      `expected realIndex 4 after slideToLoop(4), got ${swiper.realIndex}`,
+    );
+    return swiper.el;
+  },
+);
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
slidesPerViewDynamic() is used to work out how many slides are visible when slidesPerView is 'auto', and loopFix() uses that number to decide whether there are enough slides to run loop mode. When centeredSlides is also on, the dynamic calculation sums slide sizes outward from the active slide until the running total passes the container size (swiper.size).

The container size is only set once updateSize() measures a non-zero clientWidth/clientHeight. If the container is hidden, not yet laid out, or running in a DOM environment with no real layout, swiper.size stays undefined. Comparing any slide size against undefined is always false, so the centered branch never stops and walks every slide, returning a count close to the total slide count instead of what actually fits. loopFix then sees that inflated count and reports "not enough slides for loop mode" even with plenty of slides. This matches what people in the thread found: the warning shows up specifically with slidesPerView 'auto' plus centeredSlides, and also through breakpoints that switch a swiper into that combination, since breakpoints go through the same function.

The fix makes slidesPerViewDynamic() fall back to 1 whenever the container size is unknown, which is the same result the non-auto branches already produce implicitly in that situation. No behavior change when the size is actually known.

Added tests/element-dom/loop-warning.test.mjs, a real DOM regression test using happy-dom (it never runs real layout, so it reproduces the unmeasured container condition on every run instead of needing a timing-dependent setup). It covers auto alone, centeredSlides alone, both together, a breakpoints switch into that combination, a control case confirming a genuine slide shortage still warns, and a slideToLoop check. Wired into npm test as loop-warning-test.

Ran against master before this change to confirm the two auto plus centeredSlides cases fail with the real warning text, then confirmed all six pass after the fix. Also ran type-check, build, and the existing contract, element-dom, ssr, and consumer-types suites with no regressions.

I did not touch the slideToLoop index bug some commenters described in the thread. I could not reproduce it against current master, with or without this fix, so I left it alone instead of guessing at a change for something I couldn't observe. I also did not add a way to suppress the warning directly. The calculation fix removes the false positive for the reported cases, and there is no existing debug/logger flag to attach a suppression option to.

Fixes #7586
