### PR TITLE
fix(vue,react): skip emitSlidesClasses() on a destroyed instance

### DIFF
--- a/src/react/swiper.tsx
+++ b/src/react/swiper.tsx
@@ -142,7 +142,7 @@ const Swiper = forwardRef<HTMLElement, SwiperProps>(function Swiper(propsArg, ex
   });
 
   useEffect(() => {
-    if (!initializedRef.current && swiperRef.current) {
+    if (!initializedRef.current && swiperRef.current && !swiperRef.current.destroyed) {
       swiperRef.current.emitSlidesClasses();
       initializedRef.current = true;
     }

--- a/src/vue/swiper.ts
+++ b/src/vue/swiper.ts
@@ -373,7 +373,7 @@ const Swiper = defineComponent({
     }
 
     onUpdated(() => {
-      if (!initializedRef.value && swiperRef.value) {
+      if (!initializedRef.value && swiperRef.value && !swiperRef.value.destroyed) {
         swiperRef.value.emitSlidesClasses();
         initializedRef.value = true;
       }


### PR DESCRIPTION
Fixes #8225

Both the Vue and the React wrapper set the initialized flag by calling `emitSlidesClasses()` without checking `destroyed`. The `updateSwiper` branch right below the Vue one already checks.

`destroy(true)` runs `deleteProps(swiper)`, so `swiper.params` is gone and `emitSlidesClasses()` reads `swiper.params._emitClasses`:

```
TypeError: Cannot read properties of undefined (reading '_emitClasses')
```

It only happens while `initializedRef` is still `false`, so the instance has to be destroyed before that first hook run. It also needs a slider with no slides yet, otherwise `SwiperSlide`'s render throws first on `swiperRef.value.params.loop`, which is a separate unguarded access I left alone here.

**Vue** — reproduction: https://e7webbe6.stackblitz.io

`onUpdated` fires after `onBeforeUnmount`, so a component that renders once and is unmounted in the same Vue flush reaches the hook with the instance already destroyed. That is how we hit it in production, on a fast route change.

**React** — reproduction: https://uqcs9xky.stackblitz.io

The effect that sets the flag runs after layout effects, so destroying from a layout effect is enough. No update is needed, it throws on mount. The sandbox has an error boundary to keep the message on screen; without one the error escapes to the root and React unmounts the whole tree, leaving a blank page. Verified on 14.2.0 with react 18.3.1.

Ran `npm run type-check` and `npm run check-format`.
