### PR TITLE
fix(core): don't crash when calling updateSlides() after destroy()

### DIFF
--- a/src/core/update/updateSlides.ts
+++ b/src/core/update/updateSlides.ts
@@ -8,6 +8,7 @@ import type { Swiper, SwiperSlideElement } from '../core';
 
 export default function updateSlides(this: Swiper): void {
   const swiper = this;
+  if (!swiper || swiper.destroyed) return;
 
   function getDirectionPropertyValue(node: CSSStyleDeclaration, label: string): number {
     return parseFloat(node.getPropertyValue(swiper.getDirectionLabel(label)) || '0');

--- a/src/core/update/updateSlidesClasses.ts
+++ b/src/core/update/updateSlidesClasses.ts
@@ -17,6 +17,7 @@ const toggleSlideClasses = (slideEl: HTMLElement, condition: boolean, className:
 
 export default function updateSlidesClasses(this: Swiper): void {
   const swiper = this;
+  if (!swiper || swiper.destroyed) return;
 
   const { slides, params, slidesEl, activeIndex } = swiper;
   const isVirtual = !!(swiper.virtual && params.virtual?.enabled);

--- a/src/core/update/updateSlidesOffset.ts
+++ b/src/core/update/updateSlidesOffset.ts
@@ -2,6 +2,7 @@ import type { Swiper } from '../core';
 
 export default function updateSlidesOffset(this: Swiper): void {
   const swiper = this;
+  if (!swiper || swiper.destroyed) return;
   const slides = swiper.slides;
   const minusOffset = swiper.isElement
     ? swiper.isHorizontal()

--- a/src/core/update/updateSlidesProgress.ts
+++ b/src/core/update/updateSlidesProgress.ts
@@ -13,6 +13,7 @@ export default function updateSlidesProgress(
   translate: number = (this && this.translate) || 0,
 ): void {
   const swiper = this;
+  if (!swiper || swiper.destroyed) return;
   const params = swiper.params;
 
   const { slides, rtlTranslate: rtl, snapGrid } = swiper;

--- a/tests/element-dom/element-dom.test.mjs
+++ b/tests/element-dom/element-dom.test.mjs
@@ -231,6 +231,51 @@ await check('core swiper resolves a string scrollbar.el selector', async () => {
   }
 });
 
+// Regression: calling an `update*` method on an already-destroyed instance must no-op,
+// not throw. destroy()'s deleteProps() wipes every own property with `delete obj[key]`, so
+// `swiper.slides` becomes undefined (not null) once destroyed. Every other core method that
+// touches instance state guards with `if (!swiper || swiper.destroyed) return;` (see
+// update(), slideTo(), translateTo(), resize handlers, ...) but the update/* group lacked
+// that guard, so e.g. `swiper.updateSlides()` crashed with "Cannot read properties of
+// undefined (reading 'length')" reading `swiper.slides.length`.
+await check('update* methods no-op after destroy() instead of throwing', async () => {
+  const host = doc.createElement('div');
+  host.innerHTML = `
+    <div class="swiper">
+      <div class="swiper-wrapper">
+        <div class="swiper-slide">1</div>
+        <div class="swiper-slide">2</div>
+        <div class="swiper-slide">3</div>
+      </div>
+    </div>`;
+  doc.body.appendChild(host);
+  const { default: Swiper } = await import(dist('swiper.mjs'));
+  const swiper = new Swiper(host.querySelector('.swiper'), {
+    slidesPerView: 1,
+    width: 300,
+    height: 300,
+    speed: 0,
+  });
+  swiper.destroy();
+  assert.equal(swiper.destroyed, true, 'destroy() must set destroyed = true');
+  assert.equal(swiper.slides, undefined, 'deleteProps() wipes slides to undefined, not null');
+
+  assert.doesNotThrow(() => swiper.updateSlides(), 'updateSlides() must no-op after destroy');
+  assert.doesNotThrow(
+    () => swiper.updateSlidesOffset(),
+    'updateSlidesOffset() must no-op after destroy',
+  );
+  assert.doesNotThrow(
+    () => swiper.updateSlidesProgress(),
+    'updateSlidesProgress() must no-op after destroy',
+  );
+  assert.doesNotThrow(
+    () => swiper.updateSlidesClasses(),
+    'updateSlidesClasses() must no-op after destroy',
+  );
+  return host;
+});
+
 // Regression: https://github.com/nolimits4web/swiper/issues/8053 — `rtlTranslate` was only
 // recomputed by mount() and changeLanguageDirection(), never by changeDirection(). An RTL
 // slider switched to vertical therefore kept `rtlTranslate: true`, and every `rtlTranslate


### PR DESCRIPTION
So here's what was happening: if you call swiper.destroy() and then call swiper.updateSlides() by accident (or some other code in your app does), it would throw an error instead of just doing nothing.

Why? When destroy() runs, it wipes out all the properties on the swiper object (like swiper.slides) to help the browser clean up memory. But updateSlides() (and a few similar functions next to it) never checked if the swiper was already destroyed before trying to read swiper.slides.length. Since swiper.slides was gone, this blew up with "Cannot read properties of undefined (reading 'length')".

The rest of the codebase already has a simple check for this exact situation: "if the swiper is destroyed, just stop and do nothing." This change just adds that same check to updateSlides(), updateSlidesOffset(), updateSlidesProgress(), and updateSlidesClasses(), so they behave the same way as every other method in the library.

Added a test that destroys a swiper and then calls these four functions, making sure they no longer throw.
