### PR TITLE
fix(types): preserve module options in breakpoints

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -42,6 +42,10 @@ export type { CSSSelector, SwiperModule };
 // extend the public type surface at src/types/options.ts /
 // src/types/events.ts.
 export interface SwiperOptions extends PublicSwiperOptions {
+  breakpoints?: {
+    [width: number]: SwiperOptions;
+    [ratio: string]: SwiperOptions;
+  };
   on?: {
     [event in keyof SwiperEvents]?: SwiperEvents[event];
   };

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -42,6 +42,8 @@ export type { CSSSelector, SwiperModule };
 // extend the public type surface at src/types/options.ts /
 // src/types/events.ts.
 export interface SwiperOptions extends PublicSwiperOptions {
+  // Redeclared from PublicSwiperOptions so breakpoint values get the module-augmented
+  // SwiperOptions — the public interface's self-reference never sees augmentations.
   breakpoints?: {
     [width: number]: SwiperOptions;
     [ratio: string]: SwiperOptions;

--- a/tests/consumer-types/fixtures/core.ts
+++ b/tests/consumer-types/fixtures/core.ts
@@ -7,10 +7,10 @@
  */
 import Swiper from 'swiper';
 import { Swiper as SwiperNamed } from 'swiper';
-import { Navigation, Pagination, Autoplay, EffectFade } from 'swiper/modules';
+import { Navigation, Pagination, Autoplay, EffectFade, Grid } from 'swiper/modules';
 
 const swiper = new Swiper('.swiper', {
-  modules: [Navigation, Pagination, Autoplay, EffectFade],
+  modules: [Navigation, Pagination, Autoplay, EffectFade, Grid],
   slidesPerView: 3,
   spaceBetween: 20,
   // Module-augmented options must be accepted on SwiperOptions.
@@ -19,6 +19,9 @@ const swiper = new Swiper('.swiper', {
   autoplay: { delay: 3000, disableOnInteraction: false },
   effect: 'fade',
   fadeEffect: { crossFade: true },
+  breakpoints: {
+    640: { grid: { rows: 2, fill: 'row' } },
+  },
   on: {
     // Core event handler is typed.
     slideChange: (s) => void s.activeIndex,

--- a/tests/dist-types/augmentation.test-d.ts
+++ b/tests/dist-types/augmentation.test-d.ts
@@ -1,5 +1,5 @@
 import type { SwiperEvents, SwiperOptions } from '../../dist/core/core';
-import { Navigation } from '../../dist/modules';
+import { Grid, Navigation } from '../../dist/modules';
 /**
  * Phase 6 regression guard: each module's `declare module '../../core/core'`
  * augmentation block must reach consumers through the SHIPPED `dist/` types,
@@ -42,6 +42,13 @@ type _Evt_autoplayStart = Expect<HasKey<SwiperEvents, 'autoplayStart'>>;
 new Swiper('.x', {
   modules: [Navigation],
   navigation: { nextEl: '.n', prevEl: '.p' },
+});
+
+new Swiper('.grid', {
+  modules: [Grid],
+  breakpoints: {
+    640: { grid: { rows: 2, fill: 'row' } },
+  },
 });
 
 // Swiper instance gains the module method bag.

--- a/tests/types/augmentation.test-d.ts
+++ b/tests/types/augmentation.test-d.ts
@@ -138,8 +138,13 @@ const _o18: SwiperOptions = {
   },
 };
 const _o19: SwiperOptions = { effect: 'cards', cardsEffect: { perSlideOffset: 6 } };
+const _o20: SwiperOptions = {
+  breakpoints: {
+    640: { grid: { rows: 2, fill: 'row' } },
+  },
+};
 void [_o1, _o2, _o3, _o4, _o5, _o6, _o7, _o8, _o9, _o10, _o11, _o12, _o13];
-void [_o14, _o15, _o16, _o17, _o18, _o19];
+void [_o14, _o15, _o16, _o17, _o18, _o19, _o20];
 
 // --- SwiperParams.<module> is the normalized object form (internal) ---
 // `swiper.params.navigation` is `NavigationOptions | undefined` — never the


### PR DESCRIPTION
Fixes #8207
