### PR TITLE
fix(core): make elementOffset viewport-relative again

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -160,16 +160,8 @@ export function createElement(tag: string, classes: string | string[] = []): HTM
   return el;
 }
 
-/**
- * Offset of an element relative to the viewport.
- *
- * Viewport-relative, not document-absolute: every caller either compares the
- * result against viewport quantities (`window.innerHeight` in the keyboard
- * module, `clientX`/`clientY` in the scrollbar) or adds the scroll offset
- * itself (the zoom module, which matches it against `pageX`/`pageY`). Adding
- * `window.scrollX`/`scrollY` here breaks the first two and double-counts for
- * the third.
- */
+// Viewport-relative on purpose: every caller either compares against viewport quantities
+// or adds window.scrollX/Y itself, so folding the scroll offset in here double-counts.
 export function elementOffset(el: Element): { top: number; left: number } {
   const box = el.getBoundingClientRect();
   return {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -160,11 +160,21 @@ export function createElement(tag: string, classes: string | string[] = []): HTM
   return el;
 }
 
+/**
+ * Offset of an element relative to the viewport.
+ *
+ * Viewport-relative, not document-absolute: every caller either compares the
+ * result against viewport quantities (`window.innerHeight` in the keyboard
+ * module, `clientX`/`clientY` in the scrollbar) or adds the scroll offset
+ * itself (the zoom module, which matches it against `pageX`/`pageY`). Adding
+ * `window.scrollX`/`scrollY` here breaks the first two and double-counts for
+ * the third.
+ */
 export function elementOffset(el: Element): { top: number; left: number } {
   const box = el.getBoundingClientRect();
   return {
-    top: box.top + window.scrollY - (el.clientTop || 0),
-    left: box.left + window.scrollX - (el.clientLeft || 0),
+    top: box.top - (el.clientTop || 0),
+    left: box.left - (el.clientLeft || 0),
   };
 }
 


### PR DESCRIPTION
Fixes #8209 (SWIPER-178).

The v14 rewrite changed `elementOffset` from returning a viewport-relative top/left to a document-absolute one, by folding `window.scrollY`/`scrollX` into it. None of its three callers were updated to match, and all three want the viewport-relative value:

| Caller | Expression | What it needs |
| --- | --- | --- |
| `modules/keyboard` | compares against `window.innerHeight` | viewport-relative |
| `modules/scrollbar` | `getPointerPosition(e) - elementOffset(el)[...]`, where the pointer position is `clientX`/`clientY` | viewport-relative |
| `modules/zoom` | `elementOffset(slideEl).top + window.scrollY`, matched against `e.pageY` | viewport-relative — it adds the scroll offset itself |

The user-visible symptom is the keyboard one: with `onlyInViewport: true` (the default), a document-absolute coordinate is tested against `window.innerHeight`, so any slider sitting more than roughly one viewport height down the page fails that test permanently and stops answering arrow keys — no matter how far the page is scrolled, or that the slider is plainly on screen. A slider near the top of the document still works, which is what makes it easy to miss.

Zoom is the subtler one. `offsetY = elementOffset(gesture.slideEl).top + window.scrollY` is byte-identical between v12 and v14; only the helper beneath it changed. In v12 that composed correctly to document-absolute to match `pageY`; in v14 it counts the scroll offset twice.

Restoring the original semantics fixes all three at once and leaves every call site untouched — this changes one function and nothing else.

`PLAN_V14.md` item 7 lists this helper among the DOM helpers to simplify down to `getBoundingClientRect()`, which is now exactly what it is. The scroll term looks like the accidental part of that change.

### Verification

**Behaviour.** I patched this function in the distributed 14.0.7 bundle and drove a below-the-fold slider at three scroll positions in Chromium at 1280×720:

```
scrollY=608   activeIndex 0 -> 1  MOVED    elementOffset().top 520 | innerHeight 720
scrollY=656   activeIndex 0 -> 1  MOVED    elementOffset().top 472 | innerHeight 720
scrollY=656   activeIndex 0 -> 1  MOVED    elementOffset().top 472 | innerHeight 720

control, slider genuinely off screen: 0 -> 0  correctly IGNORED
```

The control is the important half: `onlyInViewport` still suppresses the keypress when the slider really is off screen, so this restores the guard rather than defeating it. On unpatched 14.0.7 the same page is `STUCK` at every one of those positions; on 12.2.0 it moves.

**Against a real consumer.** I maintain a Swiper-based WordPress slider plugin with a Playwright suite that covers keyboard navigation specifically, including a sweep that drives every keyboard-enabled slider on a tall fixture page at real scroll offsets and names any that fail to move. That suite is what caught this in the first place — on unpatched 14.0.7 it reported **28 of 29 sliders deaf to arrow keys**, and 5 specs failing.

I swapped this branch's build into that plugin in place of 12.2.0 and reran it:

| Spec | 14.0.7 | this branch |
| --- | --- | --- |
| arrow keys on a slider below the fold | fail | pass |
| every keyboard-navigable slider answers an arrow key (29 sliders) | fail | pass |
| arrow key with focus inside a nested slider moves only it | fail | pass |
| outer slider answers arrow keys again once focus leaves | fail | pass |
| arrow key with focus outside any slider moves the outer one | fail | pass |

The **full suite is at parity with 12.2.0 — 103 passed**, covering RTL arrow direction, nested focus hand-off, responsive rebuilds, teardown and peek/overflow. So nothing else in the v14 rewrite regresses for that consumer once this is fixed.

Incidentally it confirms the v14 bundle-size goal holds: that plugin's frontend bundle drops from 34.85 kB to 34.19 kB gzipped on 14 versus 12.

**Suite.** `npm test` passes end to end on this branch — `check-format`, `tsc --noEmit`, the contract/dist-types/consumer-types/SSR/element-DOM/loop-warning suites (31 checks, 0 failures), exit 0.

**Size.** 30 bytes smaller minified (`shared/utils.min.mjs` 4195 → 4165 B, `swiper-bundle.min.js` 151615 → 151585 B). Note that `npm run bundle-size` reports large deltas on this branch for unrelated files — the committed baseline predates v14 (it still lists `shared/ssr-window.esm.min.mjs` as present), so those numbers are not from this change. I measured the delta by building the branch with and without the patch.

### Scope

I exercised the keyboard path directly. Zoom and scrollbar are reasoned from the source — the arithmetic is unambiguous and they were written against the old semantics, but I have not driven either, and it would be worth a maintainer eye on them before this lands.

Happy to add a regression test if you want one, though I could not find an existing home for a behavioural test of module logic — `tests/` is contract, types, SSR and element-DOM rather than a jsdom-style unit suite. A below-the-fold keyboard case is precisely the gap that let this ship, so if you would like me to stand one up, say where you would want it to live.
