### PR TITLE
fix(core): recompute rtlTranslate in changeDirection (#8053)

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -1136,6 +1136,9 @@ export class Swiper {
     swiper.emitContainerClasses();
 
     swiper.params.direction = newDirection;
+    // RTL only inverts the translate axis while horizontal, so recompute the flag here —
+    // a stale `true` flips the sign of every translate read on a vertical slider.
+    swiper.rtlTranslate = newDirection === 'horizontal' && swiper.rtl;
 
     swiper.slides.forEach((slideEl) => {
       if (newDirection === 'vertical') {

--- a/tests/element-dom/element-dom.test.mjs
+++ b/tests/element-dom/element-dom.test.mjs
@@ -231,5 +231,51 @@ await check('core swiper resolves a string scrollbar.el selector', async () => {
   }
 });
 
+// Regression: https://github.com/nolimits4web/swiper/issues/8053 — `rtlTranslate` was only
+// recomputed by mount() and changeLanguageDirection(), never by changeDirection(). An RTL
+// slider switched to vertical therefore kept `rtlTranslate: true`, and every `rtlTranslate
+// ? translate : -translate` read (slidePrev, slideToClosest, updateActiveIndex, ...) got the
+// wrong sign — slidePrev() found no matching snap and fell back to slide 0.
+// `width`/`height` are passed so `swiper.size` is set without real layout, which happy-dom
+// doesn't do; with slidesPerView as a number the slide sizes are derived from it.
+await check('changeDirection() recomputes rtlTranslate', async () => {
+  const host = doc.createElement('div');
+  host.innerHTML = `
+    <div class="swiper">
+      <div class="swiper-wrapper">
+        <div class="swiper-slide">1</div>
+        <div class="swiper-slide">2</div>
+        <div class="swiper-slide">3</div>
+        <div class="swiper-slide">4</div>
+      </div>
+    </div>`;
+  doc.body.appendChild(host);
+  const { default: Swiper } = await import(dist('swiper.mjs'));
+  const swiper = new Swiper(host.querySelector('.swiper'), {
+    slidesPerView: 1,
+    width: 300,
+    height: 300,
+    speed: 0,
+  });
+  try {
+    swiper.changeLanguageDirection('rtl');
+    assert.equal(swiper.rtlTranslate, true, 'horizontal + rtl must translate RTL');
+
+    swiper.changeDirection('vertical');
+    assert.equal(swiper.rtlTranslate, false, 'vertical is never translated RTL');
+
+    swiper.slideTo(2, 0);
+    assert.equal(swiper.activeIndex, 2, 'slideTo(2) must land on slide 2');
+    swiper.slidePrev(0);
+    assert.equal(swiper.activeIndex, 1, 'slidePrev() must step back one slide, not jump to 0');
+
+    swiper.changeDirection('horizontal');
+    assert.equal(swiper.rtlTranslate, true, 'back to horizontal restores the RTL translate');
+  } finally {
+    swiper.destroy(true, false);
+    host.remove();
+  }
+});
+
 console.log(`\n${passed} passed, ${failed} failed\n`);
 process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
Fixes #8053.

### The bug

`swiper.rtlTranslate` is the flag that decides the sign of every translate read:

```js
const translate = rtlTranslate ? swiper.translate : -swiper.translate;
```

It is computed in exactly two places — `mount()` and `changeLanguageDirection()` — both as
`params.direction === 'horizontal' && rtl`. `changeDirection()` sets `params.direction` but
never touches it, so the flag goes stale as soon as the axis changes:

1. horizontal + `dir="rtl"` → `rtlTranslate: true` (correct)
2. `changeDirection('vertical')` → `rtlTranslate` stays `true` (wrong — a vertical slider is
   never translated RTL)

From then on `slidePrev()` normalizes `+translate` against a snap grid built from
`-translate`, finds no match, and falls through to `prevIndex = 0`, which is the reported
symptom: prev jumps to the first slide. `slideToClosest()`, `updateActiveIndex()`,
`updateProgress()`, `onTouchMove`/`onTouchEnd` and `setTranslate()` read the same flag, so
dragging and progress are off in that state too.

The mirror case is broken as well: an RTL slider that starts vertical and is switched to
horizontal keeps `rtlTranslate: false` and behaves as if it were LTR.

### The fix

Recompute the flag next to `params.direction`, with the same expression
`changeLanguageDirection()` already uses.

### Verification

`npm test` is green (format, type-check, build, contract, dist-types, consumer-types, SSR,
element-dom, loop-warning, cross-realm).

The regression test added to `tests/element-dom/element-dom.test.mjs` asserts the flag across
both switches and the user-visible symptom (`slidePrev()` steps back one slide instead of
jumping to 0). It fails on `master` and passes with the fix:

```
# without the fix
  FAIL  changeDirection() recomputes rtlTranslate
        vertical is never translated RTL
  7 passed, 1 failed

# with the fix
  ok  changeDirection() recomputes rtlTranslate
  8 passed, 0 failed
```

`width`/`height` params are passed in the test so `swiper.size` is set without real layout,
which happy-dom does not perform; with a numeric `slidesPerView` the slide sizes derive from
that size.

I also ran the same scenario against the published `swiper@12.2.0` bundle to confirm this is
not a v14 regression — it reproduces identically there — and diffed 32 unrelated scenarios
(loop, centered, grid, pagination types, a11y, effects, virtual, manipulation, breakpoints,
free mode, scrollbar…) between `swiper@12.2.0` and this build: no behavioural differences,
so nothing else moves.

One note on `npm run bundle-size`: the checked-in baseline is already stale on a clean
`master` (a control run there reports `TOTAL -16676 B`). This branch reports `-16481 B`, i.e.
+195 B for the added line; I left `scripts/bundle-size-baseline.json` untouched since it looks like it is
refreshed at release time.
