### PR TITLE
fix (core): use runCallbacks in updateActiveIndex

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -579,7 +579,7 @@ export interface Swiper {
    */
   updateSlidesClasses(): void;
 
-  updateActiveIndex(newActiveIndex?: number): void;
+  updateActiveIndex(newActiveIndex?: number, runCallbacks?: boolean): void;
   updateClickedSlide(el: HTMLElement, path?: EventTarget[]): void;
 
   // Breakpoints methods (prototype mixin: src/core/breakpoints)

--- a/src/core/slide/slideTo.ts
+++ b/src/core/slide/slideTo.ts
@@ -109,7 +109,7 @@ export default function slideTo(
     !isInitialVirtual &&
     ((rtl && -translate === swiper.translate) || (!rtl && translate === swiper.translate))
   ) {
-    swiper.updateActiveIndex(slideIndex);
+    swiper.updateActiveIndex(slideIndex, runCallbacks);
     // Update Height
     if (params.autoHeight) {
       swiper.updateAutoHeight();
@@ -163,7 +163,7 @@ export default function slideTo(
   }
   swiper.setTransition(speed!);
   swiper.setTranslate(translate);
-  swiper.updateActiveIndex(slideIndex);
+  swiper.updateActiveIndex(slideIndex, runCallbacks);
   swiper.updateSlidesClasses();
   swiper.emit('beforeTransitionStart', speed, internal);
   swiper.transitionStart(runCallbacks, direction);

--- a/src/core/update/updateActiveIndex.ts
+++ b/src/core/update/updateActiveIndex.ts
@@ -32,7 +32,11 @@ export function getActiveIndexByTranslate(swiper: Swiper): number {
   return activeIndex as number;
 }
 
-export default function updateActiveIndex(this: Swiper, newActiveIndex?: number): void {
+export default function updateActiveIndex(
+  this: Swiper,
+  newActiveIndex?: number,
+  runCallbacks = true,
+): void {
   const swiper = this;
   const translate = swiper.rtlTranslate ? swiper.translate : -swiper.translate;
   const {
@@ -69,7 +73,7 @@ export default function updateActiveIndex(this: Swiper, newActiveIndex?: number)
   if (activeIndex === previousIndex && !swiper.params.loop) {
     if (snapIndex !== previousSnapIndex) {
       swiper.snapIndex = snapIndex;
-      swiper.emit('snapIndexChange');
+      if (runCallbacks) swiper.emit('snapIndexChange');
     }
     return;
   }
@@ -135,13 +139,15 @@ export default function updateActiveIndex(this: Swiper, newActiveIndex?: number)
   if (swiper.initialized) {
     preload(swiper);
   }
-  swiper.emit('activeIndexChange');
-  swiper.emit('snapIndexChange');
+  if (runCallbacks) {
+    swiper.emit('activeIndexChange');
+    swiper.emit('snapIndexChange');
 
-  if (swiper.initialized || swiper.params.runCallbacksOnInit) {
-    if (previousRealIndex !== realIndex) {
-      swiper.emit('realIndexChange');
+    if (swiper.initialized || swiper.params.runCallbacksOnInit) {
+      if (previousRealIndex !== realIndex) {
+        swiper.emit('realIndexChange');
+      }
+      swiper.emit('slideChange');
     }
-    swiper.emit('slideChange');
   }
 }


### PR DESCRIPTION
This fix aims to address the issue brought up here: https://github.com/nolimits4web/swiper/issues/8015

When using some combination of props like `centeredSlides`, `loop`, `slidesPerView` set to a small value, and with a small number of slides, the pagination bullets changed their active state in an erratic manner.

What the fix does: 

* Passes the `runCallbacks` prop to `updateActiveIndex`, to conditionally emit the callback events
* Makes `slideTo` use this new parameter on `updateActiveIndex`, set to `false` in order to prevent the pagination module from eagerly changing the index

Videos:


https://github.com/user-attachments/assets/bffce485-ac9b-4ca6-8686-6e591a47607c


https://github.com/user-attachments/assets/3d061738-0a48-4948-b871-bed3a1a0347b


https://github.com/user-attachments/assets/4c7bb085-2146-43df-9250-81a867a701d7


https://github.com/user-attachments/assets/e9888f02-e7b6-46f7-bca7-64c55c4c42ec

This is my first ever pull-request after many years of calling myself a developer. I'm happy to finally contribute! 