### PR TITLE
feat: add swiperDevMode flag to strip loop-warning logs from prod builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,59 @@ $ npm run build:prod
 
 Production version will available in `dist/` folder.
 
+### Stripping Dev-Only Warnings
+
+Swiper emits a handful of `console.warn` diagnostics for loop mode misconfiguration
+(e.g. not enough slides, `slidesPerGroup` mismatch). These are gated behind a global
+`swiperDevMode` flag, following the same convention other frameworks use to let
+minifiers dead-code-eliminate dev-only code — Angular's `ngDevMode`, Vue's `__DEV__`,
+and similar:
+
+```js
+if (typeof swiperDevMode === 'undefined' || swiperDevMode) {
+  showWarning('...');
+}
+```
+
+By default the flag is undefined, so the warnings run in every build — nothing changes
+for existing consumers. To strip them (and their string literals) from a production
+bundle, use your bundler/minifier to replace `swiperDevMode` with the literal
+`false` at build time; this lets the minifier dead-code-eliminate the branch entirely.
+
+Why a plain global instead of the common `process.env.NODE_ENV === 'production'` check?
+That convention only works because webpack's `DefinePlugin` replaces `process.env.NODE_ENV`
+for you by default — it's a webpack-ism, not a standard. Bundlers that don't polyfill
+`process` (esbuild, Rollup, Vite-as-a-library) would leave that check as a runtime
+`typeof process` reference (or throw), so consumers on those tools would have no way to
+strip the warnings without shimming `process` themselves. A plain global identifier avoids
+that dependency and works the same way across every bundler listed below.
+
+**Terser**
+
+```js
+new TerserPlugin({
+  terserOptions: { compress: { global_defs: { swiperDevMode: false } } },
+});
+```
+
+**esbuild**
+
+```js
+build({ define: { swiperDevMode: 'false' } });
+```
+
+**webpack (`DefinePlugin`)**
+
+```js
+new webpack.DefinePlugin({ swiperDevMode: JSON.stringify(false) });
+```
+
+**Rollup (`@rollup/plugin-replace`)**
+
+```js
+replace({ preventAssignment: true, values: { swiperDevMode: 'false' } });
+```
+
 ## Contributing
 
 All changes should be committed to `src/` files only. Before you open an issue please review the [contributing](https://github.com/nolimits4web/swiper/blob/master/CONTRIBUTING.md) guideline.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "cross-env": "^7.0.3",
         "cssnano": "^7.1.1",
         "elapsed-time-logger": "^1.1.7",
+        "esbuild": "^0.18.20",
         "exec-sh": "^0.4.0",
         "fs-extra": "^11.1.1",
         "globby": "^13.2.2",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "element-dom-test": "node tests/element-dom/element-dom.test.mjs",
     "loop-warning-test": "node tests/element-dom/loop-warning.test.mjs",
     "cross-realm-params-test": "node tests/params/cross-realm-params.test.mjs",
+    "esbuild-dce-test": "node tests/dce/esbuild-swiperDevMode.test.mjs",
     "release": "npm run validate && node ./scripts/release",
-    "test": "npm run validate && npm run build:prod && npm run contract-test && npm run dist-types-test && npm run consumer-types-test && npm run ssr-test && npm run element-dom-test && npm run loop-warning-test && npm run cross-realm-params-test && npm run bundle-size",
+    "test": "npm run validate && npm run build:prod && npm run contract-test && npm run dist-types-test && npm run consumer-types-test && npm run ssr-test && npm run element-dom-test && npm run loop-warning-test && npm run cross-realm-params-test && npm run esbuild-dce-test && npm run bundle-size",
     "changelog": "npx conventional-changelog -p angular -i CHANGELOG.md -u -s",
     "build-sponsors": "node scripts/build-sponsors.js"
   },
@@ -87,6 +88,7 @@
     "cross-env": "^7.0.3",
     "cssnano": "^7.1.1",
     "elapsed-time-logger": "^1.1.7",
+    "esbuild": "^0.18.20",
     "exec-sh": "^0.4.0",
     "fs-extra": "^11.1.1",
     "globby": "^13.2.2",

--- a/src/core/loop/loopCreate.ts
+++ b/src/core/loop/loopCreate.ts
@@ -51,7 +51,7 @@ export default function loopCreate(this: Swiper, slideRealIndex?: number, initia
       addBlankSlides(slidesToAdd);
       swiper.recalcSlides();
       swiper.updateSlides();
-    } else {
+    } else if (typeof swiperDevMode === 'undefined' || swiperDevMode) {
       showWarning(
         'Swiper Loop Warning: The number of slides is not even to slidesPerGroup, loop mode may not function properly. You need to add more slides (or make duplicates, or empty slides)',
       );
@@ -64,7 +64,7 @@ export default function loopCreate(this: Swiper, slideRealIndex?: number, initia
       addBlankSlides(slidesToAdd);
       swiper.recalcSlides();
       swiper.updateSlides();
-    } else {
+    } else if (typeof swiperDevMode === 'undefined' || swiperDevMode) {
       showWarning(
         'Swiper Loop Warning: The number of slides is not even to grid.rows, loop mode may not function properly. You need to add more slides (or make duplicates, or empty slides)',
       );

--- a/src/core/loop/loopFix.ts
+++ b/src/core/loop/loopFix.ts
@@ -111,15 +111,17 @@ export default function loopFix(this: Swiper, options: LoopFixOptions = {}): voi
   swiper.loopedSlides = loopedSlides;
   const gridEnabled = swiper.grid && params.grid && params.grid.rows! > 1;
 
-  if (
-    slides.length < slidesPerView + loopedSlides ||
-    (swiper.params.effect === 'cards' && slides.length < slidesPerView + loopedSlides * 2)
-  ) {
-    showWarning(
-      'Swiper Loop Warning: The number of slides is not enough for loop mode, it will be disabled or not function properly. You need to add more slides (or make duplicates) or lower the values of slidesPerView and slidesPerGroup parameters',
-    );
-  } else if (gridEnabled && params.grid!.fill === 'row') {
-    showWarning('Swiper Loop Warning: Loop mode is not compatible with grid.fill = `row`');
+  if (typeof swiperDevMode === 'undefined' || swiperDevMode) {
+    if (
+      slides.length < slidesPerView + loopedSlides ||
+      (swiper.params.effect === 'cards' && slides.length < slidesPerView + loopedSlides * 2)
+    ) {
+      showWarning(
+        'Swiper Loop Warning: The number of slides is not enough for loop mode, it will be disabled or not function properly. You need to add more slides (or make duplicates) or lower the values of slidesPerView and slidesPerGroup parameters',
+      );
+    } else if (gridEnabled && params.grid!.fill === 'row') {
+      showWarning('Swiper Loop Warning: Loop mode is not compatible with grid.fill = `row`');
+    }
   }
 
   const prependSlidesIndexes: number[] = [];

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,5 +1,22 @@
 import classesToTokens from './classes-to-tokens';
 
+// Compile-time flag, undefined by default so existing behavior is unchanged.
+// Bundlers can statically replace it with `false` (e.g. via webpack
+// DefinePlugin, esbuild `define`, Terser `global_defs`, or
+// @rollup/plugin-replace) to let minifiers dead-code-eliminate dev-only
+// diagnostics (see `showWarning` call sites) from production builds.
+//
+// Deliberately not gated behind `process.env.NODE_ENV === 'production'`: that convention
+// is a webpack/DefinePlugin-ism
+// (it works there because webpack replaces `process.env.NODE_ENV` for you) and doesn't
+// hold for bundlers that don't polyfill `process`, so relying on it would leave
+// esbuild/Rollup/Vite-library consumers unable to strip these warnings without a shim. A
+// plain global identifier works the same way everywhere, and lets us keep the guard as a
+// simple `typeof` check without pulling in a `process` polyfill.
+declare global {
+  const swiperDevMode: boolean | undefined;
+}
+
 export function deleteProps(obj: Record<string, unknown>): void {
   Object.keys(obj).forEach((key) => {
     try {

--- a/tests/dce/esbuild-swiperDevMode.test.mjs
+++ b/tests/dce/esbuild-swiperDevMode.test.mjs
@@ -1,0 +1,91 @@
+// Verifies the `swiperDevMode` compile-time flag (see src/shared/utils.ts and the
+// showWarning() call sites in src/core/loop/loopCreate.ts and loopFix.ts) is actually
+// dead-code-eliminable: bundling dist/swiper-bundle.mjs through esbuild with
+// `define: { swiperDevMode: 'false' }` + minification must strip the loop-warning
+// string literals from the output entirely, while a build without the define keeps them.
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as esbuild from 'esbuild';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(__dirname, '..', '..', 'dist');
+const entry = path.join(distDir, 'swiper-bundle.mjs');
+
+if (!fs.existsSync(entry)) {
+  console.error('dist/swiper-bundle.mjs missing — run `npm run build:prod` first.');
+  process.exit(1);
+}
+
+// One fragment per showWarning() call site, so a regression in any single guard is caught.
+const WARNING_FRAGMENTS = [
+  'is not even to slidesPerGroup',
+  'is not even to grid.rows',
+  'is not enough for loop mode',
+  'is not compatible with grid.fill',
+];
+
+async function bundle({ define } = {}) {
+  const result = await esbuild.build({
+    entryPoints: [entry],
+    bundle: true,
+    minify: true,
+    write: false,
+    format: 'esm',
+    define,
+  });
+  return result.outputFiles[0].text;
+}
+
+let failed = 0;
+let passed = 0;
+async function check(label, fn) {
+  try {
+    await fn();
+    passed += 1;
+    console.log(`  ok  ${label}`);
+  } catch (err) {
+    failed += 1;
+    console.log(`  FAIL  ${label}`);
+    console.log(`        ${err.message}`);
+  }
+}
+
+console.log('\nswiperDevMode esbuild dead-code-elimination test\n');
+
+const withoutDefine = await bundle();
+const withDefineFalse = await bundle({ define: { swiperDevMode: 'false' } });
+
+await check('sanity: bundle without define is non-trivial and defines Swiper', () => {
+  assert.ok(withoutDefine.length > 1000, 'bundle output looks too small to be real');
+  assert.match(withoutDefine, /Swiper/, 'bundle should still reference Swiper');
+});
+
+for (const fragment of WARNING_FRAGMENTS) {
+  await check(`without define: bundle keeps "${fragment}"`, () => {
+    assert.ok(
+      withoutDefine.includes(fragment),
+      `expected default build to retain warning fragment ${JSON.stringify(fragment)}`,
+    );
+  });
+
+  await check(`swiperDevMode: false: bundle strips "${fragment}"`, () => {
+    assert.ok(
+      !withDefineFalse.includes(fragment),
+      `expected swiperDevMode: false build to eliminate warning fragment ${JSON.stringify(fragment)}, but it was still present`,
+    );
+  });
+}
+
+await check('swiperDevMode: false: bundle is smaller than the default build', () => {
+  assert.ok(
+    withDefineFalse.length < withoutDefine.length,
+    `expected DCE build (${withDefineFalse.length} bytes) to be smaller than default build (${withoutDefine.length} bytes)`,
+  );
+});
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
Right now, Swiper prints console.warn() messages when loop mode is set up in a way that might not work well (like not having enough slides). These warnings always run, even in your production build. That's annoying because error-tracking tools like Sentry or Rollbar often grab console.warn calls and turn them into noisy issues you have to dismiss.

This adds a new global flag called swiperDevMode, similar to how Angular has ngDevMode. By default it does nothing different - the warnings still show up exactly like they always have. But if you want, your bundler (webpack, esbuild, Rollup, or Terser) can be told to replace swiperDevMode with the literal value false at build time. Once that happens, your minifier can see the warning code will never run and deletes it completely, so your production bundle gets smaller and the console stays quiet.

Also added a small test that actually runs an esbuild build with the flag set to false and checks the warning text is really gone from the output, not just skipped at runtime.

No breaking changes here. This is fully opt-in - if you don't touch anything, Swiper works exactly the same as before. It's just a new tree-shaking option for people who want smaller, quieter prod bundles.